### PR TITLE
feat(artist): local + custom artist images with multi-source artwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 - **Tray menu** — control playback from the system tray.
 - **Prevent sleep** — optionally keep your system awake while music is playing.
 - **Themes** — light, dark (gray), and black (pure black for OLED screens) themes.
-- **Online Artist Arts** — fetch and display artist arts from Deezer.
+- **Artist images** — uses local `artist.jpg`/`.jpeg`/`.png` files from your music folders (in the artist folder or beside the songs), or set your own custom image per artist. Toggle "Online Artist Artwork" to use Deezer images instead; turn it off to use your local files.
 - **Remote control** — control playback from any browser on the same network. Enable the remote server in settings, open the displayed URL on your phone or tablet, and enter the PIN to start controlling playback, managing the queue, and viewing lyrics remotely.
 
 ## Audio Format Support

--- a/catalog/artwork/README.md
+++ b/catalog/artwork/README.md
@@ -117,20 +117,96 @@ artworkUrlMd = `wails://artwork/${artworkKey}?v=md`;
 
 Fallback: if `artworkKey` is empty, a placeholder image is shown.
 
-## Artist Artwork (Online)
+## Artist Artwork
 
-Artist artwork is fetched dynamically from the Deezer API when enabled in settings (`UseOnlineArtistArtwork`).
+Artist artwork has three independent sources, **each stored separately** on the
+artist row. Every source's cache key is kept; which one is shown is decided at
+read time, so toggling the preference switches the displayed image instantly with
+no re-fetch or re-scan.
 
-### Fetching Flow
+| Source     | Column               | Set by                                  |
+| ---------- | -------------------- | --------------------------------------- |
+| Manual     | `artwork_key_manual` | User picks an image in ArtistDetailView |
+| Local file | `artwork_key_local`  | Scanned `artist.jpg/jpeg/png` from disk |
+| Online     | `artwork_key_online` | Background Deezer fetch                 |
 
-1. The frontend calls `LibraryService.GetArtistArtwork(artistID, eventID)`.
-2. If the artist already has an `artwork_key` in the database, the cached URL is returned immediately.
-3. If not cached, the request is placed on an asynchronous queue (`artistArtworkQueue`).
-4. A background worker (`StartArtistArtworkWorker`) picks up the job:
-   - Verifies the `UseOnlineArtistArtwork` setting is enabled.
-   - Searches the Deezer API (`https://api.deezer.com/search/artist?q={name}`).
-   - Downloads the `picture_medium` image.
-   - Saves it to the standard `ArtworkCache` (which generates the standard variants).
-   - Updates the `artists` table with the new `artwork_key`.
-   - Emits a Wails event using the provided `eventID` with the new artwork URL.
-5. The frontend component (`ArtistCard.vue`) listens for this event to dynamically display the fetched image.
+**Read-time resolution** (`domain.Artist.ResolveArtworkKey(preferLocal)`):
+`manual` always wins; otherwise a single setting, **`use_online_artist_artwork`**,
+picks the local/online order — on → Deezer first, off → local first
+(`preferLocal = !use_online_artist_artwork`). Turning online off still shows an
+already-downloaded Deezer image if no local one exists (it stops new fetches and
+deletes nothing); the displayed image switches instantly because resolution is
+client-side.
+
+Files (in `internal/app/library/`):
+
+| File                   | Purpose                                                       |
+| ---------------------- | ------------------------------------------------------------- |
+| `artist_local_image.go`| Local image scan, per-source writes, version-gated rescan     |
+| `artist_artwork.go`    | Deezer fetch + background worker                              |
+
+### Write path
+
+Writes go through `LibraryService.writeArtistArtworkSource(artistID, source, load)`
+— per-artist locked (keyed `sync.Map` of mutexes), lazily loads + caches the
+bytes, skips if that source's key is unchanged, then calls
+`ArtistRepository.SetArtworkSource(id, source, key)` (writes one source column;
+nil clears just that source). No cross-source precedence at write time.
+
+On every change it emits a global `artist-artwork-updated` Wails event
+`{ artist_id, source, key }` (empty `key` = cleared). `ArtistCard.vue` keeps a
+reactive copy of the three keys, updates the changed slot, and recomputes the
+displayed image — so live changes and preference toggles both reflect instantly.
+
+### Local file scan
+
+- `findArtistImageFile(dir)` looks for `artist.jpg`, then `artist.jpeg`, then
+  `artist.png` (priority order).
+- A full sync resolves images in one batch (`applyLocalArtistImagesForDirs`):
+  the walk collects every directory holding an `artist.*`, each image is cached
+  once, and `artistIDsForImageDir` maps it to artists **two ways** (unioned):
+  - **by folder name** — `GetByNormalizationKey(NormalizationKey(base(dir)))`, so
+    an artist folder that contains only `artist.jpg` (tracks live elsewhere, e.g.
+    in the music root) still matches;
+  - **by contained tracks** — artists of tracks in the dir or its subfolders.
+  No per-track stat/read storm. Single-file imports (watcher add) fall back to the
+  per-track `resolveTrackArtistImages` (gated by the `syncing` flag).
+- The `fsnotify` watcher reacts to `artist.*` create/write (set local) and
+  remove/rename (clear the `local_file` source only; manual/online remain).
+- `ScanArtistImages` is a heavier per-artist sweep used only by the version-gated
+  rescan (below).
+
+### Version-gated rescan
+
+`maybeRescanArtistImages` runs once on startup when `last_scan_version` is empty
+or older than `config.Version` (semver compare), so existing libraries pick up
+artist images already on disk after upgrading. Stores the current version after.
+
+### Online (Deezer) fetch
+
+1. `LibraryService.GetArtistArtwork(artistID, eventID)` resolves the display key;
+   if non-empty, returns its URL.
+2. If nothing is showable **and** `UseOnlineArtistArtwork` is on **and** no online
+   key exists yet, the request is queued (`artistArtworkQueue`).
+3. The background worker (`StartArtistArtworkWorker`) skips if an online key
+   already exists, otherwise searches Deezer
+   (`https://api.deezer.com/search/artist?q={name}`), downloads `picture_medium`,
+   and stores it via `writeArtistArtworkSource` with source `online`.
+
+### Custom image & cache cleanup
+
+- `SelectAndSetArtistArtwork` / `RemoveArtistArtwork` set / clear the `manual`
+  source (ArtistDetailView avatar menu).
+- `ArtistRepository.GetAllArtworkKeys` returns keys across all three columns;
+  `CleanupOrphanedArtworks` unions them with track keys so artist images survive
+  while the artist exists and **all** of an artist's cached images are deleted once
+  it is orphaned. It runs after a full sync and on folder removal — not per watcher
+  delete event (that would rescan the whole cache dir and thrash on bulk deletes).
+
+### Custom image (in-app)
+
+- `LibraryService.SelectAndSetArtistArtwork(artistID)` opens a file picker and
+  sets the chosen image with source `manual` (locked).
+- `LibraryService.RemoveArtistArtwork(artistID)` clears it, allowing automatic
+  sources to repopulate.
+- Surfaced in `ArtistDetailView.vue` via the avatar hover/right-click menu.

--- a/catalog/database/README.md
+++ b/catalog/database/README.md
@@ -42,6 +42,10 @@ SQLite database managed via `golang-migrate` for schema versioning and `sqlx` fo
 | 000015 | `artist_artwork.up.sql`              | `ALTER TABLE artists ADD COLUMN artwork_key TEXT`                                                                                    |
 | 000016 | `app_settings_artist_artwork.up.sql` | `ALTER TABLE app_settings ADD COLUMN use_online_artist_artwork BOOLEAN NOT NULL DEFAULT 1`                                          |
 | 000017 | `lyrics_provider_settings.up.sql`    | Add `enable_lrclib`, `enable_kugou`, `prefer_metadata_lyrics` (all `BOOLEAN NOT NULL DEFAULT 1`) to `app_settings`                 |
+| 000023 | `artist_artwork_source.up.sql`       | `ALTER TABLE artists ADD COLUMN artwork_source TEXT NOT NULL DEFAULT ''` — tracks artwork origin (`online`/`local_file`/`manual`)   |
+| 000024 | `app_settings_artist_artwork.up.sql` | Add `prefer_local_artist_artwork BOOLEAN NOT NULL DEFAULT 1` and `last_scan_version TEXT NOT NULL DEFAULT ''` to `app_settings`     |
+| 000026 | `drop_prefer_local_artist_artwork.up.sql` | Drop `prefer_local_artist_artwork` — replaced by deriving from `use_online_artist_artwork` |
+| 000025 | `artist_artwork_multi_source.up.sql` | Replace `artwork_key`/`artwork_source` with per-source `artwork_key_manual`/`_local`/`_online` (backfilled), then drop the old two |
 
 ## Full Schema
 
@@ -53,7 +57,9 @@ artists (
     name TEXT NOT NULL,
     sort_name TEXT NOT NULL,
     normalization_key TEXT,
-    artwork_key TEXT,
+    artwork_key_manual TEXT,  -- user-set image (highest priority)
+    artwork_key_local TEXT,   -- scanned artist.jpg/png
+    artwork_key_online TEXT,  -- Deezer fetch
     created_at DATETIME,
     updated_at DATETIME
 )
@@ -179,6 +185,7 @@ app_settings (
     eq_enabled BOOLEAN DEFAULT 0,
     lrclib_mode TEXT DEFAULT 'prefer_metadata',
     use_online_artist_artwork BOOLEAN NOT NULL DEFAULT 1,
+    last_scan_version TEXT NOT NULL DEFAULT '',
     enable_lrclib BOOLEAN NOT NULL DEFAULT 1,
     enable_kugou BOOLEAN NOT NULL DEFAULT 1,
     prefer_metadata_lyrics BOOLEAN NOT NULL DEFAULT 1,

--- a/catalog/library/README.md
+++ b/catalog/library/README.md
@@ -30,6 +30,9 @@ File system events are debounced (500ms) before processing:
 
 - `Create` / `Write` → import file
 - `Remove` / `Rename` → delete track from DB and search index
+- `artist.jpg/jpeg/png` events are routed to artist-artwork handling instead of
+  the track pipeline (apply on create/write, clear on remove). See the
+  [Artwork catalog](../artwork/README.md#artist-artwork).
 
 ## Import Pipeline
 
@@ -76,6 +79,8 @@ GetSyncStatus(): SyncProgress | null     // stub; used for frontend type generat
 // Metadata & artwork
 GetAlbumColors(id: string): ThemeColors
 GetArtistArtwork(artistID: string, eventID: string): string | null
+SelectAndSetArtistArtwork(artistID: string): string   // pick file → manual artwork
+RemoveArtistArtwork(artistID: string): void           // clear custom artwork
 ToggleFavorite(trackID: string): boolean
 UpdateTrackMetadata(trackID: string, update: MetadataUpdate): void
 ShowInExplorer(trackID: string): void
@@ -115,6 +120,7 @@ GetComposerByID(id: string): Composer
 | `library:sync-finished` | `{}`                       | Scan complete            |
 | `library:track-updated` | `TrackDTO`                 | Metadata written to file |
 | `library:updated`       | `{}`                       | General library change   |
+| `artist-artwork-updated`| `{ artist_id, source, key }` | One artwork source's key changed (empty `key` = cleared) |
 
 ## Frontend Integration
 

--- a/catalog/settings/README.md
+++ b/catalog/settings/README.md
@@ -29,7 +29,8 @@ type AppSettings struct {
     EnableLrclib           bool                // enable LRClib lyrics provider
     EnableKugou            bool                // enable Kugou lyrics provider
     PreferMetadataLyrics   bool                // prefer embedded lyrics over fetched
-    UseOnlineArtistArtwork bool                // fetch artist artwork from Deezer
+    UseOnlineArtistArtwork bool                // on: prefer Deezer image; off: prefer local artist.jpg/png
+    LastScanVersion        string              // app version of last artist-image rescan
     PreventSleepWhilePlaying bool             // prevent OS sleep during playback
 }
 ```
@@ -185,3 +186,7 @@ Settings evolved across multiple migrations:
 | 000016    | Add `use_online_artist_artwork` setting column                   |
 | 000017    | Add `enable_lrclib`, `enable_kugou`, `prefer_metadata_lyrics`; all `BOOLEAN NOT NULL DEFAULT 1` |
 | 000019    | Add `prevent_sleep_while_playing BOOLEAN NOT NULL DEFAULT 0`     |
+| 000023    | Add `artwork_source` column to `artists` table                   |
+| 000024    | Add `prefer_local_artist_artwork`, `last_scan_version` settings  |
+| 000026    | Drop `prefer_local_artist_artwork` (derived from online toggle)   |
+| 000025    | Split artist artwork into per-source key columns                 |

--- a/frontend/src/components/ArtistCard.vue
+++ b/frontend/src/components/ArtistCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, watch } from 'vue'
+import { ref, reactive, computed, onMounted, onUnmounted, watch } from 'vue'
 import { User } from 'lucide-vue-next'
 import type { Artist } from '../../bindings/airmedy/internal/domain/models'
 import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
@@ -16,66 +16,82 @@ const emit = defineEmits<{
 }>()
 
 const appStore = useAppStore()
+
+// All stored artwork keys are kept; which one shows is resolved client-side so
+// flipping the "prefer local" setting swaps instantly without any round-trip.
+const keys = reactive({
+  manual: props.artist.artwork_key_manual as string | null,
+  local: props.artist.artwork_key_local as string | null,
+  online: props.artist.artwork_key_online as string | null,
+})
+
+const resolvedKey = computed(() => {
+  if (keys.manual) return keys.manual
+  // Single toggle: online on → prefer Deezer image; off → prefer local.
+  return appStore.useOnlineArtistArtwork
+    ? (keys.online || keys.local)
+    : (keys.local || keys.online)
+})
+
 const imageUrl = ref<string | null>(null)
-let offArtwork: (() => void) | null = null
+let offGlobal: (() => void) | null = null
 
-const loadArtwork = async () => {
-  if (!appStore.useOnlineArtistArtwork || imageUrl.value) return
+// Keep imageUrl in sync with the resolved key (instant on preference/key change).
+watch(resolvedKey, (key) => {
+  imageUrl.value = key ? `/artwork/${key}` : null
+}, { immediate: true })
 
-  const eventId = `artist-artwork:${props.artist.id}`
-  try {
-    const url = await LibraryService.GetArtistArtwork(props.artist.id, eventId)
-    if (url) {
-      imageUrl.value = url
-    } else {
-      // Wait for event
-      if (!offArtwork) {
-        offArtwork = Events.On(eventId, (ev) => {
-          imageUrl.value = ev.data as string
-          if (offArtwork) {
-            offArtwork()
-            offArtwork = null
-          }
-        })
-      }
-    }
-  } catch (err) {
-    console.error(`[ArtistCard] Failed to get artist artwork for ${props.artist.name}:`, err)
-  }
+const seedKeys = () => {
+  keys.manual = props.artist.artwork_key_manual as string | null
+  keys.local = props.artist.artwork_key_local as string | null
+  keys.online = props.artist.artwork_key_online as string | null
+}
+
+// Fetch the Deezer image when online is enabled and none is cached yet (even if a
+// local image exists, so it's ready and shown per the toggle).
+const maybeFetchOnline = () => {
+  if (!appStore.useOnlineArtistArtwork || keys.online) return
+  LibraryService.GetArtistArtwork(props.artist.id, `artist-artwork:${props.artist.id}`)
+    .catch((err) => console.error(`[ArtistCard] artwork fetch failed for ${props.artist.name}:`, err))
+}
+
+// Backend emits this whenever a single source's key changes (empty = cleared).
+const subscribeGlobal = () => {
+  if (offGlobal) return
+  offGlobal = Events.On('artist-artwork-updated', (ev) => {
+    const data = ev.data as { artist_id?: string; source?: string; key?: string } | undefined
+    if (!data || data.artist_id !== props.artist.id) return
+    const value = data.key ? data.key : null
+    if (data.source === 'manual') keys.manual = value
+    else if (data.source === 'local_file') keys.local = value
+    else if (data.source === 'online') keys.online = value
+  })
 }
 
 watch(() => props.artist.id, () => {
-  if (offArtwork) {
-    offArtwork()
-    offArtwork = null
-  }
-  imageUrl.value = null
-  loadArtwork()
+  seedKeys()
+  maybeFetchOnline()
 })
 
 watch(() => appStore.useOnlineArtistArtwork, (enabled) => {
-  if (enabled) {
-    loadArtwork()
-  } else {
-    imageUrl.value = null
-  }
+  // Re-attempt a fetch when online is re-enabled and nothing is shown.
+  if (enabled) maybeFetchOnline()
 })
 
 onMounted(() => {
-  loadArtwork()
+  subscribeGlobal()
+  maybeFetchOnline()
 })
 
 onUnmounted(() => {
-  if (offArtwork) {
-    offArtwork()
-  }
+  if (offGlobal) offGlobal()
 })
 </script>
 
 <template>
   <!-- Avatar only variant -->
   <div v-if="variant === 'avatar'" class="w-full h-full flex items-center justify-center">
-    <div v-if="imageUrl && appStore.useOnlineArtistArtwork" class="w-full h-full">
+    <div v-if="imageUrl" class="w-full h-full">
       <img 
         :src="imageUrl" 
         class="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
@@ -94,9 +110,9 @@ onUnmounted(() => {
     @click="emit('click', artist.id)"
   >
     <div class="aspect-square bg-foreground/5 rounded-full ring-1 ring-foreground/[0.06] overflow-hidden relative mb-3 transition-all flex items-center justify-center">
-      <div v-if="imageUrl && appStore.useOnlineArtistArtwork" class="w-full h-full">
-        <img 
-          :src="imageUrl" 
+      <div v-if="imageUrl" class="w-full h-full">
+        <img
+          :src="imageUrl"
           class="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
           @error="imageUrl = null"
         />

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -78,7 +78,7 @@
     "integrations": {
       "title": "Integrationen",
       "online_artist_artwork": "Online-Künstlerbilder",
-      "online_artist_artwork_desc": "Künstlerbilder automatisch von Deezer abrufen",
+      "online_artist_artwork_desc": "An: Künstlerbilder von Deezer; aus: lokale artist.jpg/png-Dateien",
       "enable_lrclib": "LRCLIB.NET Songtexte",
       "enable_lrclib_desc": "Songtexte von LRCLIB.NET abrufen",
       "enable_kugou": "KuGou Songtexte",
@@ -342,7 +342,10 @@
   },
   "artist": {
     "albums_count": "{count} Alben",
-    "songs_count": "{count} Songs"
+    "songs_count": "{count} Songs",
+    "edit_image": "Künstlerbild bearbeiten",
+    "set_custom_image": "Eigenes Bild festlegen",
+    "remove_custom_image": "Eigenes Bild entfernen"
   },
   "track_info": {
     "title": "Titelinformationen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -78,7 +78,7 @@
     "integrations": {
       "title": "Integrations",
       "online_artist_artwork": "Online Artist Artwork",
-      "online_artist_artwork_desc": "Automatically fetch artist artwork from Deezer",
+      "online_artist_artwork_desc": "When on, use artist images from Deezer; when off, use local artist.jpg/png files",
       "enable_lrclib": "LRCLIB.NET Lyrics",
       "enable_lrclib_desc": "Fetch lyrics from LRCLIB.NET",
       "enable_kugou": "KuGou Lyrics",
@@ -342,7 +342,10 @@
   },
   "artist": {
     "albums_count": "{count} albums",
-    "songs_count": "{count} songs"
+    "songs_count": "{count} songs",
+    "edit_image": "Edit artist image",
+    "set_custom_image": "Set custom image",
+    "remove_custom_image": "Remove custom image"
   },
   "track_info": {
     "title": "Track Info",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -78,7 +78,7 @@
     "integrations": {
       "title": "Integraciones",
       "online_artist_artwork": "Carátulas de artistas en línea",
-      "online_artist_artwork_desc": "Obtener automáticamente carátulas de artistas de Deezer",
+      "online_artist_artwork_desc": "Activado: imágenes de artistas de Deezer; desactivado: archivos locales artist.jpg/png",
       "enable_lrclib": "Letras de LRCLIB.NET",
       "enable_lrclib_desc": "Obtener letras de LRCLIB.NET",
       "enable_kugou": "Letras de KuGou",
@@ -342,7 +342,10 @@
   },
   "artist": {
     "albums_count": "{count} álbumes",
-    "songs_count": "{count} canciones"
+    "songs_count": "{count} canciones",
+    "edit_image": "Editar imagen del artista",
+    "set_custom_image": "Establecer imagen personalizada",
+    "remove_custom_image": "Quitar imagen personalizada"
   },
   "track_info": {
     "title": "Información de la pista",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -78,7 +78,7 @@
     "integrations": {
       "title": "Intégrations",
       "online_artist_artwork": "Photos d'artistes en ligne",
-      "online_artist_artwork_desc": "Récupérer automatiquement les photos d'artistes depuis Deezer",
+      "online_artist_artwork_desc": "Activé : images d'artistes depuis Deezer ; désactivé : fichiers locaux artist.jpg/png",
       "enable_lrclib": "Paroles LRCLIB.NET",
       "enable_lrclib_desc": "Récupérer les paroles depuis LRCLIB.NET",
       "enable_kugou": "Paroles KuGou",
@@ -342,7 +342,10 @@
   },
   "artist": {
     "albums_count": "{count} albums",
-    "songs_count": "{count} chansons"
+    "songs_count": "{count} chansons",
+    "edit_image": "Modifier l'image de l'artiste",
+    "set_custom_image": "Définir une image personnalisée",
+    "remove_custom_image": "Supprimer l'image personnalisée"
   },
   "track_info": {
     "title": "Informations sur la piste",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -78,7 +78,7 @@
     "integrations": {
       "title": "Integrazioni",
       "online_artist_artwork": "Immagini artisti online",
-      "online_artist_artwork_desc": "Recupera automaticamente le immagini degli artisti da Deezer",
+      "online_artist_artwork_desc": "Attivo: immagini artista da Deezer; disattivo: file locali artist.jpg/png",
       "enable_lrclib": "Testi LRCLIB.NET",
       "enable_lrclib_desc": "Recupera i testi da LRCLIB.NET",
       "enable_kugou": "Testi KuGou",
@@ -342,7 +342,10 @@
   },
   "artist": {
     "albums_count": "{count} album",
-    "songs_count": "{count} brani"
+    "songs_count": "{count} brani",
+    "edit_image": "Modifica immagine artista",
+    "set_custom_image": "Imposta immagine personalizzata",
+    "remove_custom_image": "Rimuovi immagine personalizzata"
   },
   "track_info": {
     "title": "Informazioni traccia",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -78,7 +78,7 @@
     "integrations": {
       "title": "連携",
       "online_artist_artwork": "オンラインのアーティスト画像",
-      "online_artist_artwork_desc": "Deezer からアーティスト画像を自動的に取得",
+      "online_artist_artwork_desc": "オン: Deezer のアーティスト画像を使用、オフ: ローカルの artist.jpg/png を使用",
       "enable_lrclib": "LRCLIB.NET の歌詞",
       "enable_lrclib_desc": "LRCLIB.NET から歌詞を取得",
       "enable_kugou": "KuGou の歌詞",
@@ -342,7 +342,10 @@
   },
   "artist": {
     "albums_count": "{count} アルバム",
-    "songs_count": "{count} 曲"
+    "songs_count": "{count} 曲",
+    "edit_image": "アーティスト画像を編集",
+    "set_custom_image": "カスタム画像を設定",
+    "remove_custom_image": "カスタム画像を削除"
   },
   "track_info": {
     "title": "トラック情報",

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -78,7 +78,7 @@
     "integrations": {
       "title": "연동",
       "online_artist_artwork": "온라인 아티스트 아트워크",
-      "online_artist_artwork_desc": "Deezer에서 자동으로 아티스트 아트워크 가져오기",
+      "online_artist_artwork_desc": "켜짐: Deezer 아티스트 이미지 사용, 꺼짐: 로컬 artist.jpg/png 사용",
       "enable_lrclib": "LRCLIB.NET 가사",
       "enable_lrclib_desc": "LRCLIB.NET에서 가사 가져오기",
       "enable_kugou": "KuGou 가사",
@@ -342,7 +342,10 @@
   },
   "artist": {
     "albums_count": "{count} 앨범",
-    "songs_count": "{count} 곡"
+    "songs_count": "{count} 곡",
+    "edit_image": "아티스트 이미지 편집",
+    "set_custom_image": "사용자 지정 이미지 설정",
+    "remove_custom_image": "사용자 지정 이미지 제거"
   },
   "track_info": {
     "title": "트랙 정보",

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -78,7 +78,7 @@
     "integrations": {
       "title": "Integrações",
       "online_artist_artwork": "Capas de artistas online",
-      "online_artist_artwork_desc": "Buscar automaticamente capas de artistas do Deezer",
+      "online_artist_artwork_desc": "Ligado: imagens de artistas do Deezer; desligado: arquivos locais artist.jpg/png",
       "enable_lrclib": "Letras do LRCLIB.NET",
       "enable_lrclib_desc": "Buscar letras do LRCLIB.NET",
       "enable_kugou": "Letras do KuGou",
@@ -342,7 +342,10 @@
   },
   "artist": {
     "albums_count": "{count} álbuns",
-    "songs_count": "{count} músicas"
+    "songs_count": "{count} músicas",
+    "edit_image": "Editar imagem do artista",
+    "set_custom_image": "Definir imagem personalizada",
+    "remove_custom_image": "Remover imagem personalizada"
   },
   "track_info": {
     "title": "Informações da faixa",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -78,7 +78,7 @@
     "integrations": {
       "title": "Интеграции",
       "online_artist_artwork": "Обложки исполнителей онлайн",
-      "online_artist_artwork_desc": "Автоматически загружать обложки исполнителей с Deezer",
+      "online_artist_artwork_desc": "Вкл.: изображения исполнителей с Deezer; выкл.: локальные файлы artist.jpg/png",
       "enable_lrclib": "Тексты LRCLIB.NET",
       "enable_lrclib_desc": "Загружать тексты с LRCLIB.NET",
       "enable_kugou": "Тексты KuGou",
@@ -342,7 +342,10 @@
   },
   "artist": {
     "albums_count": "{count} альбомов",
-    "songs_count": "{count} песен"
+    "songs_count": "{count} песен",
+    "edit_image": "Изменить изображение исполнителя",
+    "set_custom_image": "Задать своё изображение",
+    "remove_custom_image": "Удалить своё изображение"
   },
   "track_info": {
     "title": "Информация о треке",

--- a/frontend/src/locales/th.json
+++ b/frontend/src/locales/th.json
@@ -78,7 +78,7 @@
     "integrations": {
       "title": "การเชื่อมต่อ",
       "online_artist_artwork": "รูปภาพศิลปินออนไลน์",
-      "online_artist_artwork_desc": "ดึงรูปภาพศิลปินจาก Deezer โดยอัตโนมัติ",
+      "online_artist_artwork_desc": "เปิด: ใช้รูปภาพศิลปินจาก Deezer; ปิด: ใช้ไฟล์ artist.jpg/png ในเครื่อง",
       "enable_lrclib": "เนื้อเพลงจาก LRCLIB.NET",
       "enable_lrclib_desc": "ดึงเนื้อเพลงจาก LRCLIB.NET",
       "enable_kugou": "เนื้อเพลงจาก KuGou",
@@ -342,7 +342,10 @@
   },
   "artist": {
     "albums_count": "{count} อัลบั้ม",
-    "songs_count": "{count} เพลง"
+    "songs_count": "{count} เพลง",
+    "edit_image": "แก้ไขรูปภาพศิลปิน",
+    "set_custom_image": "ตั้งรูปภาพที่กำหนดเอง",
+    "remove_custom_image": "ลบรูปภาพที่กำหนดเอง"
   },
   "track_info": {
     "title": "ข้อมูลเพลง",

--- a/frontend/src/locales/vi.json
+++ b/frontend/src/locales/vi.json
@@ -78,7 +78,7 @@
     "integrations": {
       "title": "Tích hợp",
       "online_artist_artwork": "Ảnh nghệ sĩ trực tuyến",
-      "online_artist_artwork_desc": "Tự động tải ảnh nghệ sĩ từ Deezer",
+      "online_artist_artwork_desc": "Khi bật, dùng ảnh nghệ sĩ từ Deezer; khi tắt, dùng tệp artist.jpg/png cục bộ",
       "enable_lrclib": "Lời bài hát LRCLIB.NET",
       "enable_lrclib_desc": "Tải lời bài hát từ LRCLIB.NET",
       "enable_kugou": "Lời bài hát KuGou",
@@ -342,7 +342,10 @@
   },
   "artist": {
     "albums_count": "{count} album",
-    "songs_count": "{count} bài hát"
+    "songs_count": "{count} bài hát",
+    "edit_image": "Chỉnh sửa ảnh nghệ sĩ",
+    "set_custom_image": "Đặt ảnh tùy chỉnh",
+    "remove_custom_image": "Xóa ảnh tùy chỉnh"
   },
   "track_info": {
     "title": "Thông tin bài hát",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -78,7 +78,7 @@
     "integrations": {
       "title": "集成",
       "online_artist_artwork": "在线艺术家封面",
-      "online_artist_artwork_desc": "自动从 Deezer 获取艺术家封面",
+      "online_artist_artwork_desc": "开启：使用 Deezer 艺术家图片；关闭：使用本地 artist.jpg/png 文件",
       "enable_lrclib": "LRCLIB.NET 歌词",
       "enable_lrclib_desc": "从 LRCLIB.NET 获取歌词",
       "enable_kugou": "酷狗歌词",
@@ -342,7 +342,10 @@
   },
   "artist": {
     "albums_count": "{count} 张专辑",
-    "songs_count": "{count} 首曲目"
+    "songs_count": "{count} 首曲目",
+    "edit_image": "编辑艺术家图片",
+    "set_custom_image": "设置自定义图片",
+    "remove_custom_image": "移除自定义图片"
   },
   "track_info": {
     "title": "歌曲信息",

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -18,6 +18,10 @@ export const useAppStore = defineStore('app', () => {
   const enableKugou = ref(true)
   const preferLocalLyrics = ref(true)
   const useOnlineArtistArtwork = ref(true)
+  // Round-tripped only (set by the backend's version-gated rescan); never edited
+  // in the UI, but must be preserved across saves so saving settings doesn't
+  // wipe it and re-trigger a rescan.
+  const lastScanVersion = ref('')
   const preventSleepWhilePlaying = ref(false)
   const showPlayerIndicator = ref(true)
   const remoteServerEnabled = ref(false)
@@ -66,6 +70,7 @@ export const useAppStore = defineStore('app', () => {
         enableKugou.value = settings.enable_kugou !== false
         preferLocalLyrics.value = settings.prefer_local_lyrics !== false
         useOnlineArtistArtwork.value = settings.use_online_artist_artwork !== false
+        lastScanVersion.value = settings.last_scan_version || ''
         preventSleepWhilePlaying.value = !!settings.prevent_sleep_while_playing
         showPlayerIndicator.value = settings.show_player_indicator !== false
         remoteServerEnabled.value = !!settings.remote_server_enabled
@@ -132,6 +137,7 @@ export const useAppStore = defineStore('app', () => {
         enable_kugou: enableKugou.value,
         prefer_local_lyrics: preferLocalLyrics.value,
         use_online_artist_artwork: useOnlineArtistArtwork.value,
+        last_scan_version: lastScanVersion.value,
         prevent_sleep_while_playing: preventSleepWhilePlaying.value,
         show_player_indicator: showPlayerIndicator.value,
         remote_server_enabled: remoteServerEnabled.value,

--- a/frontend/src/views/ArtistDetailView.vue
+++ b/frontend/src/views/ArtistDetailView.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
-import { ref, shallowRef, computed, onMounted, watch } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
-import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
-import type { Artist, AlbumDTO, TrackDTO } from '../../bindings/airmedy/internal/domain/models'
-import GroupedAlbumList from '../components/GroupedAlbumList.vue'
 import ArtistCard from '@/components/ArtistCard.vue'
-import { User, Shuffle, Disc, Music, Play, MoreVertical } from 'lucide-vue-next'
-import { usePlayerStore } from '../stores/player'
-import { useI18n } from 'vue-i18n'
 import { useContextMenu } from '@/composables/useContextMenu'
 import { useGroupContextMenu } from '@/composables/useGroupContextMenu'
-import ContextMenu from '../components/ContextMenu.vue'
-import { DetailsButton } from '@airmedy/ui'
 import { sortTracksGrouped } from '@/lib/trackSort'
+import { DetailsButton } from '@airmedy/ui'
+import { Disc, ImagePlus, MoreVertical, Music, Play, Shuffle, Trash2 } from 'lucide-vue-next'
+import { computed, onMounted, ref, shallowRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRoute, useRouter } from 'vue-router'
+import type { AlbumDTO, Artist, TrackDTO } from '../../bindings/airmedy/internal/domain/models'
+import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
+import ContextMenu from '../components/ContextMenu.vue'
+import GroupedAlbumList from '../components/GroupedAlbumList.vue'
+import { usePlayerStore } from '../stores/player'
 
 const { t } = useI18n()
 
@@ -50,6 +50,48 @@ const loadArtistDetails = async (id: string) => {
   }
 }
 
+const refreshArtist = async (id: string) => {
+  try {
+    artist.value = await LibraryService.GetArtistByID(id)
+  } catch (err) {
+    console.error('Failed to refresh artist:', err)
+  }
+}
+
+async function handleSetArtistImage() {
+  if (!artist.value) return
+  try {
+    const url = await LibraryService.SelectAndSetArtistArtwork(artist.value.id)
+    if (url) refreshArtist(artist.value.id)
+  } catch (err) {
+    console.error('Failed to set artist image:', err)
+  }
+}
+
+async function handleRemoveArtistImage() {
+  if (!artist.value) return
+  try {
+    await LibraryService.RemoveArtistArtwork(artist.value.id)
+    refreshArtist(artist.value.id)
+  } catch (err) {
+    console.error('Failed to remove artist image:', err)
+  }
+}
+
+function openArtworkMenu(e: MouseEvent) {
+  if (!artist.value) return
+  contextMenu.open(e, [
+    { label: t('artist.set_custom_image'), icon: ImagePlus, action: handleSetArtistImage },
+    {
+      label: t('artist.remove_custom_image'),
+      icon: Trash2,
+      danger: true,
+      disabled: !artist.value.artwork_key_manual,
+      action: handleRemoveArtistImage,
+    },
+  ])
+}
+
 onMounted(() => {
   const id = route.params.id as string
   if (id) loadArtistDetails(id)
@@ -71,8 +113,15 @@ watch(() => route.params.id, (newId) => {
       <div
         class="p-8 md:p-12 flex flex-col md:flex-row gap-8 items-center bg-gradient-to-b from-dynamic-surface to-transparent border-b border-foreground/[0.06]">
         <div
-          class="w-32 h-32 xl:w-42 xl:h-42 rounded-full shadow-2xl overflow-hidden ring-2 ring-foreground/[0.08] bg-foreground/5 flex-shrink-0">
+          class="group relative w-32 h-32 xl:w-42 xl:h-42 rounded-full shadow-2xl overflow-hidden ring-2 ring-foreground/[0.08] bg-foreground/5 flex-shrink-0"
+          @contextmenu="openArtworkMenu">
           <ArtistCard :artist="artist" variant="avatar" />
+          <button type="button"
+            class="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+            :title="t('artist.edit_image')" @click.stop="openArtworkMenu">
+            <span
+              class="text-white text-xs font-medium px-2 py-1 bg-black/20 rounded-full backdrop-blur-sm">{{ t('artist.edit_image') }}</span>
+          </button>
         </div>
 
         <div class="flex-1 text-center md:text-left space-y-4 @container min-w-0">

--- a/internal/app/library/artist_artwork.go
+++ b/internal/app/library/artist_artwork.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"time"
 
+	"airmedy/internal/domain"
+
 	"github.com/wailsapp/wails/v3/pkg/application"
 )
 
@@ -51,97 +53,98 @@ func (s *LibraryService) processArtistArtworkJob(ctx context.Context, job artist
 		return
 	}
 
-	// 2. Get artist name
+	// 2. Get artist
 	artist, err := s.artistRepo.GetByID(ctx, job.ArtistID)
 	if err != nil || artist == nil {
 		s.logger.Warn("Artist not found for artwork job", "artistID", job.ArtistID, "error", err)
 		return
 	}
 
+	// 3. Already have an online image — don't refetch (it's kept even when the
+	//    online toggle is later turned off).
+	if artist.ArtworkKeyOnline != nil && *artist.ArtworkKeyOnline != "" {
+		return
+	}
+
 	s.logger.Info("Fetching artwork for artist from Deezer", "artist", artist.Name)
 
-	// 3. Search Deezer
-	artworkKey, err := s.fetchArtistArtworkFromDeezer(ctx, artist.Name)
+	// 4. Fetch + store the online source. Other sources are untouched.
+	artworkURL, _, err := s.writeArtistArtworkSource(ctx, artist.ID, domain.ArtworkSourceOnline,
+		func() ([]byte, string, error) {
+			return s.fetchArtistArtworkFromDeezer(ctx, artist.Name)
+		})
 	if err != nil {
 		s.logger.Warn("Failed to fetch artist artwork from Deezer", "artist", artist.Name, "artistID", artist.ID, "error", err)
 		return
 	}
-
-	// 4. Update Database
-	artist.ArtworkKey = &artworkKey
-	if err := s.artistRepo.Upsert(ctx, artist); err != nil {
-		s.logger.Error("Failed to update artist artwork key in DB", "artist", artist.Name, "error", err)
+	if artworkURL == "" {
 		return
 	}
 
-	// 5. Emit Event
-	artworkURL := fmt.Sprintf("/artwork/%s", artworkKey)
+	// 6. Emit the per-request event the waiting frontend card is listening for.
 	s.logger.Info("Emitting artist artwork event", "artist", artist.Name, "eventID", job.EventID, "url", artworkURL)
 	if app := application.Get(); app != nil && app.Event != nil {
 		app.Event.Emit(job.EventID, artworkURL)
 	}
 }
 
-func (s *LibraryService) fetchArtistArtworkFromDeezer(ctx context.Context, name string) (string, error) {
+// fetchArtistArtworkFromDeezer searches Deezer for the artist and downloads the
+// best picture, returning the raw image bytes and mime type. Caching/storage is
+// handled by the caller via writeArtistArtwork.
+func (s *LibraryService) fetchArtistArtworkFromDeezer(ctx context.Context, name string) ([]byte, string, error) {
 	searchURL := fmt.Sprintf("https://api.deezer.com/search/artist?q=%s", url.QueryEscape(name))
 	s.logger.Info("Deezer search request", "url", searchURL)
-	
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, searchURL, nil)
 	if err != nil {
-		return "", err
+		return nil, "", err
 	}
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", err
+		return nil, "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("deezer api returned status %d", resp.StatusCode)
+		return nil, "", fmt.Errorf("deezer api returned status %d", resp.StatusCode)
 	}
 
 	var searchResult deezerSearchResponse
 	if err := json.NewDecoder(resp.Body).Decode(&searchResult); err != nil {
-		return "", err
+		return nil, "", err
 	}
 
 	if len(searchResult.Data) == 0 {
-		return "", fmt.Errorf("artist not found on deezer")
+		return nil, "", fmt.Errorf("artist not found on deezer")
 	}
 
 	imageURL := searchResult.Data[0].PictureMedium
 	s.logger.Info("Deezer found artist artwork", "name", name, "imageURL", imageURL)
 	if imageURL == "" {
-		return "", fmt.Errorf("no picture found for artist on deezer")
+		return nil, "", fmt.Errorf("no picture found for artist on deezer")
 	}
 
 	// Download image
 	s.logger.Info("Downloading artist artwork", "url", imageURL)
 	imgResp, err := client.Get(imageURL)
 	if err != nil {
-		return "", err
+		return nil, "", err
 	}
 	defer func() { _ = imgResp.Body.Close() }()
 
 	if imgResp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to download image, status %d", imgResp.StatusCode)
+		return nil, "", fmt.Errorf("failed to download image, status %d", imgResp.StatusCode)
 	}
 
 	data, err := io.ReadAll(imgResp.Body)
 	if err != nil {
-		return "", err
+		return nil, "", err
 	}
 
 	mimeType := imgResp.Header.Get("Content-Type")
-	key, err := s.artworkCache.Save(ctx, data, mimeType)
-	if err != nil {
-		return "", err
-	}
-
-	s.logger.Info("Saved artist artwork to cache", "name", name, "key", key)
-	return key, nil
+	return data, mimeType, nil
 }
 
 func (s *LibraryService) EnqueueArtistArtwork(artistID, eventID string) {

--- a/internal/app/library/artist_local_image.go
+++ b/internal/app/library/artist_local_image.go
@@ -1,0 +1,367 @@
+package library
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"mime"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+
+	"airmedy/internal/app/config"
+	"airmedy/internal/domain"
+
+	"github.com/blang/semver"
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+// artistImageBaseNames lists the accepted local artist image files in priority
+// order: jpg > jpeg > png.
+var artistImageBaseNames = []string{"artist.jpg", "artist.jpeg", "artist.png"}
+
+// findArtistImageFile returns the path of the highest-priority artist image in
+// dir, or "" if none exists.
+func findArtistImageFile(dir string) string {
+	for _, name := range artistImageBaseNames {
+		// Case-insensitive on macOS/Windows; on Linux honour the exact lower-case
+		// name plus a couple of common casings.
+		for _, candidate := range []string{name, capitalize(name)} {
+			p := filepath.Join(dir, candidate)
+			if info, err := os.Stat(p); err == nil && !info.IsDir() {
+				return p
+			}
+		}
+	}
+	return ""
+}
+
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return string(s[0]-32) + s[1:] // "artist.jpg" -> "Artist.jpg"
+}
+
+// isArtistImageFile reports whether a file name is one of the accepted artist
+// image files (case-insensitive).
+func isArtistImageFile(name string) bool {
+	return slices.Contains(artistImageBaseNames, strings.ToLower(name))
+}
+
+// artistIDsInDir returns the distinct artist IDs of tracks located in dir or any
+// of its subdirectories. Used to map an artist image file to the artists it
+// belongs to.
+func (s *LibraryService) artistIDsInDir(ctx context.Context, dir string) []string {
+	prefix := dir
+	if !strings.HasSuffix(prefix, string(os.PathSeparator)) {
+		prefix += string(os.PathSeparator)
+	}
+	tracks, err := s.trackRepo.GetByPathPrefix(ctx, prefix)
+	if err != nil {
+		s.logger.Warn("Failed to list tracks for artist image dir", "dir", dir, "error", err)
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var ids []string
+	for _, t := range tracks {
+		for _, a := range t.Artists {
+			if _, ok := seen[a.ID]; ok {
+				continue
+			}
+			seen[a.ID] = struct{}{}
+			ids = append(ids, a.ID)
+		}
+	}
+	return ids
+}
+
+// artistIDsForImageDir maps an artist-image directory to the artists it belongs
+// to, two ways (unioned):
+//  1. by folder name — the directory is named after an artist (e.g. "Maroon 5/"),
+//     even if it holds no tracks of its own;
+//  2. by contained tracks — tracks living in the directory or its subfolders.
+//
+// Only artists that actually exist in the library are returned.
+func (s *LibraryService) artistIDsForImageDir(ctx context.Context, dir string) []string {
+	seen := make(map[string]struct{})
+	var ids []string
+	add := func(id string) {
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+
+	// 1. Folder name == artist name.
+	key := domain.NormalizationKey(filepath.Base(dir))
+	if key != "" {
+		if artist, err := s.artistRepo.GetByNormalizationKey(ctx, key); err == nil && artist != nil {
+			add(artist.ID)
+		}
+	}
+
+	// 2. Artists of tracks within the directory.
+	for _, id := range s.artistIDsInDir(ctx, dir) {
+		add(id)
+	}
+	return ids
+}
+
+// artistImageForTrack looks for an artist image next to the track (image-with-
+// songs layout) and then in the parent directory (artist-folder layout).
+func artistImageForTrack(trackPath string) string {
+	dir := filepath.Dir(trackPath)
+	if p := findArtistImageFile(dir); p != "" {
+		return p
+	}
+	return findArtistImageFile(filepath.Dir(dir))
+}
+
+func (s *LibraryService) artistLock(artistID string) *sync.Mutex {
+	m, _ := s.artistArtworkLocks.LoadOrStore(artistID, &sync.Mutex{})
+	return m.(*sync.Mutex)
+}
+
+// writeArtistArtworkSource stores artwork for one source on an artist. Every
+// source is kept independently — no cross-source precedence at write time (the
+// shown image is chosen at read time). The bytes are produced lazily by load so
+// a file is only read when needed. Returns the artwork URL and whether anything
+// changed.
+func (s *LibraryService) writeArtistArtworkSource(
+	ctx context.Context,
+	artistID, source string,
+	load func() (data []byte, mimeType string, err error),
+) (string, bool, error) {
+	data, mimeType, err := load()
+	if err != nil {
+		return "", false, err
+	}
+
+	key, err := s.artworkCache.Save(ctx, data, mimeType)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to save artist artwork: %w", err)
+	}
+
+	changed, err := s.applyArtistArtworkKey(ctx, artistID, source, key)
+	return fmt.Sprintf("/artwork/%s", key), changed, err
+}
+
+// applyArtistArtworkKey points one of an artist's artwork sources at an
+// already-cached key (locked per artist). Skips when unchanged. The cache save
+// is done by the caller so the same image can be reused across many artists
+// without re-reading the file.
+func (s *LibraryService) applyArtistArtworkKey(ctx context.Context, artistID, source, key string) (bool, error) {
+	lock := s.artistLock(artistID)
+	lock.Lock()
+	defer lock.Unlock()
+
+	artist, err := s.artistRepo.GetByID(ctx, artistID)
+	if err != nil {
+		return false, err
+	}
+	if artist == nil {
+		return false, nil
+	}
+	if cur := artist.ArtworkKeyForSource(source); cur != nil && *cur == key {
+		return false, nil
+	}
+	if err := s.artistRepo.SetArtworkSource(ctx, artistID, source, &key); err != nil {
+		return false, err
+	}
+	s.emitArtistArtworkUpdated(artistID, source, key)
+	return true, nil
+}
+
+// applyLocalArtistImagesForDirs is the bulk artist-image pass used during a full
+// sync. imageDirs is the set of directories that actually contain an
+// artist.{jpg,jpeg,png} file. Each image is cached once and applied to every
+// artist the directory maps to (by folder name and/or by contained tracks), so a
+// whole library is processed without a per-track stat/read storm. Runs after all
+// tracks are imported, so the by-name lookup only matches existing artists.
+func (s *LibraryService) applyLocalArtistImagesForDirs(ctx context.Context, imageDirs map[string]bool) {
+	imgKey := make(map[string]string) // image path -> cache key (saved once)
+	for dir := range imageDirs {
+		imagePath := findArtistImageFile(dir)
+		if imagePath == "" {
+			continue
+		}
+
+		artistIDs := s.artistIDsForImageDir(ctx, dir)
+		if len(artistIDs) == 0 {
+			continue
+		}
+
+		key, ok := imgKey[imagePath]
+		if !ok {
+			data, mimeType, err := loadImageFile(imagePath)()
+			if err != nil {
+				s.logger.Warn("Failed to read artist image during scan", "image", imagePath, "error", err)
+				continue
+			}
+			k, err := s.artworkCache.Save(ctx, data, mimeType)
+			if err != nil {
+				s.logger.Warn("Failed to cache artist image during scan", "image", imagePath, "error", err)
+				continue
+			}
+			key = k
+			imgKey[imagePath] = k
+		}
+
+		for _, id := range artistIDs {
+			if _, err := s.applyArtistArtworkKey(ctx, id, domain.ArtworkSourceLocalFile, key); err != nil {
+				s.logger.Warn("Failed to apply local artist image", "artistID", id, "error", err)
+			}
+		}
+	}
+}
+
+func loadImageFile(imagePath string) func() ([]byte, string, error) {
+	return func() ([]byte, string, error) {
+		data, err := os.ReadFile(imagePath)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to read image %s: %w", imagePath, err)
+		}
+		mimeType := mime.TypeByExtension(filepath.Ext(imagePath))
+		if mimeType == "" {
+			mimeType = "image/jpeg"
+		}
+		return data, mimeType, nil
+	}
+}
+
+// setLocalArtistImage applies a scanned artist image file to an artist's
+// local_file source.
+func (s *LibraryService) setLocalArtistImage(ctx context.Context, artistID, imagePath string) (bool, error) {
+	_, changed, err := s.writeArtistArtworkSource(ctx, artistID, domain.ArtworkSourceLocalFile, loadImageFile(imagePath))
+	return changed, err
+}
+
+// SetArtistArtworkFromFile stores a user-chosen image as the artist's manual
+// artwork (always shown over local/online). Returns the artwork URL.
+func (s *LibraryService) SetArtistArtworkFromFile(ctx context.Context, artistID, imagePath string) (string, error) {
+	url, _, err := s.writeArtistArtworkSource(ctx, artistID, domain.ArtworkSourceManual, loadImageFile(imagePath))
+	return url, err
+}
+
+// RemoveArtistArtwork clears the user's custom (manual) artwork, reverting to the
+// local/online image per preference.
+func (s *LibraryService) RemoveArtistArtwork(ctx context.Context, artistID string) error {
+	return s.clearArtistArtworkSource(ctx, artistID, domain.ArtworkSourceManual)
+}
+
+// clearArtistArtworkSource removes one source's artwork and notifies the frontend.
+func (s *LibraryService) clearArtistArtworkSource(ctx context.Context, artistID, source string) error {
+	lock := s.artistLock(artistID)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if err := s.artistRepo.SetArtworkSource(ctx, artistID, source, nil); err != nil {
+		return err
+	}
+	s.emitArtistArtworkUpdated(artistID, source, "")
+	return nil
+}
+
+// emitArtistArtworkUpdated tells the frontend a single source's key changed (key
+// is "" when cleared). The frontend re-resolves which image to show.
+func (s *LibraryService) emitArtistArtworkUpdated(artistID, source, key string) {
+	if app := application.Get(); app != nil && app.Event != nil {
+		app.Event.Emit("artist-artwork-updated", map[string]string{
+			"artist_id": artistID,
+			"source":    source,
+			"key":       key,
+		})
+	}
+}
+
+// resolveTrackArtistImages looks for a local artist image around the given track
+// path and applies it to the track's artists. Called during import so newly-added
+// tracks pick up sibling/parent artist images.
+func (s *LibraryService) resolveTrackArtistImages(ctx context.Context, trackPath string, artistIDs []string) {
+	if len(artistIDs) == 0 {
+		return
+	}
+	imagePath := artistImageForTrack(trackPath)
+	if imagePath == "" {
+		return
+	}
+	for _, id := range artistIDs {
+		if _, err := s.setLocalArtistImage(ctx, id, imagePath); err != nil {
+			s.logger.Warn("Failed to apply local artist image", "artistID", id, "image", imagePath, "error", err)
+		}
+	}
+}
+
+// maybeRescanArtistImages runs a one-time local artist image scan when the app
+// has been upgraded past the version that last ran a full scan (or never ran
+// one). This lets existing libraries pick up artist.jpg/png files already on
+// disk after updating. It is not run on every launch — only when the stored
+// version is empty or older than the current build.
+func (s *LibraryService) maybeRescanArtistImages(ctx context.Context) {
+	settings, err := s.settingsRepo.Load(ctx)
+	if err != nil {
+		s.logger.Error("Failed to load settings for artist image rescan", "error", err)
+		return
+	}
+
+	needScan := false
+	if settings.LastScanVersion == "" {
+		needScan = true
+	} else {
+		current, errCur := semver.Parse(config.Version)
+		stored, errStored := semver.Parse(settings.LastScanVersion)
+		if errCur != nil || errStored != nil {
+			// Fail safe: if either version is unparseable, rescan once.
+			needScan = true
+		} else if current.GT(stored) {
+			needScan = true
+		}
+	}
+
+	if !needScan {
+		return
+	}
+
+	s.logger.Info("Running one-time artist image rescan after upgrade",
+		"from", settings.LastScanVersion, "to", config.Version)
+	if err := s.ScanArtistImages(ctx); err != nil {
+		s.logger.Error("Artist image rescan failed", "error", err)
+		return
+	}
+
+	settings.LastScanVersion = config.Version
+	if err := s.settingsRepo.Save(ctx, settings); err != nil {
+		s.logger.Error("Failed to persist last scan version", "error", err)
+	}
+}
+
+// ScanArtistImages walks the watched folders, collects every directory holding an
+// artist.{jpg,jpeg,png}, and applies them via the shared batch pass (matching by
+// folder name and by contained tracks). Used by the version-gated upgrade rescan.
+func (s *LibraryService) ScanArtistImages(ctx context.Context) error {
+	folders, err := s.watchedFolderRepo.GetAll(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list watched folders for image scan: %w", err)
+	}
+
+	imageDirs := make(map[string]bool)
+	for _, f := range folders {
+		_ = filepath.WalkDir(f.Path, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil || d.IsDir() {
+				return nil
+			}
+			if isArtistImageFile(filepath.Base(path)) {
+				imageDirs[filepath.Dir(path)] = true
+			}
+			return nil
+		})
+	}
+
+	s.logger.Info("Scanning local artist images", "imageDirs", len(imageDirs))
+	s.applyLocalArtistImagesForDirs(ctx, imageDirs)
+	return nil
+}

--- a/internal/app/library/service.go
+++ b/internal/app/library/service.go
@@ -11,10 +11,11 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
-	"airmedy/internal/domain"
 	"airmedy/internal/app/lyrics"
+	"airmedy/internal/domain"
 	"airmedy/internal/infra/artwork"
 
 	"github.com/fsnotify/fsnotify"
@@ -55,13 +56,17 @@ type LibraryService struct {
 	logger            *slog.Logger
 	watcher           *fsnotify.Watcher
 
-	trackUpdateListeners      []func(*domain.TrackDTO)
-	artistArtworkQueue        chan artistArtworkJob
-	pendingArtistArtwork      map[string]struct{}
-	pendingArtistArtworkMu    sync.Mutex
-	ctx                       context.Context
-	cancel                    context.CancelFunc
-	mu                        sync.RWMutex
+	trackUpdateListeners   []func(*domain.TrackDTO)
+	artistArtworkQueue     chan artistArtworkJob
+	pendingArtistArtwork   map[string]struct{}
+	pendingArtistArtworkMu sync.Mutex
+	artistArtworkLocks     sync.Map     // artistID -> *sync.Mutex; serializes artwork writes
+	syncing                atomic.Int32 // >0 while a bulk SyncFolder runs (gates per-track work)
+	artworkCleanupMu       sync.Mutex
+	artworkCleanupTimer    *time.Timer // debounces orphan-artwork cleanup after watcher deletes
+	ctx                    context.Context
+	cancel                 context.CancelFunc
+	mu                     sync.RWMutex
 }
 
 type artistArtworkJob struct {
@@ -150,12 +155,19 @@ func (s *LibraryService) Start(ctx context.Context) error {
 
 	go s.watchLoop()
 	go s.StartArtistArtworkWorker(s.ctx)
+	go s.maybeRescanArtistImages(s.ctx)
 	return nil
 }
 
 func (s *LibraryService) Stop(ctx context.Context) error {
 	s.cancel()
 	return s.watcher.Close()
+}
+
+// GetSettings exposes the persisted app settings (used by the Wails layer to
+// resolve artist artwork display preferences).
+func (s *LibraryService) GetSettings(ctx context.Context) (*domain.AppSettings, error) {
+	return s.settingsRepo.Load(ctx)
 }
 
 func (s *LibraryService) watchRecursive(root string) error {
@@ -192,6 +204,13 @@ func (s *LibraryService) watchLoop() {
 func (s *LibraryService) handleEvent(event fsnotify.Event) {
 	s.logger.Debug("Received watcher event", "event", event)
 
+	// Artist image files (artist.jpg/png) are handled separately from audio
+	// tracks — they update artist artwork rather than the track table.
+	if isArtistImageFile(filepath.Base(event.Name)) {
+		go s.handleArtistImageEvent(event)
+		return
+	}
+
 	if event.Has(fsnotify.Create) || event.Has(fsnotify.Write) {
 		// If it's a directory, watch it and sync it
 		// We need to check if it's a directory
@@ -199,7 +218,7 @@ func (s *LibraryService) handleEvent(event fsnotify.Event) {
 		// Use os.Stat or similar.
 		// Wait, ImportFile/SyncFolder handles it.
 		// But for Write, we want to debounce.
-		
+
 		// For simplicity, just import
 		go func() {
 			// Small delay to let file be written
@@ -256,6 +275,10 @@ func (s *LibraryService) handleEvent(event fsnotify.Event) {
 			}
 
 			s.cleanupOrphanedEntities(ctx)
+			// Artwork cache cleanup scans the whole cache dir, so it isn't run
+			// inline per event (would thrash on bulk deletes). Debounce it: bulk
+			// deletes coalesce into a single cleanup a few seconds later.
+			s.scheduleArtworkCleanup()
 
 			// Notify frontend: per-track for in-place views + generic for full reloads
 			if app := application.Get(); app != nil && app.Event != nil {
@@ -265,6 +288,51 @@ func (s *LibraryService) handleEvent(event fsnotify.Event) {
 				app.Event.Emit("library:updated", nil)
 			}
 		}()
+	}
+}
+
+// handleArtistImageEvent reacts to a local artist image file being created,
+// modified or removed while the app is running.
+func (s *LibraryService) handleArtistImageEvent(event fsnotify.Event) {
+	ctx := context.Background()
+	dir := filepath.Dir(event.Name)
+
+	if event.Has(fsnotify.Create) || event.Has(fsnotify.Write) {
+		// Give the file a moment to finish being written.
+		time.Sleep(500 * time.Millisecond)
+		if _, err := os.Stat(event.Name); err != nil {
+			return
+		}
+		for _, id := range s.artistIDsForImageDir(ctx, dir) {
+			if _, err := s.setLocalArtistImage(ctx, id, event.Name); err != nil {
+				s.logger.Warn("Failed to apply changed artist image", "artistID", id, "error", err)
+			}
+		}
+		return
+	}
+
+	if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
+		settings, err := s.settingsRepo.Load(ctx)
+		if err != nil {
+			s.logger.Warn("Failed to load settings for artist image removal", "error", err)
+			return
+		}
+		for _, id := range s.artistIDsForImageDir(ctx, dir) {
+			artist, err := s.artistRepo.GetByID(ctx, id)
+			if err != nil || artist == nil || artist.ArtworkKeyLocal == nil {
+				continue
+			}
+			// Clear only the local source; manual/online remain and the display
+			// re-resolves automatically.
+			if err := s.clearArtistArtworkSource(ctx, id, domain.ArtworkSourceLocalFile); err != nil {
+				s.logger.Warn("Failed to clear local artist artwork after image removal", "artistID", id, "error", err)
+				continue
+			}
+			// If nothing else is available and online is enabled, fetch from Deezer.
+			if settings.UseOnlineArtistArtwork && artist.ArtworkKeyManual == nil && artist.ArtworkKeyOnline == nil {
+				s.EnqueueArtistArtwork(id, fmt.Sprintf("artist-artwork:%s", id))
+			}
+		}
 	}
 }
 
@@ -394,6 +462,21 @@ func (s *LibraryService) RemoveWatchedFolder(ctx context.Context, id string, kee
 	return nil
 }
 
+// scheduleArtworkCleanup debounces orphan-artwork cleanup: each call resets a
+// short timer so a burst of watcher deletes triggers a single cache sweep.
+func (s *LibraryService) scheduleArtworkCleanup() {
+	s.artworkCleanupMu.Lock()
+	defer s.artworkCleanupMu.Unlock()
+	if s.artworkCleanupTimer != nil {
+		s.artworkCleanupTimer.Stop()
+	}
+	s.artworkCleanupTimer = time.AfterFunc(5*time.Second, func() {
+		if err := s.CleanupOrphanedArtworks(s.ctx); err != nil {
+			s.logger.Warn("Failed to cleanup orphaned artworks (debounced)", "error", err)
+		}
+	})
+}
+
 func (s *LibraryService) CleanupOrphanedArtworks(ctx context.Context) error {
 	keys, err := s.trackRepo.GetAllArtworkKeys(ctx)
 	if err != nil {
@@ -405,11 +488,26 @@ func (s *LibraryService) CleanupOrphanedArtworks(ctx context.Context) error {
 		activeKeys[k] = true
 	}
 
+	// Include artist artwork (all sources) so it isn't deleted while the artist
+	// exists — and so all of an artist's images are removed once it's orphaned.
+	artistKeys, err := s.artistRepo.GetAllArtworkKeys(ctx)
+	if err != nil {
+		return err
+	}
+	for _, k := range artistKeys {
+		activeKeys[k] = true
+	}
+
 	return s.artworkCache.CleanupOrphaned(ctx, activeKeys)
 }
 
 func (s *LibraryService) SyncFolder(ctx context.Context, root string) error {
 	s.logger.Info("Starting folder sync", "root", root)
+
+	// Mark a bulk sync in progress so per-file ImportFile skips its own artist
+	// image lookup — the batch pass below handles it far more cheaply.
+	s.syncing.Add(1)
+	defer s.syncing.Add(-1)
 
 	supportedExtensions := SupportedAudioExtensions
 
@@ -440,6 +538,7 @@ func (s *LibraryService) SyncFolder(ctx context.Context, root string) error {
 	// 2. Import files
 	var current int
 	foundPaths := make(map[string]bool)
+	imageDirs := make(map[string]bool) // directories containing an artist.{jpg,jpeg,png}
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			s.logger.Warn("Error walking path", "path", path, "error", err)
@@ -452,6 +551,11 @@ func (s *LibraryService) SyncFolder(ctx context.Context, root string) error {
 		}
 
 		if d.IsDir() {
+			return nil
+		}
+
+		if isArtistImageFile(filename) {
+			imageDirs[filepath.Dir(path)] = true
 			return nil
 		}
 
@@ -491,6 +595,9 @@ func (s *LibraryService) SyncFolder(ctx context.Context, root string) error {
 		return fmt.Errorf("failed to walk directory: %w", err)
 	}
 
+	// 2b. Apply local artist images in one batch (per image directory).
+	s.applyLocalArtistImagesForDirs(ctx, imageDirs)
+
 	// 3. Cleanup missing files
 	s.logger.Info("Cleaning up missing files", "root", root)
 	var deletedIDs []string
@@ -515,6 +622,9 @@ func (s *LibraryService) SyncFolder(ctx context.Context, root string) error {
 	// Always clear orphans: a track removed here (or by an earlier run/path) can
 	// leave an album/artist/genre/composer with no tracks.
 	s.cleanupOrphanedEntities(ctx)
+	if err := s.CleanupOrphanedArtworks(ctx); err != nil {
+		s.logger.Warn("Failed to cleanup orphaned artworks", "error", err)
+	}
 
 	s.logger.Info("Finished folder sync", "root", root)
 	if app := application.Get(); app != nil && app.Event != nil {
@@ -561,6 +671,21 @@ func (s *LibraryService) ImportFile(ctx context.Context, path string) error {
 	// Resolve related entities
 	if err := s.resolveEntities(ctx, dto); err != nil {
 		return fmt.Errorf("failed to resolve entities for %s: %w", path, err)
+	}
+
+	// Pick up a local artist image (artist.jpg/png) sitting next to the track or
+	// in the parent (artist) folder, for the track's artists and album artists.
+	// During a bulk sync this is skipped — SyncFolder's batch pass handles it
+	// once per directory instead of once per track.
+	if s.syncing.Load() == 0 {
+		var artistIDs []string
+		for _, a := range dto.Artists {
+			artistIDs = append(artistIDs, a.ID)
+		}
+		for _, a := range dto.AlbumArtists {
+			artistIDs = append(artistIDs, a.ID)
+		}
+		s.resolveTrackArtistImages(ctx, path, artistIDs)
 	}
 
 	// Extract lyrics from metadata
@@ -740,7 +865,6 @@ func (s *LibraryService) resolveEntities(ctx context.Context, dto *domain.TrackD
 	if err := s.trackRepo.SetComposers(ctx, dto.ID, composerIDs); err != nil {
 		return err
 	}
-
 
 	return nil
 }

--- a/internal/app/library/service_test.go
+++ b/internal/app/library/service_test.go
@@ -95,6 +95,9 @@ func (m *mockArtistRepo) GetByNormalizationKey(ctx context.Context, key string) 
 	return nil, nil
 }
 func (m *mockArtistRepo) GetAll(ctx context.Context) ([]*domain.Artist, error) { return nil, nil }
+func (m *mockArtistRepo) GetAllArtworkKeys(ctx context.Context) ([]string, error) {
+	return nil, nil
+}
 
 type mockGenreRepo struct{ domain.GenreRepository }
 

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -65,15 +65,67 @@ type AlbumDTO struct {
 	Artists []*Artist `json:"artists,omitempty"`
 }
 
+// Artist artwork sources. Each is stored independently; the one shown is chosen
+// at read time by ResolveArtworkKey (manual outranks the local/online pair).
+const (
+	ArtworkSourceOnline    = "online"     // fetched automatically from Deezer
+	ArtworkSourceLocalFile = "local_file" // scanned artist.jpg/png from disk
+	ArtworkSourceManual    = "manual"     // set explicitly by the user
+)
+
 // Artist represents a music artist
 type Artist struct {
-	ID               string    `json:"id" db:"id"`
-	Name             string    `json:"name" db:"name"`
-	SortName         string    `json:"sort_name" db:"sort_name"`
-	NormalizationKey string    `json:"normalization_key" db:"normalization_key"`
-	ArtworkKey       *string   `json:"artwork_key" db:"artwork_key"`
-	CreatedAt        time.Time `json:"created_at" db:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at" db:"updated_at"`
+	ID               string  `json:"id" db:"id"`
+	Name             string  `json:"name" db:"name"`
+	SortName         string  `json:"sort_name" db:"sort_name"`
+	NormalizationKey string  `json:"normalization_key" db:"normalization_key"`
+	ArtworkKeyManual *string `json:"artwork_key_manual" db:"artwork_key_manual"`
+	ArtworkKeyLocal  *string `json:"artwork_key_local" db:"artwork_key_local"`
+	ArtworkKeyOnline *string `json:"artwork_key_online" db:"artwork_key_online"`
+	// ArtworkKey is the resolved key to display, computed at read time (not stored).
+	ArtworkKey string    `json:"artwork_key" db:"-"`
+	CreatedAt  time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at" db:"updated_at"`
+}
+
+// ResolveArtworkKey picks which stored artwork to show. Manual always wins; the
+// local/online order follows the user's preference. An existing online image is
+// shown regardless of whether online fetching is currently enabled.
+func (a *Artist) ResolveArtworkKey(preferLocal bool) string {
+	if a.ArtworkKeyManual != nil && *a.ArtworkKeyManual != "" {
+		return *a.ArtworkKeyManual
+	}
+	local, online := "", ""
+	if a.ArtworkKeyLocal != nil {
+		local = *a.ArtworkKeyLocal
+	}
+	if a.ArtworkKeyOnline != nil {
+		online = *a.ArtworkKeyOnline
+	}
+	if preferLocal {
+		if local != "" {
+			return local
+		}
+		return online
+	}
+	if online != "" {
+		return online
+	}
+	return local
+}
+
+// ArtworkKeyForSource returns the stored key for a given source ("" if unset).
+func (a *Artist) ArtworkKeyForSource(source string) *string {
+	switch source {
+	case ArtworkSourceManual:
+		return a.ArtworkKeyManual
+	case ArtworkSourceLocalFile:
+		return a.ArtworkKeyLocal
+	case ArtworkSourceOnline:
+		return a.ArtworkKeyOnline
+	default:
+		return nil
+	}
 }
 
 // Genre represents a music genre
@@ -139,14 +191,14 @@ type WatchedFolder struct {
 
 // PlayerState holds the playback state to persist across app restarts
 type PlayerState struct {
-	QueueTrackIDs         []string   `json:"queue_track_ids"`
-	OriginalTrackIDs      []string   `json:"original_track_ids"`
-	CurrentTrackID        string     `json:"current_track_id"`
-	Position              float64    `json:"position"`
-	Volume                float64    `json:"volume"`
-	Muted                 bool       `json:"muted"`
-	Shuffle               bool       `json:"shuffle"`
-	RepeatMode            RepeatMode `json:"repeat_mode"`
+	QueueTrackIDs    []string   `json:"queue_track_ids"`
+	OriginalTrackIDs []string   `json:"original_track_ids"`
+	CurrentTrackID   string     `json:"current_track_id"`
+	Position         float64    `json:"position"`
+	Volume           float64    `json:"volume"`
+	Muted            bool       `json:"muted"`
+	Shuffle          bool       `json:"shuffle"`
+	RepeatMode       RepeatMode `json:"repeat_mode"`
 }
 
 // AppSettings holds general application settings
@@ -162,6 +214,7 @@ type AppSettings struct {
 	EnableKugou              bool   `json:"enable_kugou"`
 	PreferLocalLyrics        bool   `json:"prefer_local_lyrics"`
 	UseOnlineArtistArtwork   bool   `json:"use_online_artist_artwork"`
+	LastScanVersion          string `json:"last_scan_version"`
 	PreventSleepWhilePlaying bool   `json:"prevent_sleep_while_playing"`
 	RemoteServerEnabled      bool   `json:"remote_server_enabled"`
 	RemoteServerPort         int    `json:"remote_server_port"`

--- a/internal/domain/repositories.go
+++ b/internal/domain/repositories.go
@@ -54,6 +54,12 @@ type ArtistRepository interface {
 	GetAll(ctx context.Context) ([]*Artist, error)
 	Save(ctx context.Context, artist *Artist) error
 	Upsert(ctx context.Context, artist *Artist) error
+	// SetArtworkSource sets the cache key for a single artwork source. A nil key
+	// clears that source only; other sources are left untouched.
+	SetArtworkSource(ctx context.Context, id string, source string, key *string) error
+	// GetAllArtworkKeys returns every non-empty artwork key across all sources,
+	// used to keep live artist images out of the orphan-cleanup set.
+	GetAllArtworkKeys(ctx context.Context) ([]string, error)
 	DeleteOrphaned(ctx context.Context) error
 }
 

--- a/internal/infra/sqlite/artist_repository.go
+++ b/internal/infra/sqlite/artist_repository.go
@@ -59,9 +59,9 @@ func (r *artistRepository) Save(ctx context.Context, artist *domain.Artist) erro
 
 	query := `
 		INSERT INTO artists (
-			id, name, sort_name, normalization_key, artwork_key, created_at, updated_at
+			id, name, sort_name, normalization_key, created_at, updated_at
 		) VALUES (
-			:id, :name, :sort_name, :normalization_key, :artwork_key, :created_at, :updated_at
+			:id, :name, :sort_name, :normalization_key, :created_at, :updated_at
 		)`
 
 	_, err := r.db.NamedExecContext(ctx, query, artist)
@@ -78,25 +78,75 @@ func (r *artistRepository) Upsert(ctx context.Context, artist *domain.Artist) er
 	}
 	artist.UpdatedAt = now
 
+	// Artwork columns are intentionally not touched here — they are managed
+	// separately via SetArtworkSource so a metadata re-import never clobbers them.
 	query := `
 		INSERT INTO artists (
-			id, name, sort_name, normalization_key, artwork_key, created_at, updated_at
+			id, name, sort_name, normalization_key, created_at, updated_at
 		) VALUES (
-			:id, :name, :sort_name, :normalization_key, :artwork_key, :created_at, :updated_at
+			:id, :name, :sort_name, :normalization_key, :created_at, :updated_at
 		) ON CONFLICT(id) DO UPDATE SET
 			name = excluded.name,
 			sort_name = excluded.sort_name,
 			normalization_key = excluded.normalization_key,
-			artwork_key = CASE 
-				WHEN excluded.artwork_key IS NOT NULL THEN excluded.artwork_key 
-				ELSE artists.artwork_key 
-			END,
 			updated_at = excluded.updated_at
 	`
 
 	_, err := r.db.NamedExecContext(ctx, query, artist)
 	if err != nil {
 		return fmt.Errorf("failed to upsert artist: %w", err)
+	}
+	return nil
+}
+
+// artworkColumnForSource maps an artwork source to its DB column.
+func artworkColumnForSource(source string) string {
+	switch source {
+	case domain.ArtworkSourceManual:
+		return "artwork_key_manual"
+	case domain.ArtworkSourceLocalFile:
+		return "artwork_key_local"
+	case domain.ArtworkSourceOnline:
+		return "artwork_key_online"
+	default:
+		return ""
+	}
+}
+
+func (r *artistRepository) SetArtworkSource(ctx context.Context, id string, source string, key *string) error {
+	col := artworkColumnForSource(source)
+	if col == "" {
+		return fmt.Errorf("unknown artwork source: %q", source)
+	}
+	query := fmt.Sprintf("UPDATE artists SET %s = ?, updated_at = ? WHERE id = ?", col)
+	if _, err := r.db.ExecContext(ctx, query, key, time.Now(), id); err != nil {
+		return fmt.Errorf("failed to set artist artwork (%s): %w", source, err)
+	}
+	return nil
+}
+
+func (r *artistRepository) GetAllArtworkKeys(ctx context.Context) ([]string, error) {
+	var keys []string
+	err := r.db.SelectContext(ctx, &keys, `
+		SELECT artwork_key_manual FROM artists WHERE artwork_key_manual IS NOT NULL AND artwork_key_manual != ''
+		UNION
+		SELECT artwork_key_local FROM artists WHERE artwork_key_local IS NOT NULL AND artwork_key_local != ''
+		UNION
+		SELECT artwork_key_online FROM artists WHERE artwork_key_online IS NOT NULL AND artwork_key_online != ''
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get all artist artwork keys: %w", err)
+	}
+	return keys, nil
+}
+
+func (r *artistRepository) SetArtwork(ctx context.Context, id string, key *string, source string) error {
+	_, err := r.db.ExecContext(ctx,
+		"UPDATE artists SET artwork_key = ?, artwork_source = ?, updated_at = ? WHERE id = ?",
+		key, source, time.Now(), id,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to set artist artwork: %w", err)
 	}
 	return nil
 }

--- a/internal/infra/sqlite/migrations/000023_artist_artwork_source.down.sql
+++ b/internal/infra/sqlite/migrations/000023_artist_artwork_source.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE artists DROP COLUMN artwork_source;

--- a/internal/infra/sqlite/migrations/000023_artist_artwork_source.up.sql
+++ b/internal/infra/sqlite/migrations/000023_artist_artwork_source.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE artists ADD COLUMN artwork_source TEXT NOT NULL DEFAULT '';

--- a/internal/infra/sqlite/migrations/000024_app_settings_artist_artwork.down.sql
+++ b/internal/infra/sqlite/migrations/000024_app_settings_artist_artwork.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE app_settings DROP COLUMN prefer_local_artist_artwork;
+ALTER TABLE app_settings DROP COLUMN last_scan_version;

--- a/internal/infra/sqlite/migrations/000024_app_settings_artist_artwork.up.sql
+++ b/internal/infra/sqlite/migrations/000024_app_settings_artist_artwork.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE app_settings ADD COLUMN prefer_local_artist_artwork BOOLEAN NOT NULL DEFAULT 1;
+ALTER TABLE app_settings ADD COLUMN last_scan_version TEXT NOT NULL DEFAULT '';

--- a/internal/infra/sqlite/migrations/000025_artist_artwork_multi_source.down.sql
+++ b/internal/infra/sqlite/migrations/000025_artist_artwork_multi_source.down.sql
@@ -1,0 +1,10 @@
+ALTER TABLE artists ADD COLUMN artwork_key TEXT;
+ALTER TABLE artists ADD COLUMN artwork_source TEXT NOT NULL DEFAULT '';
+
+UPDATE artists SET artwork_key = artwork_key_manual, artwork_source = 'manual' WHERE artwork_key_manual IS NOT NULL;
+UPDATE artists SET artwork_key = artwork_key_local, artwork_source = 'local_file' WHERE artwork_key IS NULL AND artwork_key_local IS NOT NULL;
+UPDATE artists SET artwork_key = artwork_key_online, artwork_source = 'online' WHERE artwork_key IS NULL AND artwork_key_online IS NOT NULL;
+
+ALTER TABLE artists DROP COLUMN artwork_key_manual;
+ALTER TABLE artists DROP COLUMN artwork_key_local;
+ALTER TABLE artists DROP COLUMN artwork_key_online;

--- a/internal/infra/sqlite/migrations/000025_artist_artwork_multi_source.up.sql
+++ b/internal/infra/sqlite/migrations/000025_artist_artwork_multi_source.up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE artists ADD COLUMN artwork_key_manual TEXT;
+ALTER TABLE artists ADD COLUMN artwork_key_local TEXT;
+ALTER TABLE artists ADD COLUMN artwork_key_online TEXT;
+
+UPDATE artists SET artwork_key_manual = artwork_key WHERE artwork_source = 'manual' AND artwork_key IS NOT NULL;
+UPDATE artists SET artwork_key_local = artwork_key WHERE artwork_source = 'local_file' AND artwork_key IS NOT NULL;
+UPDATE artists SET artwork_key_online = artwork_key WHERE artwork_source = 'online' AND artwork_key IS NOT NULL;
+
+ALTER TABLE artists DROP COLUMN artwork_key;
+ALTER TABLE artists DROP COLUMN artwork_source;

--- a/internal/infra/sqlite/migrations/000026_drop_prefer_local_artist_artwork.down.sql
+++ b/internal/infra/sqlite/migrations/000026_drop_prefer_local_artist_artwork.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE app_settings ADD COLUMN prefer_local_artist_artwork BOOLEAN NOT NULL DEFAULT 1;

--- a/internal/infra/sqlite/migrations/000026_drop_prefer_local_artist_artwork.up.sql
+++ b/internal/infra/sqlite/migrations/000026_drop_prefer_local_artist_artwork.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE app_settings DROP COLUMN prefer_local_artist_artwork;

--- a/internal/infra/sqlite/settings_repository.go
+++ b/internal/infra/sqlite/settings_repository.go
@@ -18,8 +18,8 @@ func NewSettingsRepository(db *DB) domain.SettingsRepository {
 
 func (r *settingsRepository) Save(ctx context.Context, settings *domain.AppSettings) error {
 	_, err := r.db.ExecContext(ctx,
-		`INSERT INTO app_settings (id, language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, enable_lrclib, enable_kugou, prefer_local_lyrics, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator, updated_at)
-		 VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		`INSERT INTO app_settings (id, language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, last_scan_version, enable_lrclib, enable_kugou, prefer_local_lyrics, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator, updated_at)
+		 VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		 ON CONFLICT(id) DO UPDATE SET
 		   language = excluded.language,
 		   theme = excluded.theme,
@@ -29,6 +29,7 @@ func (r *settingsRepository) Save(ctx context.Context, settings *domain.AppSetti
 		   show_tray_icon = excluded.show_tray_icon,
 		   eq_enabled = excluded.eq_enabled,
 		   use_online_artist_artwork = excluded.use_online_artist_artwork,
+		   last_scan_version = excluded.last_scan_version,
 		   enable_lrclib = excluded.enable_lrclib,
 		   enable_kugou = excluded.enable_kugou,
 		   prefer_local_lyrics = excluded.prefer_local_lyrics,
@@ -46,6 +47,7 @@ func (r *settingsRepository) Save(ctx context.Context, settings *domain.AppSetti
 		settings.ShowTrayIcon,
 		settings.EQEnabled,
 		settings.UseOnlineArtistArtwork,
+		settings.LastScanVersion,
 		settings.EnableLrclib,
 		settings.EnableKugou,
 		settings.PreferLocalLyrics,
@@ -71,6 +73,7 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 		ShowTrayIcon             bool           `db:"show_tray_icon"`
 		EQEnabled                bool           `db:"eq_enabled"`
 		UseOnlineArtistArtwork   bool           `db:"use_online_artist_artwork"`
+		LastScanVersion          string         `db:"last_scan_version"`
 		EnableLrclib             bool           `db:"enable_lrclib"`
 		EnableKugou              bool           `db:"enable_kugou"`
 		PreferLocalLyrics        bool           `db:"prefer_local_lyrics"`
@@ -81,7 +84,7 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 		ShowPlayerIndicator      bool           `db:"show_player_indicator"`
 	}
 	err := r.db.GetContext(ctx, &row,
-		`SELECT language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, enable_lrclib, enable_kugou, prefer_local_lyrics, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator FROM app_settings WHERE id = 1`,
+		`SELECT language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, last_scan_version, enable_lrclib, enable_kugou, prefer_local_lyrics, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator FROM app_settings WHERE id = 1`,
 	)
 	if err == sql.ErrNoRows {
 		return &domain.AppSettings{
@@ -115,6 +118,7 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 		EnableKugou:              row.EnableKugou,
 		PreferLocalLyrics:        row.PreferLocalLyrics,
 		UseOnlineArtistArtwork:   row.UseOnlineArtistArtwork,
+		LastScanVersion:          row.LastScanVersion,
 		PreventSleepWhilePlaying: row.PreventSleepWhilePlaying,
 		RemoteServerEnabled:      row.RemoteServerEnabled,
 		RemoteServerPort:         row.RemoteServerPort,

--- a/internal/infra/wails/library_service.go
+++ b/internal/infra/wails/library_service.go
@@ -73,7 +73,7 @@ func (s *LibraryService) DownloadArtwork(artworkKey, defaultName string) error {
 
 	dest, err := app.Dialog.SaveFile().
 		SetMessage("Save Artwork").
-		SetFilename(name + ext).
+		SetFilename(name+ext).
 		AddFilter("Image", "*"+ext).
 		PromptForSingleSelection()
 	if err != nil {
@@ -211,11 +211,37 @@ func (s *LibraryService) GetAlbumsByArtistID(artistID string) ([]*domain.AlbumDT
 }
 
 func (s *LibraryService) GetAllArtists() ([]*domain.Artist, error) {
-	return s.artistRepo.GetAll(context.Background())
+	ctx := context.Background()
+	artists, err := s.artistRepo.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	preferLocal := s.preferLocalArtistArtwork(ctx)
+	for _, a := range artists {
+		a.ArtworkKey = a.ResolveArtworkKey(preferLocal)
+	}
+	return artists, nil
 }
 
 func (s *LibraryService) GetArtistByID(id string) (*domain.Artist, error) {
-	return s.artistRepo.GetByID(context.Background(), id)
+	ctx := context.Background()
+	artist, err := s.artistRepo.GetByID(ctx, id)
+	if err != nil || artist == nil {
+		return artist, err
+	}
+	artist.ArtworkKey = artist.ResolveArtworkKey(s.preferLocalArtistArtwork(ctx))
+	return artist, nil
+}
+
+// preferLocalArtistArtwork reports whether local images should be preferred over
+// the Deezer image. There is a single user toggle, "Online Artist Artwork":
+// when off (or settings unreadable) local images win.
+func (s *LibraryService) preferLocalArtistArtwork(ctx context.Context) bool {
+	settings, err := s.libService.GetSettings(ctx)
+	if err != nil || settings == nil {
+		return true
+	}
+	return !settings.UseOnlineArtistArtwork
 }
 
 func (s *LibraryService) GetAllGenres() ([]*domain.Genre, error) {
@@ -260,7 +286,8 @@ func (s *LibraryService) GetAlbumColors(id string) (*domain.ThemeColors, error) 
 }
 
 func (s *LibraryService) GetArtistArtwork(artistID, eventID string) (*string, error) {
-	artist, err := s.artistRepo.GetByID(context.Background(), artistID)
+	ctx := context.Background()
+	artist, err := s.artistRepo.GetByID(ctx, artistID)
 	if err != nil {
 		return nil, err
 	}
@@ -268,12 +295,47 @@ func (s *LibraryService) GetArtistArtwork(artistID, eventID string) (*string, er
 		return nil, fmt.Errorf("artist not found")
 	}
 
-	if artist.ArtworkKey != nil && *artist.ArtworkKey != "" {
-		url := fmt.Sprintf("/artwork/%s", *artist.ArtworkKey)
-		return &url, nil
+	settings, _ := s.libService.GetSettings(ctx)
+	useOnline := settings != nil && settings.UseOnlineArtistArtwork
+	preferLocal := !useOnline
+
+	// When online is enabled and no Deezer image is cached yet, fetch it (even if a
+	// local image exists, so it's ready and shown per preference).
+	if useOnline && artist.ArtworkKeyOnline == nil {
+		s.libService.EnqueueArtistArtwork(artistID, eventID)
 	}
 
-	// Not cached, enqueue
-	s.libService.EnqueueArtistArtwork(artistID, eventID)
+	if key := artist.ResolveArtworkKey(preferLocal); key != "" {
+		url := fmt.Sprintf("/artwork/%s", key)
+		return &url, nil
+	}
 	return nil, nil
+}
+
+// SelectAndSetArtistArtwork prompts the user to pick an image file and sets it
+// as the artist's custom (manual) artwork. Returns the new artwork URL, or ""
+// if the dialog was cancelled.
+func (s *LibraryService) SelectAndSetArtistArtwork(artistID string) (string, error) {
+	app := application.Get()
+	if app == nil {
+		return "", fmt.Errorf("application not initialized")
+	}
+
+	result, err := app.Dialog.OpenFile().
+		SetTitle("Select Artist Image").
+		AddFilter("Images", "*.jpg;*.jpeg;*.png").
+		PromptForSingleSelection()
+	if err != nil {
+		return "", err
+	}
+	if result == "" {
+		return "", nil
+	}
+
+	return s.libService.SetArtistArtworkFromFile(context.Background(), artistID, result)
+}
+
+// RemoveArtistArtwork clears the artist's custom artwork.
+func (s *LibraryService) RemoveArtistArtwork(artistID string) error {
+	return s.libService.RemoveArtistArtwork(context.Background(), artistID)
 }


### PR DESCRIPTION
## Summary
Adds local artist image support alongside the existing Deezer fetch, with all artwork sources stored per artist and the displayed one chosen at read time.

## What changed
- **Local image scan** — finds `artist.jpg/jpeg/png` (priority `jpg > jpeg > png`) in music folders, matched two ways: by folder name (an artist-named folder, even with no tracks of its own) and by tracks contained in the directory/subfolders. Batch pass during sync; live add/change/remove via the file watcher.
- **Multi-source artwork** — each artist keeps `manual`, `local_file` and `online` keys independently. `ResolveArtworkKey` decides what to show: `manual` always wins, otherwise the single **Online Artist Artwork** toggle sets the order (on → Deezer first, off → local first). Toggling switches the shown image instantly (client-side resolution).
- **Online toggle semantics** — when off, no new Deezer fetches, but already-downloaded images are kept (not deleted) and still shown if no local exists.
- **Custom image** — set / remove a per-artist image from the artist detail page (hover overlay → context menu).
- **Upgrade rescan** — one-time, version-gated (`last_scan_version` vs `config.Version`) so existing libraries pick up on-disk images after updating.
- **Correctness/perf** — per-artist write lock guards races between scan, watcher and the Deezer worker; orphaned artist images are pruned from the cache on sync, on folder removal, and debounced after watcher deletes (no per-event full cache scan).

## Schema
Migrations `000023`–`000026` (add `artwork_source`/settings, split into per-source key columns, drop the interim `prefer_local_artist_artwork`).

## i18n / docs
New keys across all locales; catalog (`artwork`, `database`, `settings`, `library`) and README updated.

## Test
`go build ./...`, `go test ./internal/app/library/... ./internal/infra/sqlite/... ./internal/domain/...`, and `vue-tsc --noEmit` all pass. (`player` package test fails only due to a missing SFBAudioEngine framework locally — unrelated.)