### PR TITLE
feat: recently added shows tracks instead of albums

### DIFF
--- a/catalog/database/README.md
+++ b/catalog/database/README.md
@@ -233,6 +233,8 @@ idx_composers_normalization_key ON composers(normalization_key)
 
 **`GetRecentlyPlayed`**: `ORDER BY updated_at DESC LIMIT ?` (updated when play count increments)
 
+**`GetRecentlyAdded`**: `ORDER BY created_at DESC LIMIT ?` (track import time)
+
 **`Upsert`**: `INSERT OR REPLACE INTO tracks ...` using sqlx named parameters.
 
 **Junction `Set*` methods**: Wrapped in a transaction — DELETE existing junction rows, then INSERT new ones with positional ordering.

--- a/catalog/library/README.md
+++ b/catalog/library/README.md
@@ -89,6 +89,7 @@ GetTracksByGenreID(genreID: string): TrackDTO[]
 GetTracksByComposerID(composerID: string): TrackDTO[]
 GetFavoriteTracks(): TrackDTO[]
 GetRecentlyPlayedTracks(limit: number): TrackDTO[]
+GetRecentlyAddedTracks(limit: number): TrackDTO[]
 GetMostListenedTracks(limit: number): TrackDTO[]
 GetLeastListenedTracks(limit: number): TrackDTO[]
 // Album queries

--- a/catalog/ui/README.md
+++ b/catalog/ui/README.md
@@ -25,7 +25,7 @@ Hash history mode (`createWebHashHistory`). All views lazy-loaded except HomeVie
 | Route             | View                 | Notes                                          |
 | ----------------- | -------------------- | ---------------------------------------------- |
 | `/`               | HomeView             | Recently played, most/least listened carousels |
-| `/recently-added` | RecentlyAddedView    | Sorted by import date                          |
+| `/recently-added` | RecentlyAddedView    | TrackCard grid, tracks sorted by import date   |
 | `/albums`         | AlbumsView           | Album grid                                     |
 | `/albums/:id`     | AlbumDetailView      | Hero + track table                             |
 | `/artists`        | ArtistsView          | Artist grid                                    |

--- a/frontend/src/views/RecentlyAddedView.vue
+++ b/frontend/src/views/RecentlyAddedView.vue
@@ -1,25 +1,54 @@
 <script setup lang="ts">
 import { ref, shallowRef, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
 import { Disc } from 'lucide-vue-next'
-import type { AlbumDTO } from '../../bindings/airmedy/internal/domain/models'
-import AlbumGrid from '../components/AlbumGrid.vue'
+import type { TrackDTO } from '../../bindings/airmedy/internal/domain/models'
+import VirtualizedGrid from '../components/VirtualizedGrid.vue'
+import TrackCard from '../components/TrackCard.vue'
+import TrackContextMenu from '../components/TrackContextMenu.vue'
 import ViewHeader from '../components/ViewHeader.vue'
+import { usePlayerStore } from '../stores/player'
 import { useLibrarySync } from '../composables/useLibrarySync'
 
-const albums = shallowRef<AlbumDTO[]>([])
+const router = useRouter()
+const playerStore = usePlayerStore()
+const trackContextMenu = ref<InstanceType<typeof TrackContextMenu> | null>(null)
+
+const tracks = shallowRef<TrackDTO[]>([])
 const isLoading = ref(true)
 
 const loadRecentlyAdded = async () => {
   isLoading.value = true
   try {
-    const result = await LibraryService.GetRecentlyAddedAlbums(50)
-    albums.value = result.filter((a): a is AlbumDTO => a !== null)
+    const result = await LibraryService.GetRecentlyAddedTracks(50)
+    tracks.value = result.filter((t): t is TrackDTO => t !== null)
   } catch (err) {
-    console.error('Failed to load recently added albums:', err)
+    console.error('Failed to load recently added tracks:', err)
   } finally {
     isLoading.value = false
   }
+}
+
+const playTrack = (track: TrackDTO) => {
+  const index = tracks.value.indexOf(track)
+  playerStore.playTracks(tracks.value, index < 0 ? 0 : index)
+}
+
+const navigateToTrack = (track: TrackDTO) => {
+  if (track.album) router.push(`/albums/${track.album.id}`)
+}
+
+const navigateToArtist = (id: string) => {
+  if (id) router.push(`/artists/${id}`)
+}
+
+const navigateToAlbum = (id: string) => {
+  if (id) router.push(`/albums/${id}`)
+}
+
+const onTrackContextMenu = (e: MouseEvent, track: TrackDTO) => {
+  trackContextMenu.value?.open(e, track)
 }
 
 onMounted(loadRecentlyAdded)
@@ -35,12 +64,32 @@ useLibrarySync(loadRecentlyAdded)
         <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
       </div>
 
-      <div v-else-if="albums.length === 0" class="h-full flex flex-col items-center justify-center text-foreground opacity-60">
+      <div v-else-if="tracks.length === 0" class="h-full flex flex-col items-center justify-center text-foreground opacity-60">
         <Disc class="w-12 h-12 mb-4 opacity-20" />
-        <p>{{ $t('library.no_albums') }}</p>
+        <p>{{ $t('library.no_tracks') }}</p>
       </div>
 
-      <AlbumGrid v-else :albums="albums" :gap="40" />
+      <VirtualizedGrid
+        v-else
+        :items="tracks"
+        :square-items="true"
+        :text-area-height="60"
+        :min-column-width="180"
+        :gap="40"
+      >
+        <template #default="{ item: track }">
+          <TrackCard
+            :track="track"
+            @play="playTrack"
+            @click="navigateToTrack"
+            @artist-click="navigateToArtist"
+            @album-click="navigateToAlbum"
+            @contextmenu="onTrackContextMenu"
+          />
+        </template>
+      </VirtualizedGrid>
     </div>
+
+    <TrackContextMenu ref="trackContextMenu" />
   </div>
 </template>

--- a/internal/domain/repositories.go
+++ b/internal/domain/repositories.go
@@ -20,6 +20,7 @@ type TrackRepository interface {
 	GetMostListened(ctx context.Context, limit int) ([]*TrackDTO, error)
 	GetLeastListened(ctx context.Context, limit int) ([]*TrackDTO, error)
 	GetRecentlyPlayed(ctx context.Context, limit int) ([]*TrackDTO, error)
+	GetRecentlyAdded(ctx context.Context, limit int) ([]*TrackDTO, error)
 	Save(ctx context.Context, track *Track) error
 	Delete(ctx context.Context, id string) error
 	DeleteByPathPrefix(ctx context.Context, prefix string) error

--- a/internal/infra/sqlite/track_repository.go
+++ b/internal/infra/sqlite/track_repository.go
@@ -464,6 +464,27 @@ func (r *trackRepository) GetRecentlyPlayed(ctx context.Context, limit int) ([]*
 	return r.scanTrackRows(rows), nil
 }
 
+func (r *trackRepository) GetRecentlyAdded(ctx context.Context, limit int) ([]*domain.TrackDTO, error) {
+	query := fmt.Sprintf(`
+		SELECT %s, a.title AS album_title, a.artwork_key AS album_artwork_key, a.year AS album_year,
+		       GROUP_CONCAT(art.name, '; ') AS artist_names,
+		       GROUP_CONCAT(art.id, '; ') AS artist_ids
+		FROM tracks t
+		LEFT JOIN albums a ON t.album_id = a.id
+		LEFT JOIN track_artists ta ON t.id = ta.track_id
+		LEFT JOIN artists art ON ta.artist_id = art.id
+		GROUP BY t.id
+		ORDER BY t.created_at DESC
+		LIMIT ?
+	`, trackSelectFields)
+	var rows []trackRow
+	err := r.db.SelectContext(ctx, &rows, query, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recently added tracks: %w", err)
+	}
+	return r.scanTrackRows(rows), nil
+}
+
 type trackDB struct {
 	domain.Track
 	AlbumID sql.NullString `db:"album_id"`

--- a/internal/infra/wails/library_service.go
+++ b/internal/infra/wails/library_service.go
@@ -119,6 +119,10 @@ func (s *LibraryService) GetRecentlyPlayedTracks(limit int) ([]*domain.TrackDTO,
 	return s.trackRepo.GetRecentlyPlayed(context.Background(), limit)
 }
 
+func (s *LibraryService) GetRecentlyAddedTracks(limit int) ([]*domain.TrackDTO, error) {
+	return s.trackRepo.GetRecentlyAdded(context.Background(), limit)
+}
+
 func (s *LibraryService) GetTracksByAlbumID(albumID string) ([]*domain.TrackDTO, error) {
 	return s.trackRepo.GetByAlbumID(context.Background(), albumID)
 }


### PR DESCRIPTION
## Summary
- `Recently Added` now lists individual tracks instead of albums.
- Added `GetRecentlyAdded` track query (`ORDER BY created_at DESC`) + `GetRecentlyAddedTracks` Wails method.
- `RecentlyAddedView` renders a `TrackCard` grid (same grid UI), with play/navigate/context-menu wiring.
- Updated catalog docs (library, ui, database).

## Notes
- `GetRecentlyAddedAlbums` retained (still available, no longer used by this view).