### PR TITLE
fix: restart playback after Next on last track with repeat off

### DIFF
--- a/internal/app/player/player_service.go
+++ b/internal/app/player/player_service.go
@@ -276,6 +276,12 @@ func (s *PlayerService) Stop() error {
 func (s *PlayerService) Next() error {
 	track := s.queue.Next()
 	if track == nil {
+		// Queue exhausted (repeat off). Mark ended so a subsequent Play() reloads
+		// the current track instead of issuing a plain Play() on a stopped engine,
+		// which SFBAudioEngine won't restart. Mirrors HandleTrackEnd.
+		s.mu.Lock()
+		s.endedNaturally = true
+		s.mu.Unlock()
 		return s.Stop()
 	}
 	return s.loadAndPlay(track)


### PR DESCRIPTION
## Problem

Playing the last track in the queue with repeat off, clicking Next moved the progress to start and Now Playing kept showing that track — but clicking Play did nothing.

## Cause

Manual \`Next()\` on the last queue track only called \`Stop()\`, leaving the engine finished without setting \`endedNaturally\`. A subsequent \`Play()\` issued a plain \`player.Play()\`, which SFBAudioEngine ignores on a stopped/finished item.

## Fix

Set \`endedNaturally = true\` before \`Stop()\` in \`Next()\` when the queue is exhausted, mirroring \`HandleTrackEnd\`. \`Play()\` now reloads the current track via \`loadAndPlay\` and resumes from start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)