### PR TITLE
feat(lyrics): local .lrc/.txt sibling file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 ## Features
 
 - **Your whole library** — add any folder and Airmedy scans it instantly, even with tens of thousands of tracks.
-- **Lyrics that follow along** — synced lyrics scroll line-by-line as the song plays. Plain-text lyrics shown when sync data isn't available. Supports both embedded lyrics and online lyrics from LRCLIB and Kugou.
+- **Lyrics that follow along** — synced lyrics scroll line-by-line as the song plays. Plain-text lyrics shown when sync data isn't available. Sources, in priority order: local lyric files next to the track (`.lrc`, then `.txt`), embedded lyrics, then online lyrics from LRCLIB and Kugou.
 - **Fullscreen & miniplayer modes** — go fullscreen for an immersive listening experience, or shrink to a miniplayer that stays out of your way.
 - **Playlists** — create and manage playlists, import and export them, and browse your collection by genre, artist, or album.
 - **Gapless playback** — tracks transition without any silence or interruption.
@@ -105,7 +105,7 @@ The FFmpeg libraries are statically compiled and bundled inside `internal/infra/
 | Monorepo             | pnpm workspaces + Turbo           |
 | UI package           | @airmedy/ui (packages/ui)         |
 | Utils package        | @airmedy/utils (packages/utils)   |
-| Lyrics               | LRCLIB API                        |
+| Lyrics               | Local `.lrc`/`.txt`, embedded tags, LRCLIB + Kugou |
 
 ---
 

--- a/catalog/lyrics/README.md
+++ b/catalog/lyrics/README.md
@@ -2,17 +2,18 @@
 
 ## Summary
 
-Fetches and displays synchronized (LRC) or plain-text lyrics for the current track. Lyrics are sourced from **lrclib.net** and **KuGou Music** and cached in SQLite. The frontend parses LRC timestamps and auto-scrolls to the current line.
+Fetches and displays synchronized (LRC) or plain-text lyrics for the current track. Lyrics are sourced from **sibling local files** (`.lrc` / `.txt` next to the audio file, read live at play time), embedded **file metadata** (`LYRICS` tag, read at scan time), and the external providers **lrclib.net** and **KuGou Music** (cached in SQLite). The frontend parses LRC timestamps and auto-scrolls to the current line.
 
 ## Files
 
 | File                                        | Purpose                              |
 | ------------------------------------------- | ------------------------------------ |
-| `internal/domain/repositories.go`           | `LyricsProvider` port interface      |
-| `internal/app/lyrics/lyrics_service.go`     | Use-case orchestration, CRUD, racing |
+| `internal/domain/repositories.go`           | `LyricsProvider` + `LocalLyricsReader` port interfaces |
+| `internal/app/lyrics/lyrics_service.go`     | Use-case orchestration, CRUD, racing, resolution |
+| `internal/infra/lyrics/local.go`            | Sibling `.lrc`/`.txt` file reader    |
 | `internal/infra/lyrics/lrclib.go`           | lrclib.net HTTP adapter              |
 | `internal/infra/lyrics/kugou.go`            | KuGou Music HTTP adapter             |
-| `internal/infra/lyrics/module.go`           | FX wiring for provider group         |
+| `internal/infra/lyrics/module.go`           | FX wiring for provider group + local reader |
 | `internal/infra/sqlite/lyric_repository.go` | SQLite persistence                   |
 | `internal/infra/wails/lyrics_service.go`    | Wails binding                        |
 | `frontend/src/composables/useLyrics.ts`     | LRC parser, synced/plain view        |
@@ -33,16 +34,37 @@ type Lyric struct {
 
 ## Resolution Strategy
 
-`LyricsService.ResolveLyrics(ctx, trackID, preferMetadata bool)` determines which lyrics to display based on three boolean settings stored in the DB:
+`LyricsService.ResolveLyrics(ctx, trackID, audioPath, preferLocal bool)` picks the best lyric.
+
+The **local tier** is built first: a sibling lyric file next to `audioPath` (read live by
+`LocalLyricsReader`, `.lrc` preferred over `.txt`) if present, otherwise the embedded metadata tag
+(`MetaContent`, cached in DB at scan time). So within the local tier: **local file beats tag**.
+
+`preferLocal` then decides local tier vs external provider content:
 
 | Setting | Effect |
 | --- | --- |
-| `prefer_metadata_lyrics=true` | (Default) Use `MetaContent` if available, otherwise fall back to `Content` (external provider). |
-| `prefer_metadata_lyrics=false` | Use `Content` (external provider) if available, otherwise fall back to `MetaContent`. |
+| `prefer_local_lyrics=true` | (Default) Use the local tier if available, otherwise fall back to `Content` (external provider). |
+| `prefer_local_lyrics=false` | Use `Content` (external provider) if available, otherwise fall back to the local tier. |
 | `enable_lrclib=false` | lrclib.net provider disabled; not queried on fetch. |
 | `enable_kugou=false` | KuGou provider disabled; not queried on fetch. |
 
+**Full priority (default `prefer_local_lyrics=true`):**
+`Local .lrc` → `Local .txt` → `Metadata tag` → `LRClib / KuGou`.
+
+The setting was renamed from `prefer_metadata_lyrics` (migration `000022_prefer_local_lyrics`,
+`RENAME COLUMN` preserves the existing value).
+
 If both `enable_lrclib` and `enable_kugou` are false, no external fetch is attempted. If resolution returns no cached result and at least one provider is enabled, `PlayerService` triggers an external fetch.
+
+### Local Lyric Files
+
+- Filename must match the audio file's basename exactly, differing only in extension
+  (`/music/Song.mp3` → `/music/Song.lrc` or `/music/Song.txt`).
+- Read **live at play time** in `PlayerService.fetchAndEmitLyrics` — not cached and not watched, so
+  newly added/edited files are picked up on the next play. No rescan needed.
+- Sources: `local-lrc`, `local-txt`. Frontend keys synced/plain off the content (timestamps), so
+  `.lrc` renders synced and `.txt` renders plain automatically.
 
 ## Fetch Strategy
 
@@ -96,6 +118,12 @@ type LyricRepository interface {
 type LyricsProvider interface {
     Fetch(ctx context.Context, track *TrackDTO) (*Lyric, error)
     Name() string
+}
+
+// LocalLyricsReader reads a sibling lyric file next to the audio file
+// (<base>.lrc preferred, then <base>.txt). found=false if neither exists.
+type LocalLyricsReader interface {
+    Read(audioPath string) (content, source string, found bool)
 }
 ```
 

--- a/frontend/src/components/settings/IntegrationsSettings.vue
+++ b/frontend/src/components/settings/IntegrationsSettings.vue
@@ -174,14 +174,14 @@ onMounted(() => {
         <div class="p-5 flex items-center justify-between gap-x-2">
           <div>
             <p class="text-sm font-semibold">
-              {{ t('settings.integrations.prefer_metadata_lyrics', 'Prefer MetadataLyrics') }}
+              {{ t('settings.integrations.prefer_local_lyrics', 'Prefer Local Lyrics') }}
             </p>
             <p class="text-xs text-foreground opacity-60 mt-1">
-              {{ t('settings.integrations.prefer_metadata_lyrics_desc', 'Use embedded lyrics when available') }}
+              {{ t('settings.integrations.prefer_local_lyrics_desc', 'Use local lyric files or embedded lyrics when available') }}
             </p>
           </div>
-          <Switch :model-value="appStore.preferMetadataLyrics"
-            @update:model-value="appStore.updatePreferMetadataLyrics" />
+          <Switch :model-value="appStore.preferLocalLyrics"
+            @update:model-value="appStore.updatePreferLocalLyrics" />
         </div>
       </div>
     </section>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -83,8 +83,8 @@
       "enable_lrclib_desc": "Songtexte von LRCLIB.NET abrufen",
       "enable_kugou": "KuGou Songtexte",
       "enable_kugou_desc": "Songtexte von KuGou Music abrufen",
-      "prefer_metadata_lyrics": "Metadaten-Songtexte bevorzugen",
-      "prefer_metadata_lyrics_desc": "Eingebettete Songtexte verwenden, falls verfügbar",
+      "prefer_local_lyrics": "Lokale Songtexte bevorzugen",
+      "prefer_local_lyrics_desc": "Lokale Songtextdateien (.lrc/.txt) oder eingebettete Songtexte verwenden, falls verfügbar",
       "scrobbling": "Scrobbling",
       "artwork": "Bilder",
       "lyrics": "Songtexte"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -83,8 +83,8 @@
       "enable_lrclib_desc": "Fetch lyrics from LRCLIB.NET",
       "enable_kugou": "KuGou Lyrics",
       "enable_kugou_desc": "Fetch lyrics from KuGou Music",
-      "prefer_metadata_lyrics": "Prefer Metadata Lyrics",
-      "prefer_metadata_lyrics_desc": "Use embedded lyrics when available",
+      "prefer_local_lyrics": "Prefer Local Lyrics",
+      "prefer_local_lyrics_desc": "Use local lyric files (.lrc/.txt) or embedded lyrics when available",
       "scrobbling": "Scrobbling",
       "artwork": "Artwork",
       "lyrics": "Lyrics"

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -83,8 +83,8 @@
       "enable_lrclib_desc": "Obtener letras de LRCLIB.NET",
       "enable_kugou": "Letras de KuGou",
       "enable_kugou_desc": "Obtener letras de KuGou Music",
-      "prefer_metadata_lyrics": "Preferir letras de metadatos",
-      "prefer_metadata_lyrics_desc": "Usar letras incrustadas cuando estén disponibles",
+      "prefer_local_lyrics": "Preferir letras locales",
+      "prefer_local_lyrics_desc": "Usar archivos de letras (.lrc/.txt) o letras incrustadas cuando estén disponibles",
       "scrobbling": "Scrobbling",
       "artwork": "Carátulas",
       "lyrics": "Letras"

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -83,8 +83,8 @@
       "enable_lrclib_desc": "Récupérer les paroles depuis LRCLIB.NET",
       "enable_kugou": "Paroles KuGou",
       "enable_kugou_desc": "Récupérer les paroles depuis KuGou Music",
-      "prefer_metadata_lyrics": "Privilégier les paroles des métadonnées",
-      "prefer_metadata_lyrics_desc": "Utiliser les paroles intégrées lorsqu'elles sont disponibles",
+      "prefer_local_lyrics": "Privilégier les paroles locales",
+      "prefer_local_lyrics_desc": "Utiliser les fichiers de paroles (.lrc/.txt) ou les paroles intégrées lorsqu'ils sont disponibles",
       "scrobbling": "Scrobbling",
       "artwork": "Illustrations",
       "lyrics": "Paroles"

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -83,8 +83,8 @@
       "enable_lrclib_desc": "Recupera i testi da LRCLIB.NET",
       "enable_kugou": "Testi KuGou",
       "enable_kugou_desc": "Recupera i testi da KuGou Music",
-      "prefer_metadata_lyrics": "Preferisci testi dei metadati",
-      "prefer_metadata_lyrics_desc": "Usa i testi incorporati quando disponibili",
+      "prefer_local_lyrics": "Preferisci testi locali",
+      "prefer_local_lyrics_desc": "Usa file di testo (.lrc/.txt) o testi incorporati quando disponibili",
       "scrobbling": "Scrobbling",
       "artwork": "Immagini",
       "lyrics": "Testi"

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -83,8 +83,8 @@
       "enable_lrclib_desc": "LRCLIB.NET から歌詞を取得",
       "enable_kugou": "KuGou の歌詞",
       "enable_kugou_desc": "KuGou Music から歌詞を取得",
-      "prefer_metadata_lyrics": "メタデータの歌詞を優先",
-      "prefer_metadata_lyrics_desc": "利用可能な場合は埋め込まれた歌詞を使用する",
+      "prefer_local_lyrics": "ローカル歌詞を優先",
+      "prefer_local_lyrics_desc": "利用可能な場合はローカル歌詞ファイル（.lrc/.txt）または埋め込み歌詞を使用",
       "scrobbling": "Scrobbling",
       "artwork": "画像",
       "lyrics": "歌詞"

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -83,8 +83,8 @@
       "enable_lrclib_desc": "LRCLIB.NET에서 가사 가져오기",
       "enable_kugou": "KuGou 가사",
       "enable_kugou_desc": "KuGou Music에서 가사 가져오기",
-      "prefer_metadata_lyrics": "메타데이터 가사 우선",
-      "prefer_metadata_lyrics_desc": "사용 가능한 경우 포함된 가사 사용",
+      "prefer_local_lyrics": "로컬 가사 우선",
+      "prefer_local_lyrics_desc": "사용 가능한 경우 로컬 가사 파일(.lrc/.txt) 또는 포함된 가사 사용",
       "scrobbling": "Scrobbling",
       "artwork": "아트워크",
       "lyrics": "가사"

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -83,8 +83,8 @@
       "enable_lrclib_desc": "Buscar letras do LRCLIB.NET",
       "enable_kugou": "Letras do KuGou",
       "enable_kugou_desc": "Buscar letras do KuGou Music",
-      "prefer_metadata_lyrics": "Preferir letras de metadatos",
-      "prefer_metadata_lyrics_desc": "Usar letras incorporadas quando disponíveis",
+      "prefer_local_lyrics": "Preferir letras locais",
+      "prefer_local_lyrics_desc": "Usar ficheiros de letras (.lrc/.txt) ou letras incorporadas quando disponíveis",
       "scrobbling": "Scrobbling",
       "artwork": "Capas",
       "lyrics": "Letras"

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -83,8 +83,8 @@
       "enable_lrclib_desc": "Загружать тексты с LRCLIB.NET",
       "enable_kugou": "Тексты KuGou",
       "enable_kugou_desc": "Загружать тексты с KuGou Music",
-      "prefer_metadata_lyrics": "Предпочитать встроенные тексты",
-      "prefer_metadata_lyrics_desc": "Использовать встроенные тексты, если они доступны",
+      "prefer_local_lyrics": "Предпочитать локальные тексты",
+      "prefer_local_lyrics_desc": "Использовать локальные файлы текстов (.lrc/.txt) или встроенные тексты, если доступны",
       "scrobbling": "Скробблинг",
       "artwork": "Обложки",
       "lyrics": "Тексты"

--- a/frontend/src/locales/th.json
+++ b/frontend/src/locales/th.json
@@ -83,8 +83,8 @@
       "enable_lrclib_desc": "ดึงเนื้อเพลงจาก LRCLIB.NET",
       "enable_kugou": "เนื้อเพลงจาก KuGou",
       "enable_kugou_desc": "ดึงเนื้อเพลงจาก KuGou Music",
-      "prefer_metadata_lyrics": "ใช้เนื้อเพลงจากข้อมูลเมตาก่อน",
-      "prefer_metadata_lyrics_desc": "ใช้เนื้อเพลงที่ฝังไว้เมื่อมี",
+      "prefer_local_lyrics": "ใช้เนื้อเพลงในเครื่องก่อน",
+      "prefer_local_lyrics_desc": "ใช้ไฟล์เนื้อเพลง (.lrc/.txt) หรือเนื้อเพลงที่ฝังไว้เมื่อมี",
       "scrobbling": "การสคร็อบเบิล",
       "artwork": "รูปภาพ",
       "lyrics": "เนื้อเพลง"

--- a/frontend/src/locales/vi.json
+++ b/frontend/src/locales/vi.json
@@ -83,8 +83,8 @@
       "enable_lrclib_desc": "Tải lời bài hát từ LRCLIB.NET",
       "enable_kugou": "Lời bài hát KuGou",
       "enable_kugou_desc": "Tải lời bài hát từ KuGou Music",
-      "prefer_metadata_lyrics": "Ưu tiên lời bài hát trong tệp",
-      "prefer_metadata_lyrics_desc": "Sử dụng lời bài hát được nhúng nếu có",
+      "prefer_local_lyrics": "Ưu tiên lời bài hát cục bộ",
+      "prefer_local_lyrics_desc": "Dùng tệp lời (.lrc/.txt) hoặc lời nhúng khi có",
       "scrobbling": "Scrobbling",
       "artwork": "Ảnh bìa",
       "lyrics": "Lời bài hát"

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -83,8 +83,8 @@
       "enable_lrclib_desc": "从 LRCLIB.NET 获取歌词",
       "enable_kugou": "酷狗歌词",
       "enable_kugou_desc": "从酷狗音乐获取歌词",
-      "prefer_metadata_lyrics": "优先使用元数据歌词",
-      "prefer_metadata_lyrics_desc": "可用时使用嵌入的歌词",
+      "prefer_local_lyrics": "优先使用本地歌词",
+      "prefer_local_lyrics_desc": "可用时使用本地歌词文件（.lrc/.txt）或嵌入歌词",
       "scrobbling": "Scrobbling",
       "artwork": "封面",
       "lyrics": "歌词"

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -16,7 +16,7 @@ export const useAppStore = defineStore('app', () => {
   const eqEnabled = ref(true)
   const enableLrclib = ref(true)
   const enableKugou = ref(true)
-  const preferMetadataLyrics = ref(true)
+  const preferLocalLyrics = ref(true)
   const useOnlineArtistArtwork = ref(true)
   const preventSleepWhilePlaying = ref(false)
   const showPlayerIndicator = ref(true)
@@ -64,7 +64,7 @@ export const useAppStore = defineStore('app', () => {
         eqEnabled.value = settings.eq_enabled !== false
         enableLrclib.value = settings.enable_lrclib !== false
         enableKugou.value = settings.enable_kugou !== false
-        preferMetadataLyrics.value = settings.prefer_metadata_lyrics !== false
+        preferLocalLyrics.value = settings.prefer_local_lyrics !== false
         useOnlineArtistArtwork.value = settings.use_online_artist_artwork !== false
         preventSleepWhilePlaying.value = !!settings.prevent_sleep_while_playing
         showPlayerIndicator.value = settings.show_player_indicator !== false
@@ -130,7 +130,7 @@ export const useAppStore = defineStore('app', () => {
         eq_enabled: eqEnabled.value,
         enable_lrclib: enableLrclib.value,
         enable_kugou: enableKugou.value,
-        prefer_metadata_lyrics: preferMetadataLyrics.value,
+        prefer_local_lyrics: preferLocalLyrics.value,
         use_online_artist_artwork: useOnlineArtistArtwork.value,
         prevent_sleep_while_playing: preventSleepWhilePlaying.value,
         show_player_indicator: showPlayerIndicator.value,
@@ -190,8 +190,8 @@ export const useAppStore = defineStore('app', () => {
     await saveSettings()
   }
 
-  const updatePreferMetadataLyrics = async (enabled: boolean) => {
-    preferMetadataLyrics.value = enabled
+  const updatePreferLocalLyrics = async (enabled: boolean) => {
+    preferLocalLyrics.value = enabled
     await saveSettings()
   }
 
@@ -243,7 +243,7 @@ export const useAppStore = defineStore('app', () => {
     eqEnabled,
     enableLrclib,
     enableKugou,
-    preferMetadataLyrics,
+    preferLocalLyrics,
     useOnlineArtistArtwork,
     preventSleepWhilePlaying,
     showPlayerIndicator,
@@ -267,7 +267,7 @@ export const useAppStore = defineStore('app', () => {
     updateLastFmUsername,
     updateEnableLrclib,
     updateEnableKugou,
-    updatePreferMetadataLyrics,
+    updatePreferLocalLyrics,
     updateUseOnlineArtistArtwork,
     updatePreventSleepWhilePlaying,
     updateShowPlayerIndicator,

--- a/internal/app/lyrics/lyrics_service.go
+++ b/internal/app/lyrics/lyrics_service.go
@@ -160,6 +160,20 @@ func (s *LyricsService) ResolveLyrics(ctx context.Context, trackID, audioPath st
 	return resolved
 }
 
+// HasLocalLyrics reports whether a local-tier lyric exists for the track: a
+// sibling lyric file next to audioPath, or an embedded metadata tag in the DB.
+func (s *LyricsService) HasLocalLyrics(ctx context.Context, trackID, audioPath string) bool {
+	if s.localReader != nil {
+		if _, _, found := s.localReader.Read(audioPath); found {
+			return true
+		}
+	}
+	if lyric, _ := s.repo.GetByTrackID(ctx, trackID); lyric != nil && lyric.MetaContent != "" {
+		return true
+	}
+	return false
+}
+
 // FetchFromProviders fetches lyrics from enabled providers concurrently.
 // When both are enabled, the first non-nil result wins and the other request is cancelled.
 func (s *LyricsService) FetchFromProviders(ctx context.Context, track *domain.TrackDTO, enableLrclib, enableKugou bool) (*domain.Lyric, error) {

--- a/internal/app/lyrics/lyrics_service.go
+++ b/internal/app/lyrics/lyrics_service.go
@@ -9,13 +9,14 @@ import (
 )
 
 type LyricsService struct {
-	repo      domain.LyricRepository
-	logger    *slog.Logger
-	providers []domain.LyricsProvider
+	repo        domain.LyricRepository
+	logger      *slog.Logger
+	providers   []domain.LyricsProvider
+	localReader domain.LocalLyricsReader
 }
 
-func NewLyricsService(repo domain.LyricRepository, logger *slog.Logger, providers []domain.LyricsProvider) *LyricsService {
-	return &LyricsService{repo: repo, logger: logger, providers: providers}
+func NewLyricsService(repo domain.LyricRepository, logger *slog.Logger, providers []domain.LyricsProvider, localReader domain.LocalLyricsReader) *LyricsService {
+	return &LyricsService{repo: repo, logger: logger, providers: providers, localReader: localReader}
 }
 
 func (s *LyricsService) GetLyrics(ctx context.Context, trackID string) (*domain.Lyric, error) {
@@ -94,25 +95,69 @@ func (s *LyricsService) SaveMetaLyrics(ctx context.Context, trackID, content, so
 	})
 }
 
-// ResolveLyrics returns the best available cached lyric based on the preferMetadata flag.
-// Returns nil if no cached lyric is available (caller should fetch from providers).
-func (s *LyricsService) ResolveLyrics(ctx context.Context, trackID string, preferMetadata bool) *domain.Lyric {
+// ResolveLyrics returns the best available lyric for display.
+//
+// "Local lyrics" tier = a sibling lyric file next to audioPath (read live, .lrc
+// preferred over .txt) if present, otherwise the embedded metadata tag stored in
+// the DB. When preferLocal is true, the local tier wins over external provider
+// content; when false, provider content wins.
+//
+// Returns nil if nothing is available (caller may fetch from providers).
+func (s *LyricsService) ResolveLyrics(ctx context.Context, trackID, audioPath string, preferLocal bool) *domain.Lyric {
 	lyric, _ := s.repo.GetByTrackID(ctx, trackID)
-	if lyric == nil {
-		return nil
-	}
 
-	if preferMetadata && lyric.MetaContent != "" {
-		return &domain.Lyric{
-			TrackID: trackID,
-			Content: lyric.MetaContent,
-			Source:  lyric.MetaSource,
+	// Build the local tier: sibling file beats embedded metadata tag.
+	var localContent, localSource string
+	if s.localReader != nil {
+		if content, source, found := s.localReader.Read(audioPath); found {
+			localContent, localSource = content, source
+			s.logger.Debug("local lyric file found", "track_id", trackID, "path", audioPath, "source", source)
+		} else {
+			s.logger.Debug("no local lyric file", "track_id", trackID, "path", audioPath)
 		}
 	}
-	if lyric.Content != "" {
-		return lyric
+	if localContent == "" && lyric != nil && lyric.MetaContent != "" {
+		localContent, localSource = lyric.MetaContent, lyric.MetaSource
+		s.logger.Debug("using metadata tag lyrics", "track_id", trackID, "source", localSource)
 	}
-	return nil
+
+	var providerContent, providerSource string
+	if lyric != nil && lyric.Content != "" {
+		providerContent, providerSource = lyric.Content, lyric.Source
+	}
+
+	local := func() *domain.Lyric {
+		if localContent == "" {
+			return nil
+		}
+		return &domain.Lyric{TrackID: trackID, Content: localContent, Source: localSource}
+	}
+	provider := func() *domain.Lyric {
+		if providerContent == "" {
+			return nil
+		}
+		return &domain.Lyric{TrackID: trackID, Content: providerContent, Source: providerSource}
+	}
+
+	resolved := func() *domain.Lyric {
+		if preferLocal {
+			if l := local(); l != nil {
+				return l
+			}
+			return provider()
+		}
+		if p := provider(); p != nil {
+			return p
+		}
+		return local()
+	}()
+
+	if resolved != nil {
+		s.logger.Debug("resolved lyrics", "track_id", trackID, "prefer_local", preferLocal, "source", resolved.Source)
+	} else {
+		s.logger.Debug("no lyrics resolved", "track_id", trackID, "prefer_local", preferLocal)
+	}
+	return resolved
 }
 
 // FetchFromProviders fetches lyrics from enabled providers concurrently.

--- a/internal/app/lyrics/lyrics_service_test.go
+++ b/internal/app/lyrics/lyrics_service_test.go
@@ -1,0 +1,111 @@
+package lyrics
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"airmedy/internal/domain"
+)
+
+type stubRepo struct {
+	lyric *domain.Lyric
+}
+
+func (s *stubRepo) GetByTrackID(_ context.Context, _ string) (*domain.Lyric, error) {
+	return s.lyric, nil
+}
+func (s *stubRepo) Save(_ context.Context, _ *domain.Lyric) error   { return nil }
+func (s *stubRepo) Upsert(_ context.Context, l *domain.Lyric) error { s.lyric = l; return nil }
+func (s *stubRepo) Delete(_ context.Context, _ string) error        { return nil }
+
+type stubLocal struct {
+	content string
+	source  string
+}
+
+func (s stubLocal) Read(string) (string, string, bool) {
+	if s.content == "" {
+		return "", "", false
+	}
+	return s.content, s.source, true
+}
+
+func newService(lyric *domain.Lyric, local domain.LocalLyricsReader) *LyricsService {
+	return NewLyricsService(&stubRepo{lyric: lyric}, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, local)
+}
+
+func TestResolveLyrics(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name        string
+		dbLyric     *domain.Lyric
+		local       domain.LocalLyricsReader
+		preferLocal bool
+		wantSource  string // "" => expect nil
+	}{
+		{
+			name:        "local file beats tag and provider (preferLocal)",
+			dbLyric:     &domain.Lyric{MetaContent: "tag", MetaSource: "meta-plain", Content: "prov", Source: "lrclib-synced"},
+			local:       stubLocal{content: "[00:01.00]file", source: "local-lrc"},
+			preferLocal: true,
+			wantSource:  "local-lrc",
+		},
+		{
+			name:        "tag used when no local file (preferLocal)",
+			dbLyric:     &domain.Lyric{MetaContent: "tag", MetaSource: "meta-plain", Content: "prov", Source: "lrclib-synced"},
+			local:       stubLocal{},
+			preferLocal: true,
+			wantSource:  "meta-plain",
+		},
+		{
+			name:        "provider wins when preferLocal false",
+			dbLyric:     &domain.Lyric{MetaContent: "tag", MetaSource: "meta-plain", Content: "prov", Source: "lrclib-synced"},
+			local:       stubLocal{content: "file", source: "local-txt"},
+			preferLocal: false,
+			wantSource:  "lrclib-synced",
+		},
+		{
+			name:        "fall back to local when provider empty and preferLocal false",
+			dbLyric:     &domain.Lyric{MetaContent: "tag", MetaSource: "meta-plain"},
+			local:       stubLocal{content: "file", source: "local-txt"},
+			preferLocal: false,
+			wantSource:  "local-txt",
+		},
+		{
+			name:        "nil when nothing available",
+			dbLyric:     nil,
+			local:       stubLocal{},
+			preferLocal: true,
+			wantSource:  "",
+		},
+		{
+			name:        "local file with no db row (preferLocal)",
+			dbLyric:     nil,
+			local:       stubLocal{content: "file", source: "local-lrc"},
+			preferLocal: true,
+			wantSource:  "local-lrc",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newService(tc.dbLyric, tc.local)
+			got := svc.ResolveLyrics(ctx, "track1", "/music/Song.mp3", tc.preferLocal)
+			if tc.wantSource == "" {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected source %q, got nil", tc.wantSource)
+			}
+			if got.Source != tc.wantSource {
+				t.Fatalf("expected source %q, got %q", tc.wantSource, got.Source)
+			}
+		})
+	}
+}

--- a/internal/app/player/player_service.go
+++ b/internal/app/player/player_service.go
@@ -736,36 +736,35 @@ func (s *PlayerService) fetchAndEmitLyrics(track *domain.TrackDTO) {
 		settings = &domain.AppSettings{}
 	}
 
-	// 1. Try to get best available lyrics according to settings.
-	lyric := s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, settings.PreferLocalLyrics)
+	preferLocal := settings.PreferLocalLyrics
+
+	// 1. Emit the best currently-available lyric for the chosen preference.
+	lyric := s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, preferLocal)
 	if lyric != nil {
 		s.emitLyrics(track.ID, lyric)
 	}
 
-	// 2. If any provider is enabled and we don't have external lyrics yet, fetch from providers.
+	// 2. When local lyrics are preferred and present, they win outright. Don't
+	//    fetch providers, so nothing overrides the displayed local lyric.
+	if preferLocal && s.lyricsService.HasLocalLyrics(ctx, track.ID, track.Path) {
+		return
+	}
+
+	// 3. Fetch from providers when enabled and not already cached.
 	dbLyric, _ := s.lyricsService.GetLyrics(ctx, track.ID)
 	hasExternal := dbLyric != nil && dbLyric.Content != ""
 	anyProviderEnabled := settings.EnableLrclib || settings.EnableKugou
 	if !hasExternal && anyProviderEnabled {
-		fetched, err := s.lyricsService.FetchFromProviders(ctx, track, settings.EnableLrclib, settings.EnableKugou)
-		if err != nil {
+		if _, err := s.lyricsService.FetchFromProviders(ctx, track, settings.EnableLrclib, settings.EnableKugou); err != nil {
 			s.logger.Warn("failed to fetch lyrics from providers", "track_id", track.ID, "error", err)
-			if lyric == nil {
-				lyric = s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, true)
-				s.emitLyrics(track.ID, lyric)
-			}
-		} else if fetched != nil {
-			s.emitLyrics(track.ID, fetched)
-			return
-		} else if lyric == nil {
-			// No provider results — fall back to metadata if available.
-			lyric = s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, true)
-			s.emitLyrics(track.ID, lyric)
 		}
-	} else if lyric == nil {
-		// Providers disabled — fall back to metadata if available.
-		lyric = s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, true)
-		s.emitLyrics(track.ID, lyric)
+	}
+
+	// 4. Re-resolve so the final emit honors the preference now that provider
+	//    content may be cached. This is the single source of priority truth.
+	resolved := s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, preferLocal)
+	if resolved != nil {
+		s.emitLyrics(track.ID, resolved)
 	}
 }
 

--- a/internal/app/player/player_service.go
+++ b/internal/app/player/player_service.go
@@ -737,7 +737,7 @@ func (s *PlayerService) fetchAndEmitLyrics(track *domain.TrackDTO) {
 	}
 
 	// 1. Try to get best available lyrics according to settings.
-	lyric := s.lyricsService.ResolveLyrics(ctx, track.ID, settings.PreferMetadataLyrics)
+	lyric := s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, settings.PreferLocalLyrics)
 	if lyric != nil {
 		s.emitLyrics(track.ID, lyric)
 	}
@@ -751,7 +751,7 @@ func (s *PlayerService) fetchAndEmitLyrics(track *domain.TrackDTO) {
 		if err != nil {
 			s.logger.Warn("failed to fetch lyrics from providers", "track_id", track.ID, "error", err)
 			if lyric == nil {
-				lyric = s.lyricsService.ResolveLyrics(ctx, track.ID, true)
+				lyric = s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, true)
 				s.emitLyrics(track.ID, lyric)
 			}
 		} else if fetched != nil {
@@ -759,12 +759,12 @@ func (s *PlayerService) fetchAndEmitLyrics(track *domain.TrackDTO) {
 			return
 		} else if lyric == nil {
 			// No provider results — fall back to metadata if available.
-			lyric = s.lyricsService.ResolveLyrics(ctx, track.ID, true)
+			lyric = s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, true)
 			s.emitLyrics(track.ID, lyric)
 		}
 	} else if lyric == nil {
 		// Providers disabled — fall back to metadata if available.
-		lyric = s.lyricsService.ResolveLyrics(ctx, track.ID, true)
+		lyric = s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, true)
 		s.emitLyrics(track.ID, lyric)
 	}
 }

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -160,7 +160,7 @@ type AppSettings struct {
 	EQEnabled                bool   `json:"eq_enabled"`
 	EnableLrclib             bool   `json:"enable_lrclib"`
 	EnableKugou              bool   `json:"enable_kugou"`
-	PreferMetadataLyrics     bool   `json:"prefer_metadata_lyrics"`
+	PreferLocalLyrics        bool   `json:"prefer_local_lyrics"`
 	UseOnlineArtistArtwork   bool   `json:"use_online_artist_artwork"`
 	PreventSleepWhilePlaying bool   `json:"prevent_sleep_while_playing"`
 	RemoteServerEnabled      bool   `json:"remote_server_enabled"`

--- a/internal/domain/repositories.go
+++ b/internal/domain/repositories.go
@@ -108,6 +108,13 @@ type LyricsProvider interface {
 	Name() string
 }
 
+// LocalLyricsReader reads a sibling lyric file located next to the audio file.
+// The lyric file must share the audio file's basename, differing only in extension.
+// It tries "<base>.lrc" first, then "<base>.txt". found is false if neither exists.
+type LocalLyricsReader interface {
+	Read(audioPath string) (content, source string, found bool)
+}
+
 type EQRepository interface {
 	GetActive(ctx context.Context) (*EQProfile, error)
 	GetAll(ctx context.Context) ([]*EQProfile, error)

--- a/internal/infra/lyrics/local.go
+++ b/internal/infra/lyrics/local.go
@@ -1,0 +1,52 @@
+package lyrics
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"airmedy/internal/domain"
+)
+
+// localReader reads sibling lyric files (.lrc preferred, then .txt) located next
+// to the audio file and sharing its basename.
+type localReader struct{}
+
+// NewLocalLyricsReader returns a domain.LocalLyricsReader backed by the filesystem.
+func NewLocalLyricsReader() domain.LocalLyricsReader {
+	return &localReader{}
+}
+
+// localCandidates pairs a file extension with the source label emitted when matched.
+// Order is the priority order: .lrc before .txt.
+var localCandidates = []struct {
+	ext    string
+	source string
+}{
+	{".lrc", "local-lrc"},
+	{".txt", "local-txt"},
+}
+
+func (r *localReader) Read(audioPath string) (string, string, bool) {
+	if audioPath == "" {
+		return "", "", false
+	}
+
+	dir := filepath.Dir(audioPath)
+	base := strings.TrimSuffix(filepath.Base(audioPath), filepath.Ext(audioPath))
+
+	for _, c := range localCandidates {
+		path := filepath.Join(dir, base+c.ext)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		content := strings.TrimSpace(strings.TrimPrefix(string(data), "\ufeff"))
+		if content == "" {
+			continue
+		}
+		return content, c.source, true
+	}
+
+	return "", "", false
+}

--- a/internal/infra/lyrics/local_test.go
+++ b/internal/infra/lyrics/local_test.go
@@ -1,0 +1,93 @@
+package lyrics
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestLocalReader_Read(t *testing.T) {
+	r := NewLocalLyricsReader()
+
+	t.Run("lrc only", func(t *testing.T) {
+		dir := t.TempDir()
+		audio := filepath.Join(dir, "Song.mp3")
+		writeFile(t, filepath.Join(dir, "Song.lrc"), "[00:01.00]hello")
+		content, source, found := r.Read(audio)
+		if !found || source != "local-lrc" || content != "[00:01.00]hello" {
+			t.Fatalf("got (%q,%q,%v)", content, source, found)
+		}
+	})
+
+	t.Run("txt only", func(t *testing.T) {
+		dir := t.TempDir()
+		audio := filepath.Join(dir, "Song.flac")
+		writeFile(t, filepath.Join(dir, "Song.txt"), "plain lyrics")
+		content, source, found := r.Read(audio)
+		if !found || source != "local-txt" || content != "plain lyrics" {
+			t.Fatalf("got (%q,%q,%v)", content, source, found)
+		}
+	})
+
+	t.Run("lrc beats txt", func(t *testing.T) {
+		dir := t.TempDir()
+		audio := filepath.Join(dir, "Song.mp3")
+		writeFile(t, filepath.Join(dir, "Song.lrc"), "[00:01.00]synced")
+		writeFile(t, filepath.Join(dir, "Song.txt"), "plain")
+		_, source, found := r.Read(audio)
+		if !found || source != "local-lrc" {
+			t.Fatalf("expected local-lrc, got %q (%v)", source, found)
+		}
+	})
+
+	t.Run("none", func(t *testing.T) {
+		dir := t.TempDir()
+		_, _, found := r.Read(filepath.Join(dir, "Song.mp3"))
+		if found {
+			t.Fatal("expected not found")
+		}
+	})
+
+	t.Run("empty file skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		audio := filepath.Join(dir, "Song.mp3")
+		writeFile(t, filepath.Join(dir, "Song.lrc"), "   \n  ")
+		_, _, found := r.Read(audio)
+		if found {
+			t.Fatal("empty/whitespace file should not match")
+		}
+	})
+
+	t.Run("name mismatch", func(t *testing.T) {
+		dir := t.TempDir()
+		audio := filepath.Join(dir, "Song.mp3")
+		writeFile(t, filepath.Join(dir, "Other.lrc"), "[00:01.00]nope")
+		_, _, found := r.Read(audio)
+		if found {
+			t.Fatal("mismatched basename should not match")
+		}
+	})
+
+	t.Run("empty path", func(t *testing.T) {
+		if _, _, found := r.Read(""); found {
+			t.Fatal("empty path should not match")
+		}
+	})
+
+	t.Run("strips BOM", func(t *testing.T) {
+		dir := t.TempDir()
+		audio := filepath.Join(dir, "Song.mp3")
+		writeFile(t, filepath.Join(dir, "Song.lrc"), "\ufeff[00:01.00]hi")
+		content, _, found := r.Read(audio)
+		if !found || content != "[00:01.00]hi" {
+			t.Fatalf("BOM not stripped: %q (%v)", content, found)
+		}
+	})
+}

--- a/internal/infra/lyrics/module.go
+++ b/internal/infra/lyrics/module.go
@@ -18,5 +18,6 @@ var Module = fx.Module("lyrics-providers",
 			func(logger *slog.Logger) domain.LyricsProvider { return NewKugouProvider(logger) },
 			fx.ResultTags(`group:"lyrics_providers"`),
 		),
+		NewLocalLyricsReader,
 	),
 )

--- a/internal/infra/sqlite/migrations/000022_prefer_local_lyrics.down.sql
+++ b/internal/infra/sqlite/migrations/000022_prefer_local_lyrics.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE app_settings RENAME COLUMN prefer_local_lyrics TO prefer_metadata_lyrics;

--- a/internal/infra/sqlite/migrations/000022_prefer_local_lyrics.up.sql
+++ b/internal/infra/sqlite/migrations/000022_prefer_local_lyrics.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE app_settings RENAME COLUMN prefer_metadata_lyrics TO prefer_local_lyrics;

--- a/internal/infra/sqlite/settings_repository.go
+++ b/internal/infra/sqlite/settings_repository.go
@@ -18,7 +18,7 @@ func NewSettingsRepository(db *DB) domain.SettingsRepository {
 
 func (r *settingsRepository) Save(ctx context.Context, settings *domain.AppSettings) error {
 	_, err := r.db.ExecContext(ctx,
-		`INSERT INTO app_settings (id, language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, enable_lrclib, enable_kugou, prefer_metadata_lyrics, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator, updated_at)
+		`INSERT INTO app_settings (id, language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, enable_lrclib, enable_kugou, prefer_local_lyrics, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator, updated_at)
 		 VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		 ON CONFLICT(id) DO UPDATE SET
 		   language = excluded.language,
@@ -31,7 +31,7 @@ func (r *settingsRepository) Save(ctx context.Context, settings *domain.AppSetti
 		   use_online_artist_artwork = excluded.use_online_artist_artwork,
 		   enable_lrclib = excluded.enable_lrclib,
 		   enable_kugou = excluded.enable_kugou,
-		   prefer_metadata_lyrics = excluded.prefer_metadata_lyrics,
+		   prefer_local_lyrics = excluded.prefer_local_lyrics,
 		   prevent_sleep_while_playing = excluded.prevent_sleep_while_playing,
 		   remote_server_enabled = excluded.remote_server_enabled,
 		   remote_server_port = excluded.remote_server_port,
@@ -48,7 +48,7 @@ func (r *settingsRepository) Save(ctx context.Context, settings *domain.AppSetti
 		settings.UseOnlineArtistArtwork,
 		settings.EnableLrclib,
 		settings.EnableKugou,
-		settings.PreferMetadataLyrics,
+		settings.PreferLocalLyrics,
 		settings.PreventSleepWhilePlaying,
 		settings.RemoteServerEnabled,
 		settings.RemoteServerPort,
@@ -73,7 +73,7 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 		UseOnlineArtistArtwork   bool           `db:"use_online_artist_artwork"`
 		EnableLrclib             bool           `db:"enable_lrclib"`
 		EnableKugou              bool           `db:"enable_kugou"`
-		PreferMetadataLyrics     bool           `db:"prefer_metadata_lyrics"`
+		PreferLocalLyrics        bool           `db:"prefer_local_lyrics"`
 		PreventSleepWhilePlaying bool           `db:"prevent_sleep_while_playing"`
 		RemoteServerEnabled      bool           `db:"remote_server_enabled"`
 		RemoteServerPort         int            `db:"remote_server_port"`
@@ -81,7 +81,7 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 		ShowPlayerIndicator      bool           `db:"show_player_indicator"`
 	}
 	err := r.db.GetContext(ctx, &row,
-		`SELECT language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, enable_lrclib, enable_kugou, prefer_metadata_lyrics, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator FROM app_settings WHERE id = 1`,
+		`SELECT language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, enable_lrclib, enable_kugou, prefer_local_lyrics, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator FROM app_settings WHERE id = 1`,
 	)
 	if err == sql.ErrNoRows {
 		return &domain.AppSettings{
@@ -93,7 +93,7 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 			EQEnabled:                true,
 			EnableLrclib:             true,
 			EnableKugou:              true,
-			PreferMetadataLyrics:     true,
+			PreferLocalLyrics:        true,
 			UseOnlineArtistArtwork:   true,
 			PreventSleepWhilePlaying: false,
 			ShowPlayerIndicator:      true,
@@ -113,7 +113,7 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 		EQEnabled:                row.EQEnabled,
 		EnableLrclib:             row.EnableLrclib,
 		EnableKugou:              row.EnableKugou,
-		PreferMetadataLyrics:     row.PreferMetadataLyrics,
+		PreferLocalLyrics:        row.PreferLocalLyrics,
 		UseOnlineArtistArtwork:   row.UseOnlineArtistArtwork,
 		PreventSleepWhilePlaying: row.PreventSleepWhilePlaying,
 		RemoteServerEnabled:      row.RemoteServerEnabled,


### PR DESCRIPTION
## Summary

Adds support for local lyric files placed next to the audio file. Enhances the offline/custom-library experience.

**Resolution priority (default):** `local .lrc` → `local .txt` → metadata tag → LRClib/Kugou.

## Behavior
- **Matching:** sibling file must share the audio basename, only the extension differs (`/music/Song.mp3` → `Song.lrc` or `Song.txt`). `.lrc` preferred over `.txt`.
- **Read timing:** live at play time — newly added/edited files picked up on next play, no rescan, no file watch.
- **"Local lyrics" tier** = sibling file or embedded `LYRICS` tag, file winning.
- Setting `Prefer Metadata Lyrics` renamed to `Prefer Local Lyrics`; it governs local tier vs external providers. Migration renames the column and preserves each user's existing value.
- `.lrc` renders synced, `.txt` renders plain (frontend keys on timestamps).

## Changes
- `LocalLyricsReader` domain port + `internal/infra/lyrics/local.go` reader, wired via FX.
- `LyricsService.ResolveLyrics` now takes `audioPath` + `preferLocal` and builds the local tier.
- `PlayerService` passes track path + setting.
- Migration `000022_prefer_local_lyrics` (`RENAME COLUMN`).
- Frontend store, settings toggle, all 12 locales updated.
- Catalog + README updated.

## Tests
- `internal/infra/lyrics/local_test.go` — reader matrix (.lrc/.txt/both/none/empty/mismatch/BOM).
- `internal/app/lyrics/lyrics_service_test.go` — resolution matrix across tiers × prefer flag.
- Frontend `vue-tsc` clean, vitest passing.