### PR TITLE
chore(ci): serialize pnpm install and dedupe AppImage StartupWMClass

### DIFF
--- a/build/Taskfile.yml
+++ b/build/Taskfile.yml
@@ -9,6 +9,11 @@ tasks:
 
   install:deps:
     summary: Install all workspace dependencies from monorepo root
+    # Multiple build tasks (build:remote, build:frontend, generate:bindings)
+    # depend on this and run in parallel. Without `run: once` Task spawns
+    # concurrent `pnpm install` processes that race on node_modules and fail
+    # on Windows with ERR_PNPM_EBUSY (file locked during rename).
+    run: once
     dir: "{{.ROOT_DIR}}"
     sources:
       - pnpm-lock.yaml

--- a/build/linux/Taskfile.yml
+++ b/build/linux/Taskfile.yml
@@ -130,12 +130,18 @@ tasks:
     cmds:
       - cp "{{.APP_BINARY}}" "{{.APP_NAME}}"
       - cp ../../appicon.png "{{.APP_NAME}}.png"
-      - wails3 generate appimage -binary "{{.APP_NAME}}" -icon {{.ICON}} -desktopfile {{.DESKTOP_FILE}} -outputdir {{.OUTPUT_DIR}} -builddir {{.ROOT_DIR}}/build/linux/appimage/build
+      # `wails3 generate appimage` injects its own StartupWMClass into the AppDir
+      # copy. The source .desktop (shared with deb/rpm) already has one, so feed
+      # the generator a stripped copy to avoid a duplicate key that appimagetool
+      # rejects ("multiple keys named StartupWMClass").
+      - grep -v "^StartupWMClass=" {{.DESKTOP_FILE}} > {{.APPIMAGE_DESKTOP}}
+      - wails3 generate appimage -binary "{{.APP_NAME}}" -icon {{.ICON}} -desktopfile {{.APPIMAGE_DESKTOP}} -outputdir {{.OUTPUT_DIR}} -builddir {{.ROOT_DIR}}/build/linux/appimage/build
     vars:
       APP_NAME: '{{.APP_NAME}}'
       APP_BINARY: '../../../bin/{{.APP_NAME}}'
       ICON: '{{.APP_NAME}}.png'
       DESKTOP_FILE: '../org.wails.{{.APP_NAME}}.desktop'
+      APPIMAGE_DESKTOP: 'org.wails.{{.APP_NAME}}.appimage.desktop'
       OUTPUT_DIR: '../../../bin'
 
   create:deb:


### PR DESCRIPTION
- Mark install:deps run:once so parallel build tasks no longer spawn concurrent pnpm install processes that race on node_modules and fail on Windows with ERR_PNPM_EBUSY.
- Strip StartupWMClass from the .desktop copy fed to wails3 generate appimage; the generator adds its own, so the shared source key caused a duplicate that appimagetool rejected.