### PR TITLE
fix(player): re-sync gapless pre-queue on repeat mode change

### DIFF
--- a/catalog/player/README.md
+++ b/catalog/player/README.md
@@ -46,6 +46,10 @@ type GaplessPlayer interface {
     // Returns true when the engine transitions automatically (SFBAudioEngine).
     // HandleTrackEnd must NOT call Load/Play when this returns true.
     AutoTransitions() bool
+    // ClearEnqueued discards the pending pre-queued track from the engine without
+    // affecting the currently playing track. Called by SetRepeatMode to re-sync
+    // the pre-queue when the repeat mode changes during playback.
+    ClearEnqueued()
 }
 ```
 

--- a/internal/app/player/player_service.go
+++ b/internal/app/player/player_service.go
@@ -375,6 +375,27 @@ func (s *PlayerService) SetShuffle(enabled bool) error {
 // SetRepeatMode sets the repeat mode.
 func (s *PlayerService) SetRepeatMode(mode domain.RepeatMode) error {
 	s.queue.SetRepeatMode(mode)
+
+	// Re-sync the gapless pre-queue with the new repeat mode so that stale
+	// pre-queued tracks don't cause the wrong track to play on the next track-end.
+	s.mu.Lock()
+	hadPreQueued := s.nextPreQueued != nil
+	s.nextPreQueued = nil
+	s.mu.Unlock()
+
+	if hadPreQueued {
+		if gp, ok := s.player.(domain.GaplessPlayer); ok {
+			gp.ClearEnqueued()
+			if next := s.queue.PeekNext(); next != nil {
+				if err := gp.EnqueueNext(next); err == nil {
+					s.mu.Lock()
+					s.nextPreQueued = next
+					s.mu.Unlock()
+				}
+			}
+		}
+	}
+
 	s.emitStatus()
 	return nil
 }
@@ -438,8 +459,8 @@ func (s *PlayerService) GetStatus() domain.PlayerStatus {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	status := s.player.GetStatus()
-	status.RepeatMode = s.queue.repeatMode
-	status.Shuffle = s.queue.shuffle
+	status.RepeatMode = s.queue.GetRepeatMode()
+	status.Shuffle = s.queue.GetShuffle()
 	status.Theme = s.currentTheme
 	return status
 }
@@ -963,8 +984,8 @@ func (s *PlayerService) saveState(ctx context.Context) {
 		Position:         status.Position,
 		Volume:           status.Volume,
 		Muted:            status.Muted,
-		Shuffle:          s.queue.shuffle,
-		RepeatMode:       s.queue.repeatMode,
+		Shuffle:          s.queue.GetShuffle(),
+		RepeatMode:       s.queue.GetRepeatMode(),
 	}
 	if err := s.stateRepo.Save(ctx, state); err != nil {
 		s.logger.Error("failed to save player state", "error", err)

--- a/internal/app/player/player_service_test.go
+++ b/internal/app/player/player_service_test.go
@@ -349,6 +349,163 @@ func TestPlayerShortcuts(t *testing.T) {
 	}
 }
 
+// fakeGaplessPlayer wraps fakePlayer and implements GaplessPlayer for repeat-mode tests.
+type fakeGaplessPlayer struct {
+	fakePlayer
+	mu            sync.Mutex
+	enqueuedTrack *domain.TrackDTO
+	clearCount    int
+}
+
+func (p *fakeGaplessPlayer) EnqueueNext(track *domain.TrackDTO) error {
+	p.mu.Lock()
+	p.enqueuedTrack = track
+	p.mu.Unlock()
+	return nil
+}
+
+func (p *fakeGaplessPlayer) StartPreloaded(track *domain.TrackDTO) error {
+	p.fakePlayer.mu.Lock()
+	p.status.TrackID = track.ID
+	p.fakePlayer.mu.Unlock()
+	return nil
+}
+
+func (p *fakeGaplessPlayer) AutoTransitions() bool { return false }
+
+func (p *fakeGaplessPlayer) ClearEnqueued() {
+	p.mu.Lock()
+	p.enqueuedTrack = nil
+	p.clearCount++
+	p.mu.Unlock()
+}
+
+func TestSetRepeatMode_ClearsAndRequeuesGaplessTrack(t *testing.T) {
+	fp := &fakeGaplessPlayer{fakePlayer: fakePlayer{status: domain.PlayerStatus{Volume: 1.0}}}
+	s, _ := newTestService(t, fp)
+
+	t1 := &domain.TrackDTO{Track: domain.Track{ID: "t1", Duration: 300}}
+	t2 := &domain.TrackDTO{Track: domain.Track{ID: "t2", Duration: 300}}
+	s.queue.SetQueue([]*domain.TrackDTO{t1, t2}, 0)
+	_ = s.SetRepeatMode(domain.RepeatModeOne)
+
+	// Simulate track loaded: nextPreQueued = t1 (RepeatOne peeks current)
+	s.mu.Lock()
+	s.nextPreQueued = t1
+	s.mu.Unlock()
+	_ = fp.EnqueueNext(t1)
+
+	// User switches off repeat — should clear engine queue and re-enqueue t2
+	_ = s.SetRepeatMode(domain.RepeatModeOff)
+
+	fp.mu.Lock()
+	cleared := fp.clearCount
+	enqueued := fp.enqueuedTrack
+	fp.mu.Unlock()
+
+	if cleared != 1 {
+		t.Errorf("expected ClearEnqueued called once, got %d", cleared)
+	}
+	if enqueued == nil || enqueued.ID != "t2" {
+		got := "<nil>"
+		if enqueued != nil {
+			got = enqueued.ID
+		}
+		t.Errorf("expected nextPreQueued = t2, got %s", got)
+	}
+
+	s.mu.RLock()
+	nq := s.nextPreQueued
+	s.mu.RUnlock()
+	if nq == nil || nq.ID != "t2" {
+		got := "<nil>"
+		if nq != nil {
+			got = nq.ID
+		}
+		t.Errorf("expected service.nextPreQueued = t2, got %s", got)
+	}
+}
+
+func TestSetRepeatMode_RepeatOneRequeuesCurrentTrack(t *testing.T) {
+	fp := &fakeGaplessPlayer{fakePlayer: fakePlayer{status: domain.PlayerStatus{Volume: 1.0}}}
+	s, _ := newTestService(t, fp)
+
+	t1 := &domain.TrackDTO{Track: domain.Track{ID: "t1", Duration: 300}}
+	t2 := &domain.TrackDTO{Track: domain.Track{ID: "t2", Duration: 300}}
+	s.queue.SetQueue([]*domain.TrackDTO{t1, t2}, 0)
+
+	// Simulate RepeatOff pre-queue: t2 was enqueued
+	s.mu.Lock()
+	s.nextPreQueued = t2
+	s.mu.Unlock()
+	_ = fp.EnqueueNext(t2)
+
+	// Switch to RepeatOne — should clear t2 and re-enqueue t1 (current)
+	_ = s.SetRepeatMode(domain.RepeatModeOne)
+
+	fp.mu.Lock()
+	enqueued := fp.enqueuedTrack
+	fp.mu.Unlock()
+
+	if enqueued == nil || enqueued.ID != "t1" {
+		got := "<nil>"
+		if enqueued != nil {
+			got = enqueued.ID
+		}
+		t.Errorf("expected nextPreQueued = t1, got %s", got)
+	}
+}
+
+func TestHandleTrackEnd_RepeatOneRepeatsCurrentTrack(t *testing.T) {
+	fp := &fakeGaplessPlayer{fakePlayer: fakePlayer{status: domain.PlayerStatus{Volume: 1.0}}}
+	s, _ := newTestService(t, fp)
+
+	t1 := &domain.TrackDTO{Track: domain.Track{ID: "t1", Duration: 300}}
+	t2 := &domain.TrackDTO{Track: domain.Track{ID: "t2", Duration: 300}}
+	s.queue.SetQueue([]*domain.TrackDTO{t1, t2}, 0)
+	_ = s.SetRepeatMode(domain.RepeatModeOne)
+
+	s.mu.Lock()
+	s.currentTrack = t1
+	s.nextPreQueued = t1 // RepeatOne pre-queued current track
+	s.mu.Unlock()
+
+	s.HandleTrackEnd()
+
+	if ct := s.GetCurrentTrack(); ct == nil || ct.ID != "t1" {
+		got := "<nil>"
+		if ct != nil {
+			got = ct.ID
+		}
+		t.Errorf("expected current track t1 after RepeatOne end, got %s", got)
+	}
+}
+
+func TestHandleTrackEnd_RepeatOffAdvancesToNext(t *testing.T) {
+	fp := &fakeGaplessPlayer{fakePlayer: fakePlayer{status: domain.PlayerStatus{Volume: 1.0}}}
+	s, _ := newTestService(t, fp)
+
+	t1 := &domain.TrackDTO{Track: domain.Track{ID: "t1", Duration: 300}}
+	t2 := &domain.TrackDTO{Track: domain.Track{ID: "t2", Duration: 300}}
+	s.queue.SetQueue([]*domain.TrackDTO{t1, t2}, 0)
+	_ = s.SetRepeatMode(domain.RepeatModeOff)
+
+	s.mu.Lock()
+	s.currentTrack = t1
+	s.nextPreQueued = t2
+	s.mu.Unlock()
+
+	s.HandleTrackEnd()
+
+	if ct := s.GetCurrentTrack(); ct == nil || ct.ID != "t2" {
+		got := "<nil>"
+		if ct != nil {
+			got = ct.ID
+		}
+		t.Errorf("expected current track t2 after RepeatOff end, got %s", got)
+	}
+}
+
 func TestFastForward_NextTrack(t *testing.T) {
 	fp := &fakePlayer{status: domain.PlayerStatus{Volume: 0.5, Position: 295.0, Duration: 300.0, PlaybackState: domain.PlaybackStatePlaying}}
 	s, _ := newTestService(t, fp)

--- a/internal/app/player/queue_service.go
+++ b/internal/app/player/queue_service.go
@@ -339,6 +339,20 @@ func (s *QueueService) SetRepeatMode(mode domain.RepeatMode) {
 	s.repeatMode = mode
 }
 
+// GetRepeatMode returns the current repeat mode.
+func (s *QueueService) GetRepeatMode() domain.RepeatMode {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.repeatMode
+}
+
+// GetShuffle returns the current shuffle state.
+func (s *QueueService) GetShuffle() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.shuffle
+}
+
 // GetQueue returns the current active list of tracks.
 func (s *QueueService) GetQueue() []*domain.TrackDTO {
 	s.mu.RLock()

--- a/internal/domain/audio.go
+++ b/internal/domain/audio.go
@@ -78,6 +78,9 @@ type GaplessPlayer interface {
 	// on its own (e.g. SFBAudioEngine). The app layer must NOT call Load/Play on
 	// HandleTrackEnd when this returns true.
 	AutoTransitions() bool
+	// ClearEnqueued discards the pending pre-queued track from the engine without
+	// affecting the currently playing track.
+	ClearEnqueued()
 }
 
 // EQController is an optional interface implemented by audio players that support EQ

--- a/internal/infra/audio/native_player_darwin.m
+++ b/internal/infra/audio/native_player_darwin.m
@@ -168,6 +168,10 @@ extern void goHandleRemoteSeek(double position);
     }
 }
 
+- (void)clearEnqueued {
+    [self.sfbPlayer clearQueue];
+}
+
 - (void)seek:(double)seconds {
     if ([self.sfbPlayer seekToTime:seconds]) {
         self.pausePosition = seconds;
@@ -376,4 +380,8 @@ void SetEQEnabled(void *playerPtr, int enabled) {
 void EnqueueNextPlayer(void *playerPtr, const char *path) {
     NSString *p = [NSString stringWithUTF8String:path];
     [(__bridge AirmedyPlayer *)playerPtr enqueueNext:p];
+}
+
+void ClearEnqueuedPlayer(void *playerPtr) {
+    [(__bridge AirmedyPlayer *)playerPtr clearEnqueued];
 }

--- a/internal/infra/audio/player_darwin.go
+++ b/internal/infra/audio/player_darwin.go
@@ -25,6 +25,7 @@ void UpdateNowPlayingPosition(void* player, double position);
 void SetEQBand(void* player, int index, double freq, double gain, double bandwidth);
 void SetEQEnabled(void* player, int enabled);
 void EnqueueNextPlayer(void* player, const char* path);
+void ClearEnqueuedPlayer(void* player);
 */
 import "C"
 import (
@@ -222,6 +223,10 @@ func (p *DarwinPlayer) StartPreloaded(track *domain.TrackDTO) error {
 
 func (p *DarwinPlayer) AutoTransitions() bool {
 	return true
+}
+
+func (p *DarwinPlayer) ClearEnqueued() {
+	C.ClearEnqueuedPlayer(p.playerPointer)
 }
 
 // --- NowPlayingController ---

--- a/internal/infra/audio/player_miniaudio.go
+++ b/internal/infra/audio/player_miniaudio.go
@@ -199,3 +199,7 @@ func (p *MiniAudioPlayer) StartPreloaded(track *domain.TrackDTO) error {
 func (p *MiniAudioPlayer) AutoTransitions() bool {
 	return false
 }
+
+func (p *MiniAudioPlayer) ClearEnqueued() {
+	C.ma_player_clear_preloaded((*C.MaPlayer)(p.ptr))
+}


### PR DESCRIPTION
  loadAndPlay() pre-enqueues the next track into the audio engine at
  track-load time. If repeat mode changed before the track ended,
  nextPreQueued was stale — HandleTrackEnd played the wrong track.

  Symptoms: switching repeat-one → off caused the current track to
  repeat again; switching off → repeat-one caused a track skip.

  - Add ClearEnqueued() to GaplessPlayer interface; implemented via [sfbPlayer clearQueue] on macOS and ma_player_clear_preloaded on Win/Linux (the C function already existed)
  - SetRepeatMode() now clears the engine's pre-queue and re-enqueues the correct next track under the new mode
  - Fix data race: GetStatus() and saveState() were reading queue.repeatMode/shuffle without holding queue.mu; replaced with GetRepeatMode()/GetShuffle() accessors