### PR TITLE
feat(lyrics): dedicated lyrics folder + per-track subfolder

### DIFF
--- a/catalog/database/README.md
+++ b/catalog/database/README.md
@@ -46,7 +46,7 @@ SQLite database managed via `golang-migrate` for schema versioning and `sqlx` fo
 | 000024 | `app_settings_artist_artwork.up.sql` | Add `prefer_local_artist_artwork BOOLEAN NOT NULL DEFAULT 1` and `last_scan_version TEXT NOT NULL DEFAULT ''` to `app_settings`     |
 | 000026 | `drop_prefer_local_artist_artwork.up.sql` | Drop `prefer_local_artist_artwork` — replaced by deriving from `use_online_artist_artwork` |
 | 000025 | `artist_artwork_multi_source.up.sql` | Replace `artwork_key`/`artwork_source` with per-source `artwork_key_manual`/`_local`/`_online` (backfilled), then drop the old two |
-| 000027 | `lyrics_folder.up.sql`               | Add `lyrics_folder_enabled BOOLEAN NOT NULL DEFAULT FALSE` and `lyrics_folder_path TEXT NOT NULL DEFAULT ''` to `app_settings` |
+| 000027 | `lyrics_folder.up.sql`               | Add `lyrics_folder_enabled`, `lyrics_folder_path`, `lyrics_subfolder_enabled`, `lyrics_subfolder_name` to `app_settings` (dedicated folder + per-track subfolder lyrics lookup) |
 
 ## Full Schema
 
@@ -192,6 +192,8 @@ app_settings (
     prefer_local_lyrics BOOLEAN NOT NULL DEFAULT 1, -- renamed from prefer_metadata_lyrics (000022)
     lyrics_folder_enabled BOOLEAN NOT NULL DEFAULT 0,
     lyrics_folder_path TEXT NOT NULL DEFAULT '',
+    lyrics_subfolder_enabled BOOLEAN NOT NULL DEFAULT 0,
+    lyrics_subfolder_name TEXT NOT NULL DEFAULT '',
     updated_at DATETIME
     -- (also: prevent_sleep_while_playing, remote_server_*, show_player_indicator)
 )

--- a/catalog/database/README.md
+++ b/catalog/database/README.md
@@ -46,6 +46,7 @@ SQLite database managed via `golang-migrate` for schema versioning and `sqlx` fo
 | 000024 | `app_settings_artist_artwork.up.sql` | Add `prefer_local_artist_artwork BOOLEAN NOT NULL DEFAULT 1` and `last_scan_version TEXT NOT NULL DEFAULT ''` to `app_settings`     |
 | 000026 | `drop_prefer_local_artist_artwork.up.sql` | Drop `prefer_local_artist_artwork` — replaced by deriving from `use_online_artist_artwork` |
 | 000025 | `artist_artwork_multi_source.up.sql` | Replace `artwork_key`/`artwork_source` with per-source `artwork_key_manual`/`_local`/`_online` (backfilled), then drop the old two |
+| 000027 | `lyrics_folder.up.sql`               | Add `lyrics_folder_enabled BOOLEAN NOT NULL DEFAULT FALSE` and `lyrics_folder_path TEXT NOT NULL DEFAULT ''` to `app_settings` |
 
 ## Full Schema
 
@@ -188,8 +189,11 @@ app_settings (
     last_scan_version TEXT NOT NULL DEFAULT '',
     enable_lrclib BOOLEAN NOT NULL DEFAULT 1,
     enable_kugou BOOLEAN NOT NULL DEFAULT 1,
-    prefer_metadata_lyrics BOOLEAN NOT NULL DEFAULT 1,
+    prefer_local_lyrics BOOLEAN NOT NULL DEFAULT 1, -- renamed from prefer_metadata_lyrics (000022)
+    lyrics_folder_enabled BOOLEAN NOT NULL DEFAULT 0,
+    lyrics_folder_path TEXT NOT NULL DEFAULT '',
     updated_at DATETIME
+    -- (also: prevent_sleep_while_playing, remote_server_*, show_player_indicator)
 )
 ```
 

--- a/catalog/lyrics/README.md
+++ b/catalog/lyrics/README.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Fetches and displays synchronized (LRC) or plain-text lyrics for the current track. Lyrics are sourced from **sibling local files** (`.lrc` / `.txt` next to the audio file, read live at play time), an optional **dedicated lyrics folder** (a single user-chosen folder searched by track basename, gated by `lyrics_folder_enabled`), embedded **file metadata** (`LYRICS` tag, read at scan time), and the external providers **lrclib.net** and **KuGou Music** (cached in SQLite). The frontend parses LRC timestamps and auto-scrolls to the current line.
+Fetches and displays synchronized (LRC) or plain-text lyrics for the current track. Lyrics are sourced from **sibling local files** (`.lrc` / `.txt` next to the audio file, read live at play time), an optional **subfolder next to the track** (gated by `lyrics_subfolder_enabled` + `lyrics_subfolder_name`, e.g. `<album>/lyrics/Song.lrc`), an optional **dedicated lyrics folder** (a single user-chosen folder searched by track basename, gated by `lyrics_folder_enabled`), embedded **file metadata** (`LYRICS` tag, read at scan time), and the external providers **lrclib.net** and **KuGou Music** (cached in SQLite). The frontend parses LRC timestamps and auto-scrolls to the current line.
 
 ## Files
 
@@ -37,14 +37,21 @@ type Lyric struct {
 `LyricsService.ResolveLyrics(ctx, trackID, audioPath, preferLocal bool, extraLyricsDir string)` picks the best lyric.
 
 The **local tier** is built first: a local lyric file (read live by `LocalLyricsReader`, `.lrc`
-preferred over `.txt`) — checked in the **sibling dir** of `audioPath` first, then in `extraLyricsDir`
-(the dedicated lyrics folder, when set) — if present, otherwise the embedded metadata tag
-(`MetaContent`, cached in DB at scan time). So within the local tier: **sibling file beats dedicated-folder
+preferred over `.txt`) — checked in the **sibling dir** of `audioPath` first, then each dir in
+`extraDirs` in order — if present, otherwise the embedded metadata tag (`MetaContent`, cached in DB
+at scan time). So within the local tier: **sibling file beats subfolder file beats dedicated-folder
 file beats tag**.
 
-`extraLyricsDir` is supplied by `PlayerService.fetchAndEmitLyrics`: it equals `lyrics_folder_path`
-when `lyrics_folder_enabled` is true, otherwise `""` (disabled → sibling-only behavior).
-`HasLocalLyrics(ctx, trackID, audioPath, extraLyricsDir)` takes the same extra dir.
+`extraDirs` is built (in priority order) by `PlayerService.fetchAndEmitLyrics`:
+1. `resolveLyricsSubdir(filepath.Dir(track.Path), lyrics_subfolder_name)` — when `lyrics_subfolder_enabled`
+   and the name passes `validLyricsSubfolderName` (single segment, no separators or `..`).
+   `resolveLyricsSubdir` matches the subfolder **case-insensitively** (exact `os.Stat` first, then a
+   case-insensitive `os.ReadDir` scan of the track dir), so a name like `lyrics` finds a `Lyrics/`
+   folder on case-sensitive filesystems (Linux) the same way macOS/Windows already would.
+2. `lyrics_folder_path` — when `lyrics_folder_enabled` and non-empty.
+
+Both `ResolveLyrics(ctx, trackID, audioPath, preferLocal, extraDirs...)` and
+`HasLocalLyrics(ctx, trackID, audioPath, extraDirs...)` take the same variadic extra dirs.
 
 `preferLocal` then decides local tier vs external provider content:
 
@@ -52,13 +59,14 @@ when `lyrics_folder_enabled` is true, otherwise `""` (disabled → sibling-only 
 | --- | --- |
 | `prefer_local_lyrics=true` | (Default) Use the local tier if available, otherwise fall back to `Content` (external provider). |
 | `prefer_local_lyrics=false` | Use `Content` (external provider) if available, otherwise fall back to the local tier. |
-| `lyrics_folder_enabled=true` | Also search `lyrics_folder_path` (flat, by basename) for `.lrc`/`.txt`, after the sibling dir. Default off. |
+| `lyrics_subfolder_enabled=true` | Also search `<track dir>/<lyrics_subfolder_name>` (flat, by basename) for `.lrc`/`.txt`, after the sibling dir. Name validated as a single safe path segment. Default off. |
+| `lyrics_folder_enabled=true` | Also search `lyrics_folder_path` (flat, by basename) for `.lrc`/`.txt`, after the subfolder. Default off. |
 | `enable_lrclib=false` | lrclib.net provider disabled; not queried on fetch. |
 | `enable_kugou=false` | KuGou provider disabled; not queried on fetch. |
 
 **Full priority (default `prefer_local_lyrics=true`):**
-`Sibling .lrc` → `Sibling .txt` → `Folder .lrc` → `Folder .txt` (when `lyrics_folder_enabled`) →
-`Metadata tag` → `LRClib / KuGou`.
+`Sibling .lrc` → `Sibling .txt` → `Subfolder .lrc` → `Subfolder .txt` (when `lyrics_subfolder_enabled`) →
+`Folder .lrc` → `Folder .txt` (when `lyrics_folder_enabled`) → `Metadata tag` → `LRClib / KuGou`.
 
 The setting was renamed from `prefer_metadata_lyrics` (migration `000022_prefer_local_lyrics`,
 `RENAME COLUMN` preserves the existing value).
@@ -69,10 +77,13 @@ If both `enable_lrclib` and `enable_kugou` are false, no external fetch is attem
 
 - Filename must match the audio file's basename exactly, differing only in extension
   (`/music/Song.mp3` → `/music/Song.lrc` or `/music/Song.txt`).
-- Searched in the audio file's **sibling dir** first, then the **dedicated lyrics folder**
-  (`extraLyricsDir`) if enabled. Both use the same basename match; the dedicated folder is a flat
-  lookup (no recursion). Sibling dir always wins. An empty extra dir, or one equal to the sibling dir,
-  is skipped (`internal/infra/lyrics/local.go`).
+- Searched in the audio file's **sibling dir** first, then each `extraDirs` entry in order:
+  the **subfolder next to the track** (`<track dir>/<lyrics_subfolder_name>`), then the
+  **dedicated lyrics folder**. All use the same basename match and are flat lookups (no recursion).
+  Sibling dir always wins. An empty extra dir, or one equal to the sibling dir, is skipped
+  (`internal/infra/lyrics/local.go`). The subfolder name is validated by `validLyricsSubfolderName`
+  in `player_service.go` so it cannot escape the track directory, and resolved **case-insensitively**
+  by `resolveLyricsSubdir` (so `lyrics` matches a `Lyrics/` folder on case-sensitive filesystems).
 - Read **live at play time** in `PlayerService.fetchAndEmitLyrics` — not cached and not watched, so
   newly added/edited files are picked up on the next play. No rescan needed.
 - Paths joined with `filepath.Join` → cross-platform (Unix `/`, Windows `\`).

--- a/catalog/lyrics/README.md
+++ b/catalog/lyrics/README.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Fetches and displays synchronized (LRC) or plain-text lyrics for the current track. Lyrics are sourced from **sibling local files** (`.lrc` / `.txt` next to the audio file, read live at play time), embedded **file metadata** (`LYRICS` tag, read at scan time), and the external providers **lrclib.net** and **KuGou Music** (cached in SQLite). The frontend parses LRC timestamps and auto-scrolls to the current line.
+Fetches and displays synchronized (LRC) or plain-text lyrics for the current track. Lyrics are sourced from **sibling local files** (`.lrc` / `.txt` next to the audio file, read live at play time), an optional **dedicated lyrics folder** (a single user-chosen folder searched by track basename, gated by `lyrics_folder_enabled`), embedded **file metadata** (`LYRICS` tag, read at scan time), and the external providers **lrclib.net** and **KuGou Music** (cached in SQLite). The frontend parses LRC timestamps and auto-scrolls to the current line.
 
 ## Files
 
@@ -34,11 +34,17 @@ type Lyric struct {
 
 ## Resolution Strategy
 
-`LyricsService.ResolveLyrics(ctx, trackID, audioPath, preferLocal bool)` picks the best lyric.
+`LyricsService.ResolveLyrics(ctx, trackID, audioPath, preferLocal bool, extraLyricsDir string)` picks the best lyric.
 
-The **local tier** is built first: a sibling lyric file next to `audioPath` (read live by
-`LocalLyricsReader`, `.lrc` preferred over `.txt`) if present, otherwise the embedded metadata tag
-(`MetaContent`, cached in DB at scan time). So within the local tier: **local file beats tag**.
+The **local tier** is built first: a local lyric file (read live by `LocalLyricsReader`, `.lrc`
+preferred over `.txt`) — checked in the **sibling dir** of `audioPath` first, then in `extraLyricsDir`
+(the dedicated lyrics folder, when set) — if present, otherwise the embedded metadata tag
+(`MetaContent`, cached in DB at scan time). So within the local tier: **sibling file beats dedicated-folder
+file beats tag**.
+
+`extraLyricsDir` is supplied by `PlayerService.fetchAndEmitLyrics`: it equals `lyrics_folder_path`
+when `lyrics_folder_enabled` is true, otherwise `""` (disabled → sibling-only behavior).
+`HasLocalLyrics(ctx, trackID, audioPath, extraLyricsDir)` takes the same extra dir.
 
 `preferLocal` then decides local tier vs external provider content:
 
@@ -46,11 +52,13 @@ The **local tier** is built first: a sibling lyric file next to `audioPath` (rea
 | --- | --- |
 | `prefer_local_lyrics=true` | (Default) Use the local tier if available, otherwise fall back to `Content` (external provider). |
 | `prefer_local_lyrics=false` | Use `Content` (external provider) if available, otherwise fall back to the local tier. |
+| `lyrics_folder_enabled=true` | Also search `lyrics_folder_path` (flat, by basename) for `.lrc`/`.txt`, after the sibling dir. Default off. |
 | `enable_lrclib=false` | lrclib.net provider disabled; not queried on fetch. |
 | `enable_kugou=false` | KuGou provider disabled; not queried on fetch. |
 
 **Full priority (default `prefer_local_lyrics=true`):**
-`Local .lrc` → `Local .txt` → `Metadata tag` → `LRClib / KuGou`.
+`Sibling .lrc` → `Sibling .txt` → `Folder .lrc` → `Folder .txt` (when `lyrics_folder_enabled`) →
+`Metadata tag` → `LRClib / KuGou`.
 
 The setting was renamed from `prefer_metadata_lyrics` (migration `000022_prefer_local_lyrics`,
 `RENAME COLUMN` preserves the existing value).
@@ -61,8 +69,13 @@ If both `enable_lrclib` and `enable_kugou` are false, no external fetch is attem
 
 - Filename must match the audio file's basename exactly, differing only in extension
   (`/music/Song.mp3` → `/music/Song.lrc` or `/music/Song.txt`).
+- Searched in the audio file's **sibling dir** first, then the **dedicated lyrics folder**
+  (`extraLyricsDir`) if enabled. Both use the same basename match; the dedicated folder is a flat
+  lookup (no recursion). Sibling dir always wins. An empty extra dir, or one equal to the sibling dir,
+  is skipped (`internal/infra/lyrics/local.go`).
 - Read **live at play time** in `PlayerService.fetchAndEmitLyrics` — not cached and not watched, so
   newly added/edited files are picked up on the next play. No rescan needed.
+- Paths joined with `filepath.Join` → cross-platform (Unix `/`, Windows `\`).
 - Sources: `local-lrc`, `local-txt`. Frontend keys synced/plain off the content (timestamps), so
   `.lrc` renders synced and `.txt` renders plain automatically.
 
@@ -120,10 +133,12 @@ type LyricsProvider interface {
     Name() string
 }
 
-// LocalLyricsReader reads a sibling lyric file next to the audio file
-// (<base>.lrc preferred, then <base>.txt). found=false if neither exists.
+// LocalLyricsReader reads a local lyric file by the audio file's basename
+// (<base>.lrc preferred, then <base>.txt). The sibling dir is checked first,
+// then each extraDir in order (skipping empty / sibling-equal dirs).
+// found=false if none exist.
 type LocalLyricsReader interface {
-    Read(audioPath string) (content, source string, found bool)
+    Read(audioPath string, extraDirs ...string) (content, source string, found bool)
 }
 ```
 

--- a/catalog/settings/README.md
+++ b/catalog/settings/README.md
@@ -147,7 +147,7 @@ Version constant moved from `internal/domain/version.go` (deleted) to `internal/
 | ------------ | -------------------------------------------------------------------------- |
 | General      | Theme selector, Language picker, Start at Login, Auto-check updates toggle |
 | Library      | Watched folders list, Add/Remove folder, Sync All, Reindex                 |
-| Integrations | Last.fm account + lyrics providers (LRClib, Kugou), prefer-local toggle, lyrics-subfolder toggle + validated name input (matched case-insensitively, with a hint), and dedicated lyrics folder toggle + picker (reuses `LibraryService.SelectFolder`) |
+| Integrations | Last.fm account + lyrics providers (LRClib, Kugou), prefer-local toggle, lyrics-subfolder toggle + validated name input (matched case-insensitively, with a hint), and dedicated lyrics folder toggle + picker (reuses `LibraryService.SelectFolder`). Toggles with conditional sub-settings use `SettingExpandableRow.vue` (header + `#control` slot + animated, inset `#expanded` slot) so the sub-setting reads as nested under its toggle. |
 | Playback     | EQ profiles and band sliders, prevent-sleep toggle (`PlaybackSettings.vue`) |
 | About        | App version, GitHub link, License, Open Data Folder button                 |
 

--- a/catalog/settings/README.md
+++ b/catalog/settings/README.md
@@ -31,6 +31,8 @@ type AppSettings struct {
     PreferLocalLyrics      bool                // prefer local/embedded lyrics over fetched
     LyricsFolderEnabled    bool                // also search a dedicated lyrics folder
     LyricsFolderPath       string              // chosen dedicated lyrics folder (flat, basename match)
+    LyricsSubfolderEnabled bool                // also search a subfolder next to each track
+    LyricsSubfolderName    string              // subfolder name (single safe path segment)
     UseOnlineArtistArtwork bool                // on: prefer Deezer image; off: prefer local artist.jpg/png
     LastScanVersion        string              // app version of last artist-image rescan
     PreventSleepWhilePlaying bool             // prevent OS sleep during playback
@@ -77,6 +79,8 @@ interface AppStore {
   preferLocalLyrics: boolean;
   lyricsFolderEnabled: boolean;
   lyricsFolderPath: string;
+  lyricsSubfolderEnabled: boolean;
+  lyricsSubfolderName: string;
   useOnlineArtistArtwork: boolean;
   preventSleepWhilePlaying: boolean;
   // Update state
@@ -101,6 +105,8 @@ interface AppStore {
   updatePreferLocalLyrics(enabled: boolean): Promise<void>;
   updateLyricsFolderEnabled(enabled: boolean): Promise<void>;
   updateLyricsFolderPath(path: string): Promise<void>;
+  updateLyricsSubfolderEnabled(enabled: boolean): Promise<void>;
+  updateLyricsSubfolderName(name: string): Promise<void>;
   updateUseOnlineArtistArtwork(enabled: boolean): Promise<void>;
   updatePreventSleepWhilePlaying(enabled: boolean): Promise<void>;
   checkForUpdate(): Promise<void>;
@@ -141,7 +147,7 @@ Version constant moved from `internal/domain/version.go` (deleted) to `internal/
 | ------------ | -------------------------------------------------------------------------- |
 | General      | Theme selector, Language picker, Start at Login, Auto-check updates toggle |
 | Library      | Watched folders list, Add/Remove folder, Sync All, Reindex                 |
-| Integrations | Last.fm account + lyrics providers (LRClib, Kugou), prefer-local toggle, and dedicated lyrics folder toggle + picker (reuses `LibraryService.SelectFolder`) |
+| Integrations | Last.fm account + lyrics providers (LRClib, Kugou), prefer-local toggle, lyrics-subfolder toggle + validated name input (matched case-insensitively, with a hint), and dedicated lyrics folder toggle + picker (reuses `LibraryService.SelectFolder`) |
 | Playback     | EQ profiles and band sliders, prevent-sleep toggle (`PlaybackSettings.vue`) |
 | About        | App version, GitHub link, License, Open Data Folder button                 |
 
@@ -196,4 +202,4 @@ Settings evolved across multiple migrations:
 | 000024    | Add `prefer_local_artist_artwork`, `last_scan_version` settings  |
 | 000026    | Drop `prefer_local_artist_artwork` (derived from online toggle)   |
 | 000025    | Split artist artwork into per-source key columns                 |
-| 000027    | Add `lyrics_folder_enabled BOOLEAN NOT NULL DEFAULT FALSE`, `lyrics_folder_path TEXT NOT NULL DEFAULT ''` |
+| 000027    | Add `lyrics_folder_enabled`, `lyrics_folder_path`, `lyrics_subfolder_enabled`, `lyrics_subfolder_name` (folder + subfolder lyrics lookup) |

--- a/catalog/settings/README.md
+++ b/catalog/settings/README.md
@@ -28,7 +28,9 @@ type AppSettings struct {
     EQEnabled              bool
     EnableLrclib           bool                // enable LRClib lyrics provider
     EnableKugou            bool                // enable Kugou lyrics provider
-    PreferMetadataLyrics   bool                // prefer embedded lyrics over fetched
+    PreferLocalLyrics      bool                // prefer local/embedded lyrics over fetched
+    LyricsFolderEnabled    bool                // also search a dedicated lyrics folder
+    LyricsFolderPath       string              // chosen dedicated lyrics folder (flat, basename match)
     UseOnlineArtistArtwork bool                // on: prefer Deezer image; off: prefer local artist.jpg/png
     LastScanVersion        string              // app version of last artist-image rescan
     PreventSleepWhilePlaying bool             // prevent OS sleep during playback
@@ -72,7 +74,9 @@ interface AppStore {
   eqEnabled: boolean;
   enableLrclib: boolean;
   enableKugou: boolean;
-  preferMetadataLyrics: boolean;
+  preferLocalLyrics: boolean;
+  lyricsFolderEnabled: boolean;
+  lyricsFolderPath: string;
   useOnlineArtistArtwork: boolean;
   preventSleepWhilePlaying: boolean;
   // Update state
@@ -94,7 +98,9 @@ interface AppStore {
   updateLastFmUsername(username: string): void;
   updateEnableLrclib(enabled: boolean): Promise<void>;
   updateEnableKugou(enabled: boolean): Promise<void>;
-  updatePreferMetadataLyrics(enabled: boolean): Promise<void>;
+  updatePreferLocalLyrics(enabled: boolean): Promise<void>;
+  updateLyricsFolderEnabled(enabled: boolean): Promise<void>;
+  updateLyricsFolderPath(path: string): Promise<void>;
   updateUseOnlineArtistArtwork(enabled: boolean): Promise<void>;
   updatePreventSleepWhilePlaying(enabled: boolean): Promise<void>;
   checkForUpdate(): Promise<void>;
@@ -135,7 +141,7 @@ Version constant moved from `internal/domain/version.go` (deleted) to `internal/
 | ------------ | -------------------------------------------------------------------------- |
 | General      | Theme selector, Language picker, Start at Login, Auto-check updates toggle |
 | Library      | Watched folders list, Add/Remove folder, Sync All, Reindex                 |
-| Integrations | Last.fm account + lyrics providers (LRClib, Kugou, metadata preference)   |
+| Integrations | Last.fm account + lyrics providers (LRClib, Kugou), prefer-local toggle, and dedicated lyrics folder toggle + picker (reuses `LibraryService.SelectFolder`) |
 | Playback     | EQ profiles and band sliders, prevent-sleep toggle (`PlaybackSettings.vue`) |
 | About        | App version, GitHub link, License, Open Data Folder button                 |
 
@@ -190,3 +196,4 @@ Settings evolved across multiple migrations:
 | 000024    | Add `prefer_local_artist_artwork`, `last_scan_version` settings  |
 | 000026    | Drop `prefer_local_artist_artwork` (derived from online toggle)   |
 | 000025    | Split artist artwork into per-source key columns                 |
+| 000027    | Add `lyrics_folder_enabled BOOLEAN NOT NULL DEFAULT FALSE`, `lyrics_folder_path TEXT NOT NULL DEFAULT ''` |

--- a/frontend/src/components/settings/IntegrationsSettings.vue
+++ b/frontend/src/components/settings/IntegrationsSettings.vue
@@ -2,13 +2,23 @@
 import { useAppStore } from '@/stores/app'
 import { Switch } from '@airmedy/ui'
 import { Events } from '@wailsio/runtime'
-import { Blocks, FileMusic, ImagePlay, MicVocal, Music } from 'lucide-vue-next'
+import { Blocks, FileMusic, Folder, ImagePlay, MicVocal, Music } from 'lucide-vue-next'
 import { onMounted, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import * as LastFmService from '../../../bindings/airmedy/internal/infra/wails/lastfmservice'
+import * as LibraryService from '../../../bindings/airmedy/internal/infra/wails/libraryservice'
 
 const { t } = useI18n()
 const appStore = useAppStore()
+
+const chooseLyricsFolder = async () => {
+  try {
+    const path = await LibraryService.SelectFolder()
+    if (path) await appStore.updateLyricsFolderPath(path)
+  } catch (err) {
+    console.error('Failed to select lyrics folder:', err)
+  }
+}
 
 const lastfmStatus = ref({ connected: false, username: '', avatar_url: '' })
 const lastfmAvatar = ref('')
@@ -182,6 +192,32 @@ onMounted(() => {
           </div>
           <Switch :model-value="appStore.preferLocalLyrics"
             @update:model-value="appStore.updatePreferLocalLyrics" />
+        </div>
+        <div class="p-5 flex items-center justify-between gap-x-2">
+          <div>
+            <p class="text-sm font-semibold">
+              {{ t('settings.integrations.lyrics_folder', 'Dedicated Lyrics Folder') }}
+            </p>
+            <p class="text-xs text-foreground opacity-60 mt-1">
+              {{ t('settings.integrations.lyrics_folder_desc', 'Also look up .lrc/.txt files (matched by track name) in a chosen folder') }}
+            </p>
+          </div>
+          <Switch :model-value="appStore.lyricsFolderEnabled"
+            @update:model-value="appStore.updateLyricsFolderEnabled" />
+        </div>
+        <div v-if="appStore.lyricsFolderEnabled" class="p-5 flex items-center justify-between gap-x-4">
+          <div class="flex items-center gap-3 overflow-hidden">
+            <div class="p-2 bg-background rounded-lg shadow-sm shrink-0">
+              <Folder class="w-4 h-4 text-foreground opacity-60" />
+            </div>
+            <span class="text-sm font-medium truncate" :title="appStore.lyricsFolderPath">
+              {{ appStore.lyricsFolderPath || t('settings.integrations.lyrics_folder_none', 'No folder selected') }}
+            </span>
+          </div>
+          <button @click="chooseLyricsFolder"
+            class="shrink-0 px-4 py-2 bg-foreground/[0.04] text-foreground rounded-xl hover:bg-foreground/[0.08] transition-all text-sm font-bold">
+            {{ t('settings.integrations.lyrics_folder_choose', 'Choose Folder') }}
+          </button>
         </div>
       </div>
     </section>

--- a/frontend/src/components/settings/IntegrationsSettings.vue
+++ b/frontend/src/components/settings/IntegrationsSettings.vue
@@ -7,6 +7,7 @@ import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import * as LastFmService from '../../../bindings/airmedy/internal/infra/wails/lastfmservice'
 import * as LibraryService from '../../../bindings/airmedy/internal/infra/wails/libraryservice'
+import SettingExpandableRow from './SettingExpandableRow.vue'
 
 const { t } = useI18n()
 const appStore = useAppStore()
@@ -238,64 +239,58 @@ onMounted(() => {
           <Switch :model-value="appStore.preferLocalLyrics"
             @update:model-value="appStore.updatePreferLocalLyrics" />
         </div>
-        <div class="p-5 flex items-center justify-between gap-x-2">
-          <div>
-            <p class="text-sm font-semibold">
-              {{ t('settings.integrations.lyrics_subfolder', 'Lyrics Subfolder Next to Track') }}
-            </p>
-            <p class="text-xs text-foreground opacity-60 mt-1">
-              {{ t('settings.integrations.lyrics_subfolder_desc', 'Also look up .lrc/.txt files in a subfolder next to each track') }}
-            </p>
-          </div>
-          <Switch :model-value="appStore.lyricsSubfolderEnabled" @update:model-value="toggleSubfolder" />
-        </div>
-        <div v-if="appStore.lyricsSubfolderEnabled" class="p-5 space-y-3">
-          <div class="flex items-center gap-3">
-            <div class="p-2 bg-background rounded-lg shadow-sm shrink-0">
-              <FolderTree class="w-4 h-4 text-foreground opacity-60" />
-            </div>
-            <Input type="text" class="flex-1" :model-value="subfolderInput"
-              :placeholder="t('settings.integrations.lyrics_subfolder_name', 'Folder name (e.g. lyrics)')"
-              @update:model-value="onSubfolderInput" @keyup.enter="saveSubfolder" />
-            <button @click="saveSubfolder" :disabled="!subfolderChanged"
-              class="shrink-0 px-4 py-2 bg-primary text-primary-foreground rounded-xl hover:opacity-90 transition-all text-sm font-bold disabled:opacity-50">
-              {{ t('common.save', 'Save') }}
-            </button>
-          </div>
-          <p v-if="subfolderError" class="text-xs text-red-500 pl-11">{{ subfolderError }}</p>
-          <template v-else>
-            <p class="text-xs text-foreground opacity-50 pl-11 truncate">{{ subfolderExample }}</p>
-            <p class="text-xs text-foreground opacity-40 pl-11">
-              {{ t('settings.integrations.lyrics_subfolder_case', 'Folder name is matched ignoring upper/lowercase.') }}
-            </p>
+        <SettingExpandableRow :title="t('settings.integrations.lyrics_subfolder', 'Lyrics Subfolder Next to Track')"
+          :description="t('settings.integrations.lyrics_subfolder_desc', 'Also look up .lrc/.txt files in a subfolder next to each track')"
+          :expanded="appStore.lyricsSubfolderEnabled">
+          <template #control>
+            <Switch :model-value="appStore.lyricsSubfolderEnabled" @update:model-value="toggleSubfolder" />
           </template>
-        </div>
-        <div class="p-5 flex items-center justify-between gap-x-2">
-          <div>
-            <p class="text-sm font-semibold">
-              {{ t('settings.integrations.lyrics_folder', 'Dedicated Lyrics Folder') }}
-            </p>
-            <p class="text-xs text-foreground opacity-60 mt-1">
-              {{ t('settings.integrations.lyrics_folder_desc', 'Also look up .lrc/.txt files (matched by track name) in a chosen folder') }}
-            </p>
-          </div>
-          <Switch :model-value="appStore.lyricsFolderEnabled"
-            @update:model-value="appStore.updateLyricsFolderEnabled" />
-        </div>
-        <div v-if="appStore.lyricsFolderEnabled" class="p-5 flex items-center justify-between gap-x-4">
-          <div class="flex items-center gap-3 overflow-hidden">
-            <div class="p-2 bg-background rounded-lg shadow-sm shrink-0">
-              <Folder class="w-4 h-4 text-foreground opacity-60" />
+          <template #expanded>
+            <div class="flex items-center gap-3">
+              <div class="p-2 bg-background rounded-lg shadow-sm shrink-0">
+                <FolderTree class="w-4 h-4 text-foreground opacity-60" />
+              </div>
+              <Input type="text" class="flex-1" :model-value="subfolderInput"
+                :placeholder="t('settings.integrations.lyrics_subfolder_name', 'Folder name (e.g. lyrics)')"
+                @update:model-value="onSubfolderInput" @keyup.enter="saveSubfolder" />
+              <button @click="saveSubfolder" :disabled="!subfolderChanged"
+                class="shrink-0 px-4 py-2 bg-primary text-primary-foreground rounded-xl hover:opacity-90 transition-all text-sm font-bold disabled:opacity-50">
+                {{ t('common.save', 'Save') }}
+              </button>
             </div>
-            <span class="text-sm font-medium truncate" :title="appStore.lyricsFolderPath">
-              {{ appStore.lyricsFolderPath || t('settings.integrations.lyrics_folder_none', 'No folder selected') }}
-            </span>
-          </div>
-          <button @click="chooseLyricsFolder"
-            class="shrink-0 px-4 py-2 bg-foreground/[0.04] text-foreground rounded-xl hover:bg-foreground/[0.08] transition-all text-sm font-bold">
-            {{ t('settings.integrations.lyrics_folder_choose', 'Choose Folder') }}
-          </button>
-        </div>
+            <p v-if="subfolderError" class="text-xs text-red-500 mt-3">{{ subfolderError }}</p>
+            <template v-else>
+              <p class="text-xs text-foreground opacity-50 mt-3 truncate">{{ subfolderExample }}</p>
+              <p class="text-xs text-foreground opacity-40 mt-1">
+                {{ t('settings.integrations.lyrics_subfolder_case', 'Folder name is matched ignoring upper/lowercase.') }}
+              </p>
+            </template>
+          </template>
+        </SettingExpandableRow>
+        <SettingExpandableRow :title="t('settings.integrations.lyrics_folder', 'Dedicated Lyrics Folder')"
+          :description="t('settings.integrations.lyrics_folder_desc', 'Also look up .lrc/.txt files (matched by track name) in a chosen folder')"
+          :expanded="appStore.lyricsFolderEnabled">
+          <template #control>
+            <Switch :model-value="appStore.lyricsFolderEnabled"
+              @update:model-value="appStore.updateLyricsFolderEnabled" />
+          </template>
+          <template #expanded>
+            <div class="flex items-center justify-between gap-x-4">
+              <div class="flex items-center gap-3 overflow-hidden">
+                <div class="p-2 bg-background rounded-lg shadow-sm shrink-0">
+                  <Folder class="w-4 h-4 text-foreground opacity-60" />
+                </div>
+                <span class="text-sm font-medium truncate" :title="appStore.lyricsFolderPath">
+                  {{ appStore.lyricsFolderPath || t('settings.integrations.lyrics_folder_none', 'No folder selected') }}
+                </span>
+              </div>
+              <button @click="chooseLyricsFolder"
+                class="shrink-0 px-4 py-2 bg-foreground/[0.04] text-foreground rounded-xl hover:bg-foreground/[0.08] transition-all text-sm font-bold">
+                {{ t('settings.integrations.lyrics_folder_choose', 'Choose Folder') }}
+              </button>
+            </div>
+          </template>
+        </SettingExpandableRow>
       </div>
     </section>
   </div>

--- a/frontend/src/components/settings/IntegrationsSettings.vue
+++ b/frontend/src/components/settings/IntegrationsSettings.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { useAppStore } from '@/stores/app'
-import { Switch } from '@airmedy/ui'
+import { Input, Switch } from '@airmedy/ui'
 import { Events } from '@wailsio/runtime'
-import { Blocks, FileMusic, Folder, ImagePlay, MicVocal, Music } from 'lucide-vue-next'
-import { onMounted, onUnmounted, ref } from 'vue'
+import { Blocks, FileMusic, Folder, FolderTree, ImagePlay, MicVocal, Music } from 'lucide-vue-next'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import * as LastFmService from '../../../bindings/airmedy/internal/infra/wails/lastfmservice'
 import * as LibraryService from '../../../bindings/airmedy/internal/infra/wails/libraryservice'
@@ -19,6 +19,51 @@ const chooseLyricsFolder = async () => {
     console.error('Failed to select lyrics folder:', err)
   }
 }
+
+// Lyrics subfolder (next to track)
+const subfolderInput = ref(appStore.lyricsSubfolderName)
+const subfolderError = ref('')
+const INVALID_SUBFOLDER = /[/\\:*?"<>|]/
+
+const validateSubfolder = (name: string): boolean => {
+  const trimmed = name.trim()
+  if (trimmed === '' || trimmed === '.' || trimmed === '..' || trimmed.includes('..') || INVALID_SUBFOLDER.test(trimmed)) {
+    subfolderError.value = t('settings.integrations.lyrics_subfolder_invalid', 'Enter a single folder name (no slashes or "..")')
+    return false
+  }
+  subfolderError.value = ''
+  return true
+}
+
+const onSubfolderInput = (v: unknown) => {
+  subfolderInput.value = String(v)
+  if (subfolderError.value) validateSubfolder(subfolderInput.value)
+}
+
+const subfolderChanged = computed(() => subfolderInput.value.trim() !== appStore.lyricsSubfolderName)
+
+const saveSubfolder = async () => {
+  const trimmed = subfolderInput.value.trim()
+  if (!validateSubfolder(trimmed)) return
+  subfolderInput.value = trimmed
+  await appStore.updateLyricsSubfolderName(trimmed)
+}
+
+const subfolderExample = computed(() =>
+  t('settings.integrations.lyrics_subfolder_example', { name: subfolderInput.value.trim() || 'lyrics' }),
+)
+
+const toggleSubfolder = async (enabled: boolean) => {
+  await appStore.updateLyricsSubfolderEnabled(enabled)
+}
+
+// Keep the local input in sync when settings load/change and the field is untouched
+// (input still equals the last value pushed from the store).
+const lastSyncedSubfolder = ref(appStore.lyricsSubfolderName)
+watch(() => appStore.lyricsSubfolderName, (name) => {
+  if (subfolderInput.value === lastSyncedSubfolder.value) subfolderInput.value = name
+  lastSyncedSubfolder.value = name
+})
 
 const lastfmStatus = ref({ connected: false, username: '', avatar_url: '' })
 const lastfmAvatar = ref('')
@@ -192,6 +237,38 @@ onMounted(() => {
           </div>
           <Switch :model-value="appStore.preferLocalLyrics"
             @update:model-value="appStore.updatePreferLocalLyrics" />
+        </div>
+        <div class="p-5 flex items-center justify-between gap-x-2">
+          <div>
+            <p class="text-sm font-semibold">
+              {{ t('settings.integrations.lyrics_subfolder', 'Lyrics Subfolder Next to Track') }}
+            </p>
+            <p class="text-xs text-foreground opacity-60 mt-1">
+              {{ t('settings.integrations.lyrics_subfolder_desc', 'Also look up .lrc/.txt files in a subfolder next to each track') }}
+            </p>
+          </div>
+          <Switch :model-value="appStore.lyricsSubfolderEnabled" @update:model-value="toggleSubfolder" />
+        </div>
+        <div v-if="appStore.lyricsSubfolderEnabled" class="p-5 space-y-3">
+          <div class="flex items-center gap-3">
+            <div class="p-2 bg-background rounded-lg shadow-sm shrink-0">
+              <FolderTree class="w-4 h-4 text-foreground opacity-60" />
+            </div>
+            <Input type="text" class="flex-1" :model-value="subfolderInput"
+              :placeholder="t('settings.integrations.lyrics_subfolder_name', 'Folder name (e.g. lyrics)')"
+              @update:model-value="onSubfolderInput" @keyup.enter="saveSubfolder" />
+            <button @click="saveSubfolder" :disabled="!subfolderChanged"
+              class="shrink-0 px-4 py-2 bg-primary text-primary-foreground rounded-xl hover:opacity-90 transition-all text-sm font-bold disabled:opacity-50">
+              {{ t('common.save', 'Save') }}
+            </button>
+          </div>
+          <p v-if="subfolderError" class="text-xs text-red-500 pl-11">{{ subfolderError }}</p>
+          <template v-else>
+            <p class="text-xs text-foreground opacity-50 pl-11 truncate">{{ subfolderExample }}</p>
+            <p class="text-xs text-foreground opacity-40 pl-11">
+              {{ t('settings.integrations.lyrics_subfolder_case', 'Folder name is matched ignoring upper/lowercase.') }}
+            </p>
+          </template>
         </div>
         <div class="p-5 flex items-center justify-between gap-x-2">
           <div>

--- a/frontend/src/components/settings/SettingExpandableRow.vue
+++ b/frontend/src/components/settings/SettingExpandableRow.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+defineProps<{
+  title: string
+  description?: string
+  expanded?: boolean
+}>()
+</script>
+
+<template>
+  <div>
+    <div class="p-5 flex items-center justify-between gap-x-2">
+      <div>
+        <p class="text-sm font-semibold">{{ title }}</p>
+        <p v-if="description" class="text-xs text-foreground opacity-60 mt-1">{{ description }}</p>
+      </div>
+      <slot name="control" />
+    </div>
+    <Transition name="expand">
+      <div v-if="expanded" class="expand-wrap">
+        <div
+          class="mx-5 mb-5 p-4 rounded-xl bg-foreground/[0.03] border border-foreground/[0.06]">
+          <slot name="expanded" />
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<style scoped>
+.expand-wrap {
+  overflow: hidden;
+}
+.expand-enter-active,
+.expand-leave-active {
+  transition:
+    max-height 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  max-height: 240px;
+}
+.expand-enter-from,
+.expand-leave-to {
+  max-height: 0;
+  opacity: 0;
+}
+</style>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -89,6 +89,12 @@
       "lyrics_folder_desc": "Auch .lrc/.txt-Dateien (nach Titelname zugeordnet) in einem gewählten Ordner suchen",
       "lyrics_folder_none": "Kein Ordner ausgewählt",
       "lyrics_folder_choose": "Ordner auswählen",
+      "lyrics_subfolder": "Songtext-Unterordner neben dem Titel",
+      "lyrics_subfolder_desc": "Auch .lrc/.txt-Dateien in einem Unterordner neben jedem Titel suchen",
+      "lyrics_subfolder_name": "Ordnername (z. B. lyrics)",
+      "lyrics_subfolder_example": "Beispiel: …/Album/{name}/Song.lrc",
+      "lyrics_subfolder_invalid": "Einen einzelnen Ordnernamen eingeben (keine Schrägstriche oder \"..\")",
+      "lyrics_subfolder_case": "Der Ordnername wird ohne Berücksichtigung der Groß-/Kleinschreibung abgeglichen.",
       "scrobbling": "Scrobbling",
       "artwork": "Bilder",
       "lyrics": "Songtexte"

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -85,6 +85,10 @@
       "enable_kugou_desc": "Songtexte von KuGou Music abrufen",
       "prefer_local_lyrics": "Lokale Songtexte bevorzugen",
       "prefer_local_lyrics_desc": "Lokale Songtextdateien (.lrc/.txt) oder eingebettete Songtexte verwenden, falls verfügbar",
+      "lyrics_folder": "Dedizierter Songtext-Ordner",
+      "lyrics_folder_desc": "Auch .lrc/.txt-Dateien (nach Titelname zugeordnet) in einem gewählten Ordner suchen",
+      "lyrics_folder_none": "Kein Ordner ausgewählt",
+      "lyrics_folder_choose": "Ordner auswählen",
       "scrobbling": "Scrobbling",
       "artwork": "Bilder",
       "lyrics": "Songtexte"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -85,6 +85,10 @@
       "enable_kugou_desc": "Fetch lyrics from KuGou Music",
       "prefer_local_lyrics": "Prefer Local Lyrics",
       "prefer_local_lyrics_desc": "Use local lyric files (.lrc/.txt) or embedded lyrics when available",
+      "lyrics_folder": "Dedicated Lyrics Folder",
+      "lyrics_folder_desc": "Also look up .lrc/.txt files (matched by track name) in a chosen folder",
+      "lyrics_folder_none": "No folder selected",
+      "lyrics_folder_choose": "Choose Folder",
       "scrobbling": "Scrobbling",
       "artwork": "Artwork",
       "lyrics": "Lyrics"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -89,6 +89,12 @@
       "lyrics_folder_desc": "Also look up .lrc/.txt files (matched by track name) in a chosen folder",
       "lyrics_folder_none": "No folder selected",
       "lyrics_folder_choose": "Choose Folder",
+      "lyrics_subfolder": "Lyrics Subfolder Next to Track",
+      "lyrics_subfolder_desc": "Also look up .lrc/.txt files in a subfolder next to each track",
+      "lyrics_subfolder_name": "Folder name (e.g. lyrics)",
+      "lyrics_subfolder_example": "Example: …/Album/{name}/Song.lrc",
+      "lyrics_subfolder_invalid": "Enter a single folder name (no slashes or \"..\")",
+      "lyrics_subfolder_case": "Folder name is matched ignoring upper/lowercase.",
       "scrobbling": "Scrobbling",
       "artwork": "Artwork",
       "lyrics": "Lyrics"

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -89,6 +89,12 @@
       "lyrics_folder_desc": "Buscar también archivos .lrc/.txt (coincidentes por nombre de pista) en una carpeta elegida",
       "lyrics_folder_none": "Ninguna carpeta seleccionada",
       "lyrics_folder_choose": "Elegir carpeta",
+      "lyrics_subfolder": "Subcarpeta de letras junto a la pista",
+      "lyrics_subfolder_desc": "Buscar también archivos .lrc/.txt en una subcarpeta junto a cada pista",
+      "lyrics_subfolder_name": "Nombre de carpeta (p. ej. lyrics)",
+      "lyrics_subfolder_example": "Ejemplo: …/Album/{name}/Song.lrc",
+      "lyrics_subfolder_invalid": "Introduce el nombre de una sola carpeta (sin barras ni \"..\")",
+      "lyrics_subfolder_case": "El nombre de la carpeta se compara sin distinguir mayúsculas/minúsculas.",
       "scrobbling": "Scrobbling",
       "artwork": "Carátulas",
       "lyrics": "Letras"

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -85,6 +85,10 @@
       "enable_kugou_desc": "Obtener letras de KuGou Music",
       "prefer_local_lyrics": "Preferir letras locales",
       "prefer_local_lyrics_desc": "Usar archivos de letras (.lrc/.txt) o letras incrustadas cuando estén disponibles",
+      "lyrics_folder": "Carpeta de letras dedicada",
+      "lyrics_folder_desc": "Buscar también archivos .lrc/.txt (coincidentes por nombre de pista) en una carpeta elegida",
+      "lyrics_folder_none": "Ninguna carpeta seleccionada",
+      "lyrics_folder_choose": "Elegir carpeta",
       "scrobbling": "Scrobbling",
       "artwork": "Carátulas",
       "lyrics": "Letras"

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -85,6 +85,10 @@
       "enable_kugou_desc": "Récupérer les paroles depuis KuGou Music",
       "prefer_local_lyrics": "Privilégier les paroles locales",
       "prefer_local_lyrics_desc": "Utiliser les fichiers de paroles (.lrc/.txt) ou les paroles intégrées lorsqu'ils sont disponibles",
+      "lyrics_folder": "Dossier de paroles dédié",
+      "lyrics_folder_desc": "Rechercher aussi les fichiers .lrc/.txt (associés par nom de piste) dans un dossier choisi",
+      "lyrics_folder_none": "Aucun dossier sélectionné",
+      "lyrics_folder_choose": "Choisir un dossier",
       "scrobbling": "Scrobbling",
       "artwork": "Illustrations",
       "lyrics": "Paroles"

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -89,6 +89,12 @@
       "lyrics_folder_desc": "Rechercher aussi les fichiers .lrc/.txt (associés par nom de piste) dans un dossier choisi",
       "lyrics_folder_none": "Aucun dossier sélectionné",
       "lyrics_folder_choose": "Choisir un dossier",
+      "lyrics_subfolder": "Sous-dossier de paroles près de la piste",
+      "lyrics_subfolder_desc": "Rechercher aussi les fichiers .lrc/.txt dans un sous-dossier près de chaque piste",
+      "lyrics_subfolder_name": "Nom du dossier (ex. lyrics)",
+      "lyrics_subfolder_example": "Exemple : …/Album/{name}/Song.lrc",
+      "lyrics_subfolder_invalid": "Saisissez un seul nom de dossier (sans barres obliques ni \"..\")",
+      "lyrics_subfolder_case": "Le nom du dossier est comparé sans tenir compte de la casse.",
       "scrobbling": "Scrobbling",
       "artwork": "Illustrations",
       "lyrics": "Paroles"

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -89,6 +89,12 @@
       "lyrics_folder_desc": "Cerca anche file .lrc/.txt (abbinati per nome traccia) in una cartella scelta",
       "lyrics_folder_none": "Nessuna cartella selezionata",
       "lyrics_folder_choose": "Scegli cartella",
+      "lyrics_subfolder": "Sottocartella testi vicino alla traccia",
+      "lyrics_subfolder_desc": "Cerca anche file .lrc/.txt in una sottocartella vicino a ogni traccia",
+      "lyrics_subfolder_name": "Nome cartella (es. lyrics)",
+      "lyrics_subfolder_example": "Esempio: …/Album/{name}/Song.lrc",
+      "lyrics_subfolder_invalid": "Inserisci il nome di una singola cartella (senza barre o \"..\")",
+      "lyrics_subfolder_case": "Il nome della cartella viene confrontato ignorando maiuscole/minuscole.",
       "scrobbling": "Scrobbling",
       "artwork": "Immagini",
       "lyrics": "Testi"

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -85,6 +85,10 @@
       "enable_kugou_desc": "Recupera i testi da KuGou Music",
       "prefer_local_lyrics": "Preferisci testi locali",
       "prefer_local_lyrics_desc": "Usa file di testo (.lrc/.txt) o testi incorporati quando disponibili",
+      "lyrics_folder": "Cartella testi dedicata",
+      "lyrics_folder_desc": "Cerca anche file .lrc/.txt (abbinati per nome traccia) in una cartella scelta",
+      "lyrics_folder_none": "Nessuna cartella selezionata",
+      "lyrics_folder_choose": "Scegli cartella",
       "scrobbling": "Scrobbling",
       "artwork": "Immagini",
       "lyrics": "Testi"

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -85,6 +85,10 @@
       "enable_kugou_desc": "KuGou Music から歌詞を取得",
       "prefer_local_lyrics": "ローカル歌詞を優先",
       "prefer_local_lyrics_desc": "利用可能な場合はローカル歌詞ファイル（.lrc/.txt）または埋め込み歌詞を使用",
+      "lyrics_folder": "専用歌詞フォルダー",
+      "lyrics_folder_desc": "選択したフォルダー内の .lrc/.txt ファイル（曲名で一致）も検索",
+      "lyrics_folder_none": "フォルダーが選択されていません",
+      "lyrics_folder_choose": "フォルダーを選択",
       "scrobbling": "Scrobbling",
       "artwork": "画像",
       "lyrics": "歌詞"

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -89,6 +89,12 @@
       "lyrics_folder_desc": "選択したフォルダー内の .lrc/.txt ファイル（曲名で一致）も検索",
       "lyrics_folder_none": "フォルダーが選択されていません",
       "lyrics_folder_choose": "フォルダーを選択",
+      "lyrics_subfolder": "トラック隣の歌詞サブフォルダー",
+      "lyrics_subfolder_desc": "各トラックの隣にあるサブフォルダー内の .lrc/.txt ファイルも検索",
+      "lyrics_subfolder_name": "フォルダー名（例: lyrics）",
+      "lyrics_subfolder_example": "例: …/Album/{name}/Song.lrc",
+      "lyrics_subfolder_invalid": "単一のフォルダー名を入力してください（スラッシュや「..」は不可）",
+      "lyrics_subfolder_case": "フォルダー名は大文字・小文字を区別せずに照合されます。",
       "scrobbling": "Scrobbling",
       "artwork": "画像",
       "lyrics": "歌詞"

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -85,6 +85,10 @@
       "enable_kugou_desc": "KuGou Music에서 가사 가져오기",
       "prefer_local_lyrics": "로컬 가사 우선",
       "prefer_local_lyrics_desc": "사용 가능한 경우 로컬 가사 파일(.lrc/.txt) 또는 포함된 가사 사용",
+      "lyrics_folder": "전용 가사 폴더",
+      "lyrics_folder_desc": "선택한 폴더에서도 .lrc/.txt 파일(트랙 이름으로 일치)을 조회",
+      "lyrics_folder_none": "폴더가 선택되지 않음",
+      "lyrics_folder_choose": "폴더 선택",
       "scrobbling": "Scrobbling",
       "artwork": "아트워크",
       "lyrics": "가사"

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -89,6 +89,12 @@
       "lyrics_folder_desc": "선택한 폴더에서도 .lrc/.txt 파일(트랙 이름으로 일치)을 조회",
       "lyrics_folder_none": "폴더가 선택되지 않음",
       "lyrics_folder_choose": "폴더 선택",
+      "lyrics_subfolder": "트랙 옆 가사 하위 폴더",
+      "lyrics_subfolder_desc": "각 트랙 옆 하위 폴더에서도 .lrc/.txt 파일을 조회",
+      "lyrics_subfolder_name": "폴더 이름 (예: lyrics)",
+      "lyrics_subfolder_example": "예: …/Album/{name}/Song.lrc",
+      "lyrics_subfolder_invalid": "단일 폴더 이름을 입력하세요 (슬래시나 \"..\" 불가)",
+      "lyrics_subfolder_case": "폴더 이름은 대소문자를 구분하지 않고 일치시킵니다.",
       "scrobbling": "Scrobbling",
       "artwork": "아트워크",
       "lyrics": "가사"

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -85,6 +85,10 @@
       "enable_kugou_desc": "Buscar letras do KuGou Music",
       "prefer_local_lyrics": "Preferir letras locais",
       "prefer_local_lyrics_desc": "Usar ficheiros de letras (.lrc/.txt) ou letras incorporadas quando disponíveis",
+      "lyrics_folder": "Pasta de letras dedicada",
+      "lyrics_folder_desc": "Procurar também ficheiros .lrc/.txt (correspondidos pelo nome da faixa) numa pasta escolhida",
+      "lyrics_folder_none": "Nenhuma pasta selecionada",
+      "lyrics_folder_choose": "Escolher pasta",
       "scrobbling": "Scrobbling",
       "artwork": "Capas",
       "lyrics": "Letras"

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -89,6 +89,12 @@
       "lyrics_folder_desc": "Procurar também ficheiros .lrc/.txt (correspondidos pelo nome da faixa) numa pasta escolhida",
       "lyrics_folder_none": "Nenhuma pasta selecionada",
       "lyrics_folder_choose": "Escolher pasta",
+      "lyrics_subfolder": "Subpasta de letras junto à faixa",
+      "lyrics_subfolder_desc": "Procurar também ficheiros .lrc/.txt numa subpasta junto a cada faixa",
+      "lyrics_subfolder_name": "Nome da pasta (ex.: lyrics)",
+      "lyrics_subfolder_example": "Exemplo: …/Album/{name}/Song.lrc",
+      "lyrics_subfolder_invalid": "Introduza o nome de uma única pasta (sem barras ou \"..\")",
+      "lyrics_subfolder_case": "O nome da pasta é correspondido ignorando maiúsculas/minúsculas.",
       "scrobbling": "Scrobbling",
       "artwork": "Capas",
       "lyrics": "Letras"

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -89,6 +89,12 @@
       "lyrics_folder_desc": "Также искать файлы .lrc/.txt (по имени трека) в выбранной папке",
       "lyrics_folder_none": "Папка не выбрана",
       "lyrics_folder_choose": "Выбрать папку",
+      "lyrics_subfolder": "Подпапка текстов рядом с треком",
+      "lyrics_subfolder_desc": "Также искать файлы .lrc/.txt в подпапке рядом с каждым треком",
+      "lyrics_subfolder_name": "Имя папки (напр. lyrics)",
+      "lyrics_subfolder_example": "Пример: …/Album/{name}/Song.lrc",
+      "lyrics_subfolder_invalid": "Введите имя одной папки (без слешей и «..»)",
+      "lyrics_subfolder_case": "Имя папки сопоставляется без учёта регистра.",
       "scrobbling": "Скробблинг",
       "artwork": "Обложки",
       "lyrics": "Тексты"

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -85,6 +85,10 @@
       "enable_kugou_desc": "Загружать тексты с KuGou Music",
       "prefer_local_lyrics": "Предпочитать локальные тексты",
       "prefer_local_lyrics_desc": "Использовать локальные файлы текстов (.lrc/.txt) или встроенные тексты, если доступны",
+      "lyrics_folder": "Отдельная папка текстов",
+      "lyrics_folder_desc": "Также искать файлы .lrc/.txt (по имени трека) в выбранной папке",
+      "lyrics_folder_none": "Папка не выбрана",
+      "lyrics_folder_choose": "Выбрать папку",
       "scrobbling": "Скробблинг",
       "artwork": "Обложки",
       "lyrics": "Тексты"

--- a/frontend/src/locales/th.json
+++ b/frontend/src/locales/th.json
@@ -85,6 +85,10 @@
       "enable_kugou_desc": "ดึงเนื้อเพลงจาก KuGou Music",
       "prefer_local_lyrics": "ใช้เนื้อเพลงในเครื่องก่อน",
       "prefer_local_lyrics_desc": "ใช้ไฟล์เนื้อเพลง (.lrc/.txt) หรือเนื้อเพลงที่ฝังไว้เมื่อมี",
+      "lyrics_folder": "โฟลเดอร์เนื้อเพลงเฉพาะ",
+      "lyrics_folder_desc": "ค้นหาไฟล์ .lrc/.txt (จับคู่ตามชื่อเพลง) ในโฟลเดอร์ที่เลือกด้วย",
+      "lyrics_folder_none": "ยังไม่ได้เลือกโฟลเดอร์",
+      "lyrics_folder_choose": "เลือกโฟลเดอร์",
       "scrobbling": "การสคร็อบเบิล",
       "artwork": "รูปภาพ",
       "lyrics": "เนื้อเพลง"

--- a/frontend/src/locales/th.json
+++ b/frontend/src/locales/th.json
@@ -89,6 +89,12 @@
       "lyrics_folder_desc": "ค้นหาไฟล์ .lrc/.txt (จับคู่ตามชื่อเพลง) ในโฟลเดอร์ที่เลือกด้วย",
       "lyrics_folder_none": "ยังไม่ได้เลือกโฟลเดอร์",
       "lyrics_folder_choose": "เลือกโฟลเดอร์",
+      "lyrics_subfolder": "โฟลเดอร์ย่อยเนื้อเพลงข้างแทร็ก",
+      "lyrics_subfolder_desc": "ค้นหาไฟล์ .lrc/.txt ในโฟลเดอร์ย่อยข้างแต่ละแทร็กด้วย",
+      "lyrics_subfolder_name": "ชื่อโฟลเดอร์ (เช่น lyrics)",
+      "lyrics_subfolder_example": "ตัวอย่าง: …/Album/{name}/Song.lrc",
+      "lyrics_subfolder_invalid": "กรอกชื่อโฟลเดอร์เดียว (ห้ามมีสแลชหรือ \"..\")",
+      "lyrics_subfolder_case": "ชื่อโฟลเดอร์จับคู่โดยไม่สนใจตัวพิมพ์ใหญ่/เล็ก",
       "scrobbling": "การสคร็อบเบิล",
       "artwork": "รูปภาพ",
       "lyrics": "เนื้อเพลง"

--- a/frontend/src/locales/vi.json
+++ b/frontend/src/locales/vi.json
@@ -89,6 +89,12 @@
       "lyrics_folder_desc": "Tìm thêm tệp .lrc/.txt (khớp theo tên bài hát) trong thư mục đã chọn",
       "lyrics_folder_none": "Chưa chọn thư mục",
       "lyrics_folder_choose": "Chọn thư mục",
+      "lyrics_subfolder": "Thư mục con chứa lời cạnh track",
+      "lyrics_subfolder_desc": "Tìm thêm tệp .lrc/.txt trong thư mục con cạnh mỗi track",
+      "lyrics_subfolder_name": "Tên thư mục (vd: lyrics)",
+      "lyrics_subfolder_example": "Ví dụ: …/Album/{name}/Song.lrc",
+      "lyrics_subfolder_invalid": "Nhập tên một thư mục (không có dấu gạch chéo hoặc \"..\")",
+      "lyrics_subfolder_case": "Tên thư mục được khớp không phân biệt hoa thường.",
       "scrobbling": "Scrobbling",
       "artwork": "Ảnh bìa",
       "lyrics": "Lời bài hát"

--- a/frontend/src/locales/vi.json
+++ b/frontend/src/locales/vi.json
@@ -85,6 +85,10 @@
       "enable_kugou_desc": "Tải lời bài hát từ KuGou Music",
       "prefer_local_lyrics": "Ưu tiên lời bài hát cục bộ",
       "prefer_local_lyrics_desc": "Dùng tệp lời (.lrc/.txt) hoặc lời nhúng khi có",
+      "lyrics_folder": "Thư mục lời riêng",
+      "lyrics_folder_desc": "Tìm thêm tệp .lrc/.txt (khớp theo tên bài hát) trong thư mục đã chọn",
+      "lyrics_folder_none": "Chưa chọn thư mục",
+      "lyrics_folder_choose": "Chọn thư mục",
       "scrobbling": "Scrobbling",
       "artwork": "Ảnh bìa",
       "lyrics": "Lời bài hát"

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -89,6 +89,12 @@
       "lyrics_folder_desc": "同时在所选文件夹中查找 .lrc/.txt 文件（按曲目名称匹配）",
       "lyrics_folder_none": "未选择文件夹",
       "lyrics_folder_choose": "选择文件夹",
+      "lyrics_subfolder": "曲目旁的歌词子文件夹",
+      "lyrics_subfolder_desc": "同时在每个曲目旁的子文件夹中查找 .lrc/.txt 文件",
+      "lyrics_subfolder_name": "文件夹名称（如 lyrics）",
+      "lyrics_subfolder_example": "示例：…/Album/{name}/Song.lrc",
+      "lyrics_subfolder_invalid": "请输入单个文件夹名称（不含斜杠或“..”）",
+      "lyrics_subfolder_case": "文件夹名称匹配时忽略大小写。",
       "scrobbling": "Scrobbling",
       "artwork": "封面",
       "lyrics": "歌词"

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -85,6 +85,10 @@
       "enable_kugou_desc": "从酷狗音乐获取歌词",
       "prefer_local_lyrics": "优先使用本地歌词",
       "prefer_local_lyrics_desc": "可用时使用本地歌词文件（.lrc/.txt）或嵌入歌词",
+      "lyrics_folder": "专用歌词文件夹",
+      "lyrics_folder_desc": "同时在所选文件夹中查找 .lrc/.txt 文件（按曲目名称匹配）",
+      "lyrics_folder_none": "未选择文件夹",
+      "lyrics_folder_choose": "选择文件夹",
       "scrobbling": "Scrobbling",
       "artwork": "封面",
       "lyrics": "歌词"

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -17,6 +17,8 @@ export const useAppStore = defineStore('app', () => {
   const enableLrclib = ref(true)
   const enableKugou = ref(true)
   const preferLocalLyrics = ref(true)
+  const lyricsFolderEnabled = ref(false)
+  const lyricsFolderPath = ref('')
   const useOnlineArtistArtwork = ref(true)
   // Round-tripped only (set by the backend's version-gated rescan); never edited
   // in the UI, but must be preserved across saves so saving settings doesn't
@@ -69,6 +71,8 @@ export const useAppStore = defineStore('app', () => {
         enableLrclib.value = settings.enable_lrclib !== false
         enableKugou.value = settings.enable_kugou !== false
         preferLocalLyrics.value = settings.prefer_local_lyrics !== false
+        lyricsFolderEnabled.value = !!settings.lyrics_folder_enabled
+        lyricsFolderPath.value = settings.lyrics_folder_path || ''
         useOnlineArtistArtwork.value = settings.use_online_artist_artwork !== false
         lastScanVersion.value = settings.last_scan_version || ''
         preventSleepWhilePlaying.value = !!settings.prevent_sleep_while_playing
@@ -136,6 +140,8 @@ export const useAppStore = defineStore('app', () => {
         enable_lrclib: enableLrclib.value,
         enable_kugou: enableKugou.value,
         prefer_local_lyrics: preferLocalLyrics.value,
+        lyrics_folder_enabled: lyricsFolderEnabled.value,
+        lyrics_folder_path: lyricsFolderPath.value,
         use_online_artist_artwork: useOnlineArtistArtwork.value,
         last_scan_version: lastScanVersion.value,
         prevent_sleep_while_playing: preventSleepWhilePlaying.value,
@@ -201,6 +207,16 @@ export const useAppStore = defineStore('app', () => {
     await saveSettings()
   }
 
+  const updateLyricsFolderEnabled = async (enabled: boolean) => {
+    lyricsFolderEnabled.value = enabled
+    await saveSettings()
+  }
+
+  const updateLyricsFolderPath = async (path: string) => {
+    lyricsFolderPath.value = path
+    await saveSettings()
+  }
+
   const updateUseOnlineArtistArtwork = async (enabled: boolean) => {
     useOnlineArtistArtwork.value = enabled
     await saveSettings()
@@ -250,6 +266,8 @@ export const useAppStore = defineStore('app', () => {
     enableLrclib,
     enableKugou,
     preferLocalLyrics,
+    lyricsFolderEnabled,
+    lyricsFolderPath,
     useOnlineArtistArtwork,
     preventSleepWhilePlaying,
     showPlayerIndicator,
@@ -274,6 +292,8 @@ export const useAppStore = defineStore('app', () => {
     updateEnableLrclib,
     updateEnableKugou,
     updatePreferLocalLyrics,
+    updateLyricsFolderEnabled,
+    updateLyricsFolderPath,
     updateUseOnlineArtistArtwork,
     updatePreventSleepWhilePlaying,
     updateShowPlayerIndicator,

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -19,6 +19,8 @@ export const useAppStore = defineStore('app', () => {
   const preferLocalLyrics = ref(true)
   const lyricsFolderEnabled = ref(false)
   const lyricsFolderPath = ref('')
+  const lyricsSubfolderEnabled = ref(false)
+  const lyricsSubfolderName = ref('')
   const useOnlineArtistArtwork = ref(true)
   // Round-tripped only (set by the backend's version-gated rescan); never edited
   // in the UI, but must be preserved across saves so saving settings doesn't
@@ -73,6 +75,8 @@ export const useAppStore = defineStore('app', () => {
         preferLocalLyrics.value = settings.prefer_local_lyrics !== false
         lyricsFolderEnabled.value = !!settings.lyrics_folder_enabled
         lyricsFolderPath.value = settings.lyrics_folder_path || ''
+        lyricsSubfolderEnabled.value = !!settings.lyrics_subfolder_enabled
+        lyricsSubfolderName.value = settings.lyrics_subfolder_name || ''
         useOnlineArtistArtwork.value = settings.use_online_artist_artwork !== false
         lastScanVersion.value = settings.last_scan_version || ''
         preventSleepWhilePlaying.value = !!settings.prevent_sleep_while_playing
@@ -142,6 +146,8 @@ export const useAppStore = defineStore('app', () => {
         prefer_local_lyrics: preferLocalLyrics.value,
         lyrics_folder_enabled: lyricsFolderEnabled.value,
         lyrics_folder_path: lyricsFolderPath.value,
+        lyrics_subfolder_enabled: lyricsSubfolderEnabled.value,
+        lyrics_subfolder_name: lyricsSubfolderName.value,
         use_online_artist_artwork: useOnlineArtistArtwork.value,
         last_scan_version: lastScanVersion.value,
         prevent_sleep_while_playing: preventSleepWhilePlaying.value,
@@ -217,6 +223,16 @@ export const useAppStore = defineStore('app', () => {
     await saveSettings()
   }
 
+  const updateLyricsSubfolderEnabled = async (enabled: boolean) => {
+    lyricsSubfolderEnabled.value = enabled
+    await saveSettings()
+  }
+
+  const updateLyricsSubfolderName = async (name: string) => {
+    lyricsSubfolderName.value = name
+    await saveSettings()
+  }
+
   const updateUseOnlineArtistArtwork = async (enabled: boolean) => {
     useOnlineArtistArtwork.value = enabled
     await saveSettings()
@@ -268,6 +284,8 @@ export const useAppStore = defineStore('app', () => {
     preferLocalLyrics,
     lyricsFolderEnabled,
     lyricsFolderPath,
+    lyricsSubfolderEnabled,
+    lyricsSubfolderName,
     useOnlineArtistArtwork,
     preventSleepWhilePlaying,
     showPlayerIndicator,
@@ -294,6 +312,8 @@ export const useAppStore = defineStore('app', () => {
     updatePreferLocalLyrics,
     updateLyricsFolderEnabled,
     updateLyricsFolderPath,
+    updateLyricsSubfolderEnabled,
+    updateLyricsSubfolderName,
     updateUseOnlineArtistArtwork,
     updatePreventSleepWhilePlaying,
     updateShowPlayerIndicator,

--- a/internal/app/lyrics/lyrics_service.go
+++ b/internal/app/lyrics/lyrics_service.go
@@ -103,13 +103,13 @@ func (s *LyricsService) SaveMetaLyrics(ctx context.Context, trackID, content, so
 // content; when false, provider content wins.
 //
 // Returns nil if nothing is available (caller may fetch from providers).
-func (s *LyricsService) ResolveLyrics(ctx context.Context, trackID, audioPath string, preferLocal bool) *domain.Lyric {
+func (s *LyricsService) ResolveLyrics(ctx context.Context, trackID, audioPath string, preferLocal bool, extraLyricsDir string) *domain.Lyric {
 	lyric, _ := s.repo.GetByTrackID(ctx, trackID)
 
 	// Build the local tier: sibling file beats embedded metadata tag.
 	var localContent, localSource string
 	if s.localReader != nil {
-		if content, source, found := s.localReader.Read(audioPath); found {
+		if content, source, found := s.localReader.Read(audioPath, extraLyricsDir); found {
 			localContent, localSource = content, source
 			s.logger.Debug("local lyric file found", "track_id", trackID, "path", audioPath, "source", source)
 		} else {
@@ -162,9 +162,9 @@ func (s *LyricsService) ResolveLyrics(ctx context.Context, trackID, audioPath st
 
 // HasLocalLyrics reports whether a local-tier lyric exists for the track: a
 // sibling lyric file next to audioPath, or an embedded metadata tag in the DB.
-func (s *LyricsService) HasLocalLyrics(ctx context.Context, trackID, audioPath string) bool {
+func (s *LyricsService) HasLocalLyrics(ctx context.Context, trackID, audioPath, extraLyricsDir string) bool {
 	if s.localReader != nil {
-		if _, _, found := s.localReader.Read(audioPath); found {
+		if _, _, found := s.localReader.Read(audioPath, extraLyricsDir); found {
 			return true
 		}
 	}

--- a/internal/app/lyrics/lyrics_service.go
+++ b/internal/app/lyrics/lyrics_service.go
@@ -103,13 +103,13 @@ func (s *LyricsService) SaveMetaLyrics(ctx context.Context, trackID, content, so
 // content; when false, provider content wins.
 //
 // Returns nil if nothing is available (caller may fetch from providers).
-func (s *LyricsService) ResolveLyrics(ctx context.Context, trackID, audioPath string, preferLocal bool, extraLyricsDir string) *domain.Lyric {
+func (s *LyricsService) ResolveLyrics(ctx context.Context, trackID, audioPath string, preferLocal bool, extraDirs ...string) *domain.Lyric {
 	lyric, _ := s.repo.GetByTrackID(ctx, trackID)
 
 	// Build the local tier: sibling file beats embedded metadata tag.
 	var localContent, localSource string
 	if s.localReader != nil {
-		if content, source, found := s.localReader.Read(audioPath, extraLyricsDir); found {
+		if content, source, found := s.localReader.Read(audioPath, extraDirs...); found {
 			localContent, localSource = content, source
 			s.logger.Debug("local lyric file found", "track_id", trackID, "path", audioPath, "source", source)
 		} else {
@@ -162,9 +162,9 @@ func (s *LyricsService) ResolveLyrics(ctx context.Context, trackID, audioPath st
 
 // HasLocalLyrics reports whether a local-tier lyric exists for the track: a
 // sibling lyric file next to audioPath, or an embedded metadata tag in the DB.
-func (s *LyricsService) HasLocalLyrics(ctx context.Context, trackID, audioPath, extraLyricsDir string) bool {
+func (s *LyricsService) HasLocalLyrics(ctx context.Context, trackID, audioPath string, extraDirs ...string) bool {
 	if s.localReader != nil {
-		if _, _, found := s.localReader.Read(audioPath, extraLyricsDir); found {
+		if _, _, found := s.localReader.Read(audioPath, extraDirs...); found {
 			return true
 		}
 	}

--- a/internal/app/lyrics/lyrics_service_test.go
+++ b/internal/app/lyrics/lyrics_service_test.go
@@ -25,7 +25,7 @@ type stubLocal struct {
 	source  string
 }
 
-func (s stubLocal) Read(string) (string, string, bool) {
+func (s stubLocal) Read(string, ...string) (string, string, bool) {
 	if s.content == "" {
 		return "", "", false
 	}
@@ -93,7 +93,7 @@ func TestResolveLyrics(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			svc := newService(tc.dbLyric, tc.local)
-			got := svc.ResolveLyrics(ctx, "track1", "/music/Song.mp3", tc.preferLocal)
+			got := svc.ResolveLyrics(ctx, "track1", "/music/Song.mp3", tc.preferLocal, "")
 			if tc.wantSource == "" {
 				if got != nil {
 					t.Fatalf("expected nil, got %+v", got)

--- a/internal/app/player/lyrics_subfolder_test.go
+++ b/internal/app/player/lyrics_subfolder_test.go
@@ -1,0 +1,53 @@
+package player
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidLyricsSubfolderName(t *testing.T) {
+	cases := map[string]bool{
+		"lyrics":  true,
+		"Lyrics":  true,
+		"my lrc":  true,
+		"":        false,
+		"  ":      false,
+		".":       false,
+		"..":      false,
+		"a/b":     false,
+		`a\b`:     false,
+		"../evil": false,
+		"ok..bad": false,
+	}
+	for name, want := range cases {
+		if got := validLyricsSubfolderName(name); got != want {
+			t.Errorf("validLyricsSubfolderName(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestResolveLyricsSubdir_CaseInsensitive(t *testing.T) {
+	parent := t.TempDir()
+	// Actual folder on disk is "Lyrics"; user typed "lyrics".
+	actual := filepath.Join(parent, "Lyrics")
+	if err := os.MkdirAll(actual, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveLyricsSubdir(parent, "lyrics")
+	if got != actual {
+		t.Errorf("resolveLyricsSubdir matched case-insensitively: got %q, want %q", got, actual)
+	}
+
+	// Exact match wins without scanning.
+	if got := resolveLyricsSubdir(parent, "Lyrics"); got != actual {
+		t.Errorf("exact match: got %q, want %q", got, actual)
+	}
+
+	// No matching dir → falls back to exact join (non-existent).
+	want := filepath.Join(parent, "nope")
+	if got := resolveLyricsSubdir(parent, "nope"); got != want {
+		t.Errorf("fallback: got %q, want %q", got, want)
+	}
+}

--- a/internal/app/player/player_service.go
+++ b/internal/app/player/player_service.go
@@ -738,15 +738,20 @@ func (s *PlayerService) fetchAndEmitLyrics(track *domain.TrackDTO) {
 
 	preferLocal := settings.PreferLocalLyrics
 
+	extraDir := ""
+	if settings.LyricsFolderEnabled {
+		extraDir = settings.LyricsFolderPath
+	}
+
 	// 1. Emit the best currently-available lyric for the chosen preference.
-	lyric := s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, preferLocal)
+	lyric := s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, preferLocal, extraDir)
 	if lyric != nil {
 		s.emitLyrics(track.ID, lyric)
 	}
 
 	// 2. When local lyrics are preferred and present, they win outright. Don't
 	//    fetch providers, so nothing overrides the displayed local lyric.
-	if preferLocal && s.lyricsService.HasLocalLyrics(ctx, track.ID, track.Path) {
+	if preferLocal && s.lyricsService.HasLocalLyrics(ctx, track.ID, track.Path, extraDir) {
 		return
 	}
 
@@ -762,7 +767,7 @@ func (s *PlayerService) fetchAndEmitLyrics(track *domain.TrackDTO) {
 
 	// 4. Re-resolve so the final emit honors the preference now that provider
 	//    content may be cached. This is the single source of priority truth.
-	resolved := s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, preferLocal)
+	resolved := s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, preferLocal, extraDir)
 	if resolved != nil {
 		s.emitLyrics(track.ID, resolved)
 	}

--- a/internal/app/player/player_service.go
+++ b/internal/app/player/player_service.go
@@ -725,6 +725,41 @@ func (s *PlayerService) extractAndEmitPalette(track *domain.TrackDTO) {
 	}
 }
 
+// validLyricsSubfolderName reports whether name is a safe single path segment for
+// a lyrics subfolder next to a track. Rejects empty, path separators, and any
+// traversal so the joined path can't escape the track's directory.
+func validLyricsSubfolderName(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	if strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") {
+		return false
+	}
+	return true
+}
+
+// resolveLyricsSubdir returns the path of the lyrics subfolder named `name` inside
+// `parent`, matching case-insensitively. macOS/Windows filesystems are already
+// case-insensitive; this makes Linux (case-sensitive) behave the same, so the name
+// the user typed matches regardless of case. Falls back to the exact join if no
+// directory matches (path may not exist yet).
+func resolveLyricsSubdir(parent, name string) string {
+	exact := filepath.Join(parent, name)
+	if fi, err := os.Stat(exact); err == nil && fi.IsDir() {
+		return exact
+	}
+	entries, err := os.ReadDir(parent)
+	if err == nil {
+		for _, e := range entries {
+			if e.IsDir() && strings.EqualFold(e.Name(), name) {
+				return filepath.Join(parent, e.Name())
+			}
+		}
+	}
+	return exact
+}
+
 func (s *PlayerService) fetchAndEmitLyrics(track *domain.TrackDTO) {
 	if s.lyricsService == nil {
 		return
@@ -738,20 +773,25 @@ func (s *PlayerService) fetchAndEmitLyrics(track *domain.TrackDTO) {
 
 	preferLocal := settings.PreferLocalLyrics
 
-	extraDir := ""
-	if settings.LyricsFolderEnabled {
-		extraDir = settings.LyricsFolderPath
+	// Extra lyric dirs in priority order (sibling dir is always checked first by
+	// the reader): subfolder next to the track, then the global lyrics folder.
+	var extraDirs []string
+	if settings.LyricsSubfolderEnabled && validLyricsSubfolderName(settings.LyricsSubfolderName) {
+		extraDirs = append(extraDirs, resolveLyricsSubdir(filepath.Dir(track.Path), settings.LyricsSubfolderName))
+	}
+	if settings.LyricsFolderEnabled && settings.LyricsFolderPath != "" {
+		extraDirs = append(extraDirs, settings.LyricsFolderPath)
 	}
 
 	// 1. Emit the best currently-available lyric for the chosen preference.
-	lyric := s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, preferLocal, extraDir)
+	lyric := s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, preferLocal, extraDirs...)
 	if lyric != nil {
 		s.emitLyrics(track.ID, lyric)
 	}
 
 	// 2. When local lyrics are preferred and present, they win outright. Don't
 	//    fetch providers, so nothing overrides the displayed local lyric.
-	if preferLocal && s.lyricsService.HasLocalLyrics(ctx, track.ID, track.Path, extraDir) {
+	if preferLocal && s.lyricsService.HasLocalLyrics(ctx, track.ID, track.Path, extraDirs...) {
 		return
 	}
 
@@ -767,7 +807,7 @@ func (s *PlayerService) fetchAndEmitLyrics(track *domain.TrackDTO) {
 
 	// 4. Re-resolve so the final emit honors the preference now that provider
 	//    content may be cached. This is the single source of priority truth.
-	resolved := s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, preferLocal, extraDir)
+	resolved := s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, preferLocal, extraDirs...)
 	if resolved != nil {
 		s.emitLyrics(track.ID, resolved)
 	}

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -213,6 +213,8 @@ type AppSettings struct {
 	EnableLrclib             bool   `json:"enable_lrclib"`
 	EnableKugou              bool   `json:"enable_kugou"`
 	PreferLocalLyrics        bool   `json:"prefer_local_lyrics"`
+	LyricsFolderEnabled      bool   `json:"lyrics_folder_enabled"`
+	LyricsFolderPath         string `json:"lyrics_folder_path"`
 	UseOnlineArtistArtwork   bool   `json:"use_online_artist_artwork"`
 	LastScanVersion          string `json:"last_scan_version"`
 	PreventSleepWhilePlaying bool   `json:"prevent_sleep_while_playing"`

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -215,6 +215,8 @@ type AppSettings struct {
 	PreferLocalLyrics        bool   `json:"prefer_local_lyrics"`
 	LyricsFolderEnabled      bool   `json:"lyrics_folder_enabled"`
 	LyricsFolderPath         string `json:"lyrics_folder_path"`
+	LyricsSubfolderEnabled   bool   `json:"lyrics_subfolder_enabled"`
+	LyricsSubfolderName      string `json:"lyrics_subfolder_name"`
 	UseOnlineArtistArtwork   bool   `json:"use_online_artist_artwork"`
 	LastScanVersion          string `json:"last_scan_version"`
 	PreventSleepWhilePlaying bool   `json:"prevent_sleep_while_playing"`

--- a/internal/domain/repositories.go
+++ b/internal/domain/repositories.go
@@ -117,8 +117,11 @@ type LyricsProvider interface {
 // LocalLyricsReader reads a sibling lyric file located next to the audio file.
 // The lyric file must share the audio file's basename, differing only in extension.
 // It tries "<base>.lrc" first, then "<base>.txt". found is false if neither exists.
+// extraDirs are additional flat directories searched (in order) after the
+// sibling dir, matched by the audio file's basename. The sibling dir keeps
+// priority over extraDirs.
 type LocalLyricsReader interface {
-	Read(audioPath string) (content, source string, found bool)
+	Read(audioPath string, extraDirs ...string) (content, source string, found bool)
 }
 
 type EQRepository interface {

--- a/internal/infra/lyrics/local.go
+++ b/internal/infra/lyrics/local.go
@@ -27,7 +27,7 @@ var localCandidates = []struct {
 	{".txt", "local-txt"},
 }
 
-func (r *localReader) Read(audioPath string) (string, string, bool) {
+func (r *localReader) Read(audioPath string, extraDirs ...string) (string, string, bool) {
 	if audioPath == "" {
 		return "", "", false
 	}
@@ -35,17 +35,28 @@ func (r *localReader) Read(audioPath string) (string, string, bool) {
 	dir := filepath.Dir(audioPath)
 	base := strings.TrimSuffix(filepath.Base(audioPath), filepath.Ext(audioPath))
 
-	for _, c := range localCandidates {
-		path := filepath.Join(dir, base+c.ext)
-		data, err := os.ReadFile(path)
-		if err != nil {
+	// Sibling dir first (highest priority), then any extra dirs in order.
+	dirs := []string{dir}
+	for _, ed := range extraDirs {
+		if ed == "" || ed == dir {
 			continue
 		}
-		content := strings.TrimSpace(strings.TrimPrefix(string(data), "\ufeff"))
-		if content == "" {
-			continue
+		dirs = append(dirs, ed)
+	}
+
+	for _, d := range dirs {
+		for _, c := range localCandidates {
+			path := filepath.Join(d, base+c.ext)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+			content := strings.TrimSpace(strings.TrimPrefix(string(data), "\ufeff"))
+			if content == "" {
+				continue
+			}
+			return content, c.source, true
 		}
-		return content, c.source, true
 	}
 
 	return "", "", false

--- a/internal/infra/lyrics/local_test.go
+++ b/internal/infra/lyrics/local_test.go
@@ -81,6 +81,39 @@ func TestLocalReader_Read(t *testing.T) {
 		}
 	})
 
+	t.Run("extra dir match by basename", func(t *testing.T) {
+		dir := t.TempDir()
+		extra := t.TempDir()
+		audio := filepath.Join(dir, "Song.mp3")
+		writeFile(t, filepath.Join(extra, "Song.lrc"), "[00:01.00]from extra")
+		content, source, found := r.Read(audio, extra)
+		if !found || source != "local-lrc" || content != "[00:01.00]from extra" {
+			t.Fatalf("got (%q,%q,%v)", content, source, found)
+		}
+	})
+
+	t.Run("sibling beats extra dir", func(t *testing.T) {
+		dir := t.TempDir()
+		extra := t.TempDir()
+		audio := filepath.Join(dir, "Song.mp3")
+		writeFile(t, filepath.Join(dir, "Song.lrc"), "[00:01.00]sibling")
+		writeFile(t, filepath.Join(extra, "Song.lrc"), "[00:01.00]extra")
+		content, _, found := r.Read(audio, extra)
+		if !found || content != "[00:01.00]sibling" {
+			t.Fatalf("expected sibling to win, got %q (%v)", content, found)
+		}
+	})
+
+	t.Run("empty extra dir ignored", func(t *testing.T) {
+		dir := t.TempDir()
+		audio := filepath.Join(dir, "Song.mp3")
+		writeFile(t, filepath.Join(dir, "Song.lrc"), "[00:01.00]sibling")
+		content, _, found := r.Read(audio, "")
+		if !found || content != "[00:01.00]sibling" {
+			t.Fatalf("got %q (%v)", content, found)
+		}
+	})
+
 	t.Run("strips BOM", func(t *testing.T) {
 		dir := t.TempDir()
 		audio := filepath.Join(dir, "Song.mp3")

--- a/internal/infra/lyrics/local_test.go
+++ b/internal/infra/lyrics/local_test.go
@@ -104,6 +104,40 @@ func TestLocalReader_Read(t *testing.T) {
 		}
 	})
 
+	t.Run("priority sibling over subfolder over global", func(t *testing.T) {
+		dir := t.TempDir()
+		sub := filepath.Join(dir, "lyrics")
+		global := t.TempDir()
+		if err := os.MkdirAll(sub, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		audio := filepath.Join(dir, "Song.mp3")
+		writeFile(t, filepath.Join(dir, "Song.lrc"), "[00:01.00]sibling")
+		writeFile(t, filepath.Join(sub, "Song.lrc"), "[00:01.00]sub")
+		writeFile(t, filepath.Join(global, "Song.lrc"), "[00:01.00]global")
+		// extraDirs order: subfolder, then global
+		content, _, found := r.Read(audio, sub, global)
+		if !found || content != "[00:01.00]sibling" {
+			t.Fatalf("expected sibling, got %q (%v)", content, found)
+		}
+	})
+
+	t.Run("subfolder beats global, no sibling", func(t *testing.T) {
+		dir := t.TempDir()
+		sub := filepath.Join(dir, "lyrics")
+		global := t.TempDir()
+		if err := os.MkdirAll(sub, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		audio := filepath.Join(dir, "Song.mp3")
+		writeFile(t, filepath.Join(sub, "Song.lrc"), "[00:01.00]sub")
+		writeFile(t, filepath.Join(global, "Song.lrc"), "[00:01.00]global")
+		content, _, found := r.Read(audio, sub, global)
+		if !found || content != "[00:01.00]sub" {
+			t.Fatalf("expected sub, got %q (%v)", content, found)
+		}
+	})
+
 	t.Run("empty extra dir ignored", func(t *testing.T) {
 		dir := t.TempDir()
 		audio := filepath.Join(dir, "Song.mp3")

--- a/internal/infra/sqlite/migrations/000027_lyrics_folder.down.sql
+++ b/internal/infra/sqlite/migrations/000027_lyrics_folder.down.sql
@@ -1,2 +1,4 @@
+ALTER TABLE app_settings DROP COLUMN lyrics_subfolder_name;
+ALTER TABLE app_settings DROP COLUMN lyrics_subfolder_enabled;
 ALTER TABLE app_settings DROP COLUMN lyrics_folder_path;
 ALTER TABLE app_settings DROP COLUMN lyrics_folder_enabled;

--- a/internal/infra/sqlite/migrations/000027_lyrics_folder.down.sql
+++ b/internal/infra/sqlite/migrations/000027_lyrics_folder.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE app_settings DROP COLUMN lyrics_folder_path;
+ALTER TABLE app_settings DROP COLUMN lyrics_folder_enabled;

--- a/internal/infra/sqlite/migrations/000027_lyrics_folder.up.sql
+++ b/internal/infra/sqlite/migrations/000027_lyrics_folder.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE app_settings ADD COLUMN lyrics_folder_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE app_settings ADD COLUMN lyrics_folder_path TEXT NOT NULL DEFAULT '';

--- a/internal/infra/sqlite/migrations/000027_lyrics_folder.up.sql
+++ b/internal/infra/sqlite/migrations/000027_lyrics_folder.up.sql
@@ -1,2 +1,4 @@
 ALTER TABLE app_settings ADD COLUMN lyrics_folder_enabled BOOLEAN NOT NULL DEFAULT FALSE;
 ALTER TABLE app_settings ADD COLUMN lyrics_folder_path TEXT NOT NULL DEFAULT '';
+ALTER TABLE app_settings ADD COLUMN lyrics_subfolder_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE app_settings ADD COLUMN lyrics_subfolder_name TEXT NOT NULL DEFAULT '';

--- a/internal/infra/sqlite/settings_repository.go
+++ b/internal/infra/sqlite/settings_repository.go
@@ -18,8 +18,8 @@ func NewSettingsRepository(db *DB) domain.SettingsRepository {
 
 func (r *settingsRepository) Save(ctx context.Context, settings *domain.AppSettings) error {
 	_, err := r.db.ExecContext(ctx,
-		`INSERT INTO app_settings (id, language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, last_scan_version, enable_lrclib, enable_kugou, prefer_local_lyrics, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator, updated_at)
-		 VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		`INSERT INTO app_settings (id, language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, last_scan_version, enable_lrclib, enable_kugou, prefer_local_lyrics, lyrics_folder_enabled, lyrics_folder_path, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator, updated_at)
+		 VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		 ON CONFLICT(id) DO UPDATE SET
 		   language = excluded.language,
 		   theme = excluded.theme,
@@ -33,6 +33,8 @@ func (r *settingsRepository) Save(ctx context.Context, settings *domain.AppSetti
 		   enable_lrclib = excluded.enable_lrclib,
 		   enable_kugou = excluded.enable_kugou,
 		   prefer_local_lyrics = excluded.prefer_local_lyrics,
+		   lyrics_folder_enabled = excluded.lyrics_folder_enabled,
+		   lyrics_folder_path = excluded.lyrics_folder_path,
 		   prevent_sleep_while_playing = excluded.prevent_sleep_while_playing,
 		   remote_server_enabled = excluded.remote_server_enabled,
 		   remote_server_port = excluded.remote_server_port,
@@ -51,6 +53,8 @@ func (r *settingsRepository) Save(ctx context.Context, settings *domain.AppSetti
 		settings.EnableLrclib,
 		settings.EnableKugou,
 		settings.PreferLocalLyrics,
+		settings.LyricsFolderEnabled,
+		settings.LyricsFolderPath,
 		settings.PreventSleepWhilePlaying,
 		settings.RemoteServerEnabled,
 		settings.RemoteServerPort,
@@ -77,6 +81,8 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 		EnableLrclib             bool           `db:"enable_lrclib"`
 		EnableKugou              bool           `db:"enable_kugou"`
 		PreferLocalLyrics        bool           `db:"prefer_local_lyrics"`
+		LyricsFolderEnabled      bool           `db:"lyrics_folder_enabled"`
+		LyricsFolderPath         sql.NullString `db:"lyrics_folder_path"`
 		PreventSleepWhilePlaying bool           `db:"prevent_sleep_while_playing"`
 		RemoteServerEnabled      bool           `db:"remote_server_enabled"`
 		RemoteServerPort         int            `db:"remote_server_port"`
@@ -84,7 +90,7 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 		ShowPlayerIndicator      bool           `db:"show_player_indicator"`
 	}
 	err := r.db.GetContext(ctx, &row,
-		`SELECT language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, last_scan_version, enable_lrclib, enable_kugou, prefer_local_lyrics, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator FROM app_settings WHERE id = 1`,
+		`SELECT language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, last_scan_version, enable_lrclib, enable_kugou, prefer_local_lyrics, lyrics_folder_enabled, lyrics_folder_path, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator FROM app_settings WHERE id = 1`,
 	)
 	if err == sql.ErrNoRows {
 		return &domain.AppSettings{
@@ -117,6 +123,8 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 		EnableLrclib:             row.EnableLrclib,
 		EnableKugou:              row.EnableKugou,
 		PreferLocalLyrics:        row.PreferLocalLyrics,
+		LyricsFolderEnabled:      row.LyricsFolderEnabled,
+		LyricsFolderPath:         row.LyricsFolderPath.String,
 		UseOnlineArtistArtwork:   row.UseOnlineArtistArtwork,
 		LastScanVersion:          row.LastScanVersion,
 		PreventSleepWhilePlaying: row.PreventSleepWhilePlaying,

--- a/internal/infra/sqlite/settings_repository.go
+++ b/internal/infra/sqlite/settings_repository.go
@@ -18,8 +18,8 @@ func NewSettingsRepository(db *DB) domain.SettingsRepository {
 
 func (r *settingsRepository) Save(ctx context.Context, settings *domain.AppSettings) error {
 	_, err := r.db.ExecContext(ctx,
-		`INSERT INTO app_settings (id, language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, last_scan_version, enable_lrclib, enable_kugou, prefer_local_lyrics, lyrics_folder_enabled, lyrics_folder_path, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator, updated_at)
-		 VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		`INSERT INTO app_settings (id, language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, last_scan_version, enable_lrclib, enable_kugou, prefer_local_lyrics, lyrics_folder_enabled, lyrics_folder_path, lyrics_subfolder_enabled, lyrics_subfolder_name, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator, updated_at)
+		 VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		 ON CONFLICT(id) DO UPDATE SET
 		   language = excluded.language,
 		   theme = excluded.theme,
@@ -35,6 +35,8 @@ func (r *settingsRepository) Save(ctx context.Context, settings *domain.AppSetti
 		   prefer_local_lyrics = excluded.prefer_local_lyrics,
 		   lyrics_folder_enabled = excluded.lyrics_folder_enabled,
 		   lyrics_folder_path = excluded.lyrics_folder_path,
+		   lyrics_subfolder_enabled = excluded.lyrics_subfolder_enabled,
+		   lyrics_subfolder_name = excluded.lyrics_subfolder_name,
 		   prevent_sleep_while_playing = excluded.prevent_sleep_while_playing,
 		   remote_server_enabled = excluded.remote_server_enabled,
 		   remote_server_port = excluded.remote_server_port,
@@ -55,6 +57,8 @@ func (r *settingsRepository) Save(ctx context.Context, settings *domain.AppSetti
 		settings.PreferLocalLyrics,
 		settings.LyricsFolderEnabled,
 		settings.LyricsFolderPath,
+		settings.LyricsSubfolderEnabled,
+		settings.LyricsSubfolderName,
 		settings.PreventSleepWhilePlaying,
 		settings.RemoteServerEnabled,
 		settings.RemoteServerPort,
@@ -83,6 +87,8 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 		PreferLocalLyrics        bool           `db:"prefer_local_lyrics"`
 		LyricsFolderEnabled      bool           `db:"lyrics_folder_enabled"`
 		LyricsFolderPath         sql.NullString `db:"lyrics_folder_path"`
+		LyricsSubfolderEnabled   bool           `db:"lyrics_subfolder_enabled"`
+		LyricsSubfolderName      sql.NullString `db:"lyrics_subfolder_name"`
 		PreventSleepWhilePlaying bool           `db:"prevent_sleep_while_playing"`
 		RemoteServerEnabled      bool           `db:"remote_server_enabled"`
 		RemoteServerPort         int            `db:"remote_server_port"`
@@ -90,7 +96,7 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 		ShowPlayerIndicator      bool           `db:"show_player_indicator"`
 	}
 	err := r.db.GetContext(ctx, &row,
-		`SELECT language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, last_scan_version, enable_lrclib, enable_kugou, prefer_local_lyrics, lyrics_folder_enabled, lyrics_folder_path, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator FROM app_settings WHERE id = 1`,
+		`SELECT language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, last_scan_version, enable_lrclib, enable_kugou, prefer_local_lyrics, lyrics_folder_enabled, lyrics_folder_path, lyrics_subfolder_enabled, lyrics_subfolder_name, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator FROM app_settings WHERE id = 1`,
 	)
 	if err == sql.ErrNoRows {
 		return &domain.AppSettings{
@@ -125,6 +131,8 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 		PreferLocalLyrics:        row.PreferLocalLyrics,
 		LyricsFolderEnabled:      row.LyricsFolderEnabled,
 		LyricsFolderPath:         row.LyricsFolderPath.String,
+		LyricsSubfolderEnabled:   row.LyricsSubfolderEnabled,
+		LyricsSubfolderName:      row.LyricsSubfolderName.String,
 		UseOnlineArtistArtwork:   row.UseOnlineArtistArtwork,
 		LastScanVersion:          row.LastScanVersion,
 		PreventSleepWhilePlaying: row.PreventSleepWhilePlaying,


### PR DESCRIPTION
## Summary

Adds two independent, optional sources for local lyric files beyond the existing sibling-of-track lookup:

1. **Dedicated lyrics folder** — one user-chosen folder, searched by track basename.
2. **Per-track subfolder** — a named subfolder next to each track (e.g. `<album>/lyrics/Song.lrc`), with a validated name.

Both toggled independently in Settings → Integrations.

### Lookup priority (high → low)
`sibling .lrc/.txt` → `subfolder` → `dedicated folder` → `metadata tag` → `LRClib / KuGou`

## Details

- **Backend**: `LocalLyricsReader.Read` takes variadic `extraDirs`, scanning sibling dir first then each extra dir by basename (cross-platform `filepath.Join`). `ResolveLyrics`/`HasLocalLyrics` thread these through; `PlayerService` builds the ordered list from settings.
- **Subfolder name**: validated as a single safe path segment (no separators / `..`) and resolved **case-insensitively** (`resolveLyricsSubdir`) so Linux matches the same way macOS/Windows already do.
- **Settings/DB**: 4 new `app_settings` columns folded into migration `000027`.
- **Frontend**: store fields + updaters, Integrations UI with validated input, live example path, and a case-insensitivity hint. i18n keys added across all 12 locales.
- **UI nesting**: sub-settings rendered via a reusable `SettingExpandableRow` (animated, inset panel) so each reads as nested under its toggle.
- **Tests**: reader priority ordering, name validation, case-insensitive resolve.
- **Docs**: lyrics / settings / database catalogs updated.

## Verification

- `go build ./...`, `go test ./internal/app/lyrics/... ./internal/infra/lyrics/...`
- `vue-tsc --noEmit`, all 12 locale JSON parse
- Manual: enable each option, confirm priority and case-insensitive subfolder matching