### PR TITLE
feat(windows): add taskbar thumbnail toolbar media controls

### DIFF
--- a/catalog/architecture/README.md
+++ b/catalog/architecture/README.md
@@ -148,18 +148,27 @@ sequenceDiagram
     participant App as app/player/player_service.go
     participant Q as queue_service.go
     participant AP as audio player
+    participant EV as Wails Event bus
 
     User->>TT: clicks Play
     TT->>PS: emits play-track
     PS->>WB: playTracks(tracks, index)
     WB->>App: PlayTracks()
     App->>Q: SetQueue()
+    App->>App: loadAndPlay(track)
     App->>AP: Load(track), Play()
-    loop every 500ms
-        AP-->>PS: EmitEvent("player:status", status)
-    end
-    PS->>PS: update status, UI re-renders
+    App->>EV: Emit("player:status", status)
+    EV-->>PS: player:status event
+    PS->>PS: sync state, rAF interpolates position
+
+    Note over App,AP: 500ms ticker polls AP.GetStatus() — no status emit on tick
+    Note over App,EV: player:status re-emitted on next state change (pause/seek/track-end)
 ```
+
+The audio player never emits events. The App-layer `PlayerService` emits
+`player:status` via `application.EmitEvent` (`player_service.go`) only on discrete
+state changes; the frontend interpolates the playback position locally with
+`requestAnimationFrame` rather than from a 500ms server push.
 
 ## Asset Serving
 
@@ -221,6 +230,7 @@ The frontend lives inside a **pnpm + Turbo monorepo** rooted at the repo root. S
 | Audio backend       | SFBAudioEngine (cgo)       | miniaudio (C library) |
 | EQ support          | AVAudioEngine EQ bands     | 10-band miniaudio chain|
 | OS Now Playing      | `MPNowPlayingInfoCenter`   | Windows SMTC / Linux MPRIS (D-Bus) |
+| Taskbar controls    | Not applicable             | Windows: thumbnail toolbar (`ITaskbarList3`, `infra/wails/thumbbar_*`) |
 | App menu            | Full macOS menu bar        | File menu only        |
 | Translucent window  | NSVisualEffectView         | Not applicable        |
 | Title bar colour    | Hidden (translucent)       | Windows: `DwmSetWindowAttribute` (Linux n/a) |

--- a/catalog/player/README.md
+++ b/catalog/player/README.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-The player feature handles audio playback, queue management, shuffle/repeat modes, state persistence across app restarts, and OS-level media integration (macOS Now Playing, Windows System Media Transport Controls, Linux MPRIS). It is split between an application-layer service and platform-specific audio adapters.
+The player feature handles audio playback, queue management, shuffle/repeat modes, state persistence across app restarts, and OS-level media integration (macOS Now Playing, Windows System Media Transport Controls + taskbar thumbnail toolbar, Linux MPRIS). It is split between an application-layer service and platform-specific audio adapters.
 
 ## Files
 
@@ -20,6 +20,10 @@ The player feature handles audio playback, queue management, shuffle/repeat mode
 | `internal/infra/audio/smtc_windows.cpp`    | WinRT SMTC implementation (C-ABI, mingw)  |
 | `internal/infra/audio/smtc_windows.h`      | C-ABI bridge for the SMTC backend         |
 | `internal/infra/wails/player_service.go`   | Wails binding wrapper                    |
+| `internal/infra/wails/thumbbar_manager_windows.go` | `ThumbBarManager`: wires taskbar thumbnail buttons → player (`//go:build windows`) |
+| `internal/infra/wails/thumbbar_manager_other.go` | No-op `ThumbBarManager` stub (non-Windows) |
+| `internal/infra/wails/thumbbar_windows.cpp` | `ITaskbarList3` thumbnail-toolbar impl (GDI icons, subclass WndProc) |
+| `internal/infra/wails/thumbbar_windows.h`  | C-ABI bridge for the thumbnail toolbar    |
 | `internal/infra/power/inhibitor_darwin.go` | macOS IOPMAssertion sleep inhibitor (cgo) |
 | `internal/infra/power/inhibitor_windows.go` | Windows SetThreadExecutionState sleep inhibitor |
 | `internal/infra/power/inhibitor_linux.go`  | Linux no-op sleep inhibitor              |
@@ -173,6 +177,30 @@ On Windows the `nowPlayingBackend` is `smtcBackend` (`player_nowplaying_windows.
   to `PlayerService` through the `goWinNowPlaying*` cgo exports.
 - **Teardown:** `MiniAudioPlayer.Close()` (called by `PlayerService` OnStop) posts quit, drains
   queued payloads, releases interfaces, and joins the thread. Idempotent.
+
+### Windows — Taskbar Thumbnail Toolbar (`internal/infra/wails/`)
+
+Separate from SMTC: adds **Prev / Play-Pause / Next** buttons to the taskbar
+thumbnail popup (hover preview) via `ITaskbarList3::ThumbBarAddButtons`. Lives in the
+**wails adapter layer** (not `infra/audio`), wired in `main.go`.
+
+- **Files:** `thumbbar_windows.cpp` / `.h` (C++ COM impl), `thumbbar_manager_windows.go`
+  (`ThumbBarManager`, `//go:build windows`), `thumbbar_manager_other.go` (no-op stub for
+  non-Windows), `cgoflags_thumbbar_windows*.go` (link libs).
+- **Init timing:** `Setup()` registers a `WindowFocus` hook (`once.Do`). The hook fires on a
+  goroutine, so actual init is dispatched via `application.InvokeAsync` onto the Win32 **message
+  thread** — the only thread valid for `SetWindowSubclass` and COM. Uses the Wails main-window
+  HWND (`mainWindow.NativeWindow()`), unlike SMTC which owns its own hidden window.
+- **COM:** `CoInitializeEx(APARTMENTTHREADED)` then `CoCreateInstance(CLSID_TaskbarList)` →
+  `ITaskbarList3`. `SetWindowSubclass` intercepts `WM_COMMAND` (`THBN_CLICKED`) for button clicks
+  and `WM_TASKBARBUTTONCREATED` to re-add buttons after an Explorer restart.
+- **Icons:** white 16×16 top-down 32bpp DIBs on transparent background (Prev/Play/Pause/Next),
+  drawn with GDI `Polygon`/`Rectangle`.
+- **Wiring:** buttons → `PlayerService.Previous` / `TogglePause` / `Next` (each in a goroutine to
+  avoid blocking the message thread). A status listener calls `ThumbBarSetPlaying` to swap the
+  play/pause icon. Clicks routed back to Go through `goThumbBar*` cgo exports.
+- **Teardown:** `Stop()` (called before `stopFX()` in `main.go`) → `ThumbBarStop` removes the
+  subclass and releases COM resources.
 
 ### Linux — MPRIS (Now Playing)
 

--- a/internal/infra/wails/cgoflags_thumbbar_windows.go
+++ b/internal/infra/wails/cgoflags_thumbbar_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package wails
+
+// CGO linker flags for thumbbar_windows.cpp (Windows Taskbar Thumbnail Toolbar).
+//
+//   -lcomctl32  SetWindowSubclass / DefSubclassProc / RemoveWindowSubclass
+//   -lole32     CoInitializeEx / CoCreateInstance / CoUninitialize
+//   -luuid      CLSID_TaskbarList / IID_ITaskbarList3 GUIDs
+
+/*
+#cgo LDFLAGS: -lcomctl32 -lgdi32 -lole32 -luuid
+*/
+import "C"

--- a/internal/infra/wails/cgoflags_thumbbar_windows_amd64.go
+++ b/internal/infra/wails/cgoflags_thumbbar_windows_amd64.go
@@ -1,0 +1,11 @@
+//go:build windows && amd64
+
+package wails
+
+// Statically link the MinGW C++/pthread runtime so thumbbar_windows.cpp (C++)
+// does not require libstdc++-6.dll / libgcc_s_seh-1.dll at runtime.
+
+/*
+#cgo LDFLAGS: -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -static-libgcc
+*/
+import "C"

--- a/internal/infra/wails/cgoflags_thumbbar_windows_arm64.go
+++ b/internal/infra/wails/cgoflags_thumbbar_windows_arm64.go
@@ -1,0 +1,12 @@
+//go:build windows && arm64
+
+package wails
+
+// llvm-mingw (arm64) uses libc++/libunwind instead of libstdc++/libgcc.
+// Suppress the redundant dllexport attribute warning clang emits for //export.
+
+/*
+#cgo CFLAGS: -Wno-dll-attribute-on-redeclaration
+#cgo LDFLAGS: -Wl,-Bstatic -lc++ -lc++abi -lunwind -lpthread -Wl,-Bdynamic
+*/
+import "C"

--- a/internal/infra/wails/thumbbar_manager_other.go
+++ b/internal/infra/wails/thumbbar_manager_other.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package wails
+
+import (
+	"airmedy/internal/app/player"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+// ThumbBarManager is a no-op stub on non-Windows platforms.
+type ThumbBarManager struct{}
+
+func NewThumbBarManager(_ *player.PlayerService) *ThumbBarManager {
+	return &ThumbBarManager{}
+}
+
+func (m *ThumbBarManager) Setup(_ *application.WebviewWindow) {}
+func (m *ThumbBarManager) Stop()                              {}

--- a/internal/infra/wails/thumbbar_manager_windows.go
+++ b/internal/infra/wails/thumbbar_manager_windows.go
@@ -1,0 +1,116 @@
+//go:build windows
+
+package wails
+
+/*
+#include "thumbbar_windows.h"
+*/
+import "C"
+import (
+	"log/slog"
+	"sync"
+	"unsafe"
+
+	"airmedy/internal/app/player"
+	"airmedy/internal/domain"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+	"github.com/wailsapp/wails/v3/pkg/events"
+)
+
+var (
+	thumbMu   sync.Mutex
+	thumbPrev func()
+	thumbPP   func()
+	thumbNext func()
+)
+
+//export goThumbBarPrev
+func goThumbBarPrev() {
+	thumbMu.Lock()
+	cb := thumbPrev
+	thumbMu.Unlock()
+	if cb != nil {
+		cb()
+	}
+}
+
+//export goThumbBarPlayPause
+func goThumbBarPlayPause() {
+	thumbMu.Lock()
+	cb := thumbPP
+	thumbMu.Unlock()
+	if cb != nil {
+		cb()
+	}
+}
+
+//export goThumbBarNext
+func goThumbBarNext() {
+	thumbMu.Lock()
+	cb := thumbNext
+	thumbMu.Unlock()
+	if cb != nil {
+		cb()
+	}
+}
+
+// ThumbBarManager wires Windows Taskbar Thumbnail Toolbar buttons to the player.
+type ThumbBarManager struct {
+	playerService *player.PlayerService
+}
+
+func NewThumbBarManager(ps *player.PlayerService) *ThumbBarManager {
+	return &ThumbBarManager{playerService: ps}
+}
+
+// Setup registers player callbacks and defers the HWND-dependent init until
+// after wailsApp.Run() starts. The WindowFocus hook fires on a goroutine
+// (not the message thread), so ThumbBarInit is dispatched via InvokeAsync
+// to the Win32 message thread — the only thread where SetWindowSubclass and
+// COM objects are valid.
+func (m *ThumbBarManager) Setup(mainWindow *application.WebviewWindow) {
+	// Callbacks invoked from the subclass WndProc (message thread).
+	// Spawn goroutines to avoid blocking the message thread.
+	thumbMu.Lock()
+	thumbPrev = func() { go func() { _ = m.playerService.Previous() }() }
+	thumbPP = func() { go func() { _ = m.playerService.TogglePause() }() }
+	thumbNext = func() { go func() { _ = m.playerService.Next() }() }
+	thumbMu.Unlock()
+
+	m.playerService.AddStatusListener(func(s domain.PlayerStatus) {
+		v := C.int(0)
+		if s.PlaybackState == domain.PlaybackStatePlaying {
+			v = 1
+		}
+		C.ThumbBarSetPlaying(v)
+	})
+
+	// WindowFocus fires on a goroutine after Run() starts the message loop.
+	// Use InvokeAsync to move the actual init onto the message thread so that
+	// SetWindowSubclass and ITaskbarList3 are created on the correct thread.
+	var once sync.Once
+	mainWindow.RegisterHook(events.Common.WindowFocus, func(_ *application.WindowEvent) {
+		once.Do(func() {
+			application.InvokeAsync(func() {
+				hwnd := uintptr(mainWindow.NativeWindow())
+				slog.Info("thumbbar: init on message thread", "hwnd", hwnd)
+				if hwnd == 0 {
+					slog.Warn("thumbbar: null HWND on message thread, skipping")
+					return
+				}
+				playing := C.int(0)
+				if m.playerService.GetStatus().PlaybackState == domain.PlaybackStatePlaying {
+					playing = 1
+				}
+				C.ThumbBarInit(unsafe.Pointer(hwnd), playing) //nolint:unsafeptr
+			})
+		})
+	})
+}
+
+// Stop removes the window subclass and releases all COM resources.
+func (m *ThumbBarManager) Stop() {
+	C.ThumbBarStop()
+	slog.Debug("thumbbar: stopped")
+}

--- a/internal/infra/wails/thumbbar_windows.cpp
+++ b/internal/infra/wails/thumbbar_windows.cpp
@@ -1,0 +1,248 @@
+// thumbbar_windows.cpp — Windows Taskbar Thumbnail Toolbar (Prev/Play-Pause/Next).
+//
+// Displays three media-control buttons inside the taskbar preview popup using
+// ITaskbarList3::ThumbBarAddButtons. Button clicks arrive as WM_COMMAND messages
+// and are forwarded to Go via the goThumbBar* exports. Play/pause icon updates
+// are posted from arbitrary goroutines via PostMessageW → WM_TB_SETPLAYING.
+//
+// Threading: ThumbBarInit is always called via application.InvokeAsync, which
+// guarantees execution on the Win32 message thread. All COM work is done
+// synchronously in ThumbBarInit on that thread. ThumbBarUpdateButtons runs in
+// the subclass WndProc — also on the message thread — so the COM STA is shared.
+
+#undef  _WIN32_WINNT
+#define _WIN32_WINNT 0x0601
+#undef  NTDDI_VERSION
+#define NTDDI_VERSION 0x06010000
+
+#include <windows.h>
+#include <commctrl.h>
+#include <shobjidl.h>
+#include <objbase.h>
+
+#include <cstdio>
+#include <cstring>
+
+#include "thumbbar_windows.h"
+
+namespace {
+
+constexpr UINT     TB_ID_PREV       = 1;
+constexpr UINT     TB_ID_PLAYPAUSE  = 2;
+constexpr UINT     TB_ID_NEXT       = 3;
+constexpr UINT     THBN_CLICKED_VAL = 0x1800;
+constexpr UINT     WM_TB_SETPLAYING = WM_APP + 10;
+constexpr UINT_PTR SUBCLASS_ID      = 0xA171;
+
+static HWND           g_hwnd         = nullptr;
+static UINT           g_wmTBCreated  = 0;
+static int            g_isPlaying    = 0;
+static bool           g_subclassed   = false;
+
+// The taskbar thumbnail popup is always dark regardless of the app theme,
+// so white icons are always correct.
+static const COLORREF g_fgColor      = RGB(255, 255, 255);
+
+// All touched only on the message thread.
+static ITaskbarList3* g_taskbar      = nullptr;
+static HICON          g_icoPlay      = nullptr;
+static HICON          g_icoPause     = nullptr;
+static HICON          g_icoPrev      = nullptr;
+static HICON          g_icoNext      = nullptr;
+static bool           g_buttonsAdded = false;
+
+static void TBDbg(const char* fmt, ...) {
+    char buf[256];
+    va_list ap; va_start(ap, fmt); vsnprintf(buf, sizeof buf, fmt, ap); va_end(ap);
+    buf[sizeof buf - 1] = '\0';
+    char tagged[288];
+    snprintf(tagged, sizeof tagged, "[thumbbar] %s\n", buf);
+    OutputDebugStringA(tagged);
+}
+
+// ---- GDI icon factory ------------------------------------------------------
+
+struct IconCtx { HDC dc; HBITMAP bmp; DWORD* bits; };
+
+static IconCtx MakeIconDC() {
+    IconCtx ctx{};
+    BITMAPINFO bmi{};
+    bmi.bmiHeader.biSize        = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biWidth       = 16;
+    bmi.bmiHeader.biHeight      = -16;
+    bmi.bmiHeader.biPlanes      = 1;
+    bmi.bmiHeader.biBitCount    = 32;
+    bmi.bmiHeader.biCompression = BI_RGB;
+    ctx.dc  = CreateCompatibleDC(nullptr);
+    ctx.bmp = CreateDIBSection(ctx.dc, &bmi, DIB_RGB_COLORS,
+                               reinterpret_cast<void**>(&ctx.bits), nullptr, 0);
+    SelectObject(ctx.dc, ctx.bmp);
+    memset(ctx.bits, 0, 16 * 16 * 4);
+    return ctx;
+}
+
+static HICON FinalizeIcon(IconCtx& ctx) {
+    // Black pixels stay transparent; all other pixels become fully opaque.
+    for (int i = 0; i < 256; i++)
+        if (ctx.bits[i] & 0x00FFFFFFu) ctx.bits[i] |= 0xFF000000u;
+    HBITMAP hMask = CreateBitmap(16, 16, 1, 1, nullptr);
+    ICONINFO ii{ TRUE, 0, 0, hMask, ctx.bmp };
+    HICON icon = CreateIconIndirect(&ii);
+    DeleteObject(hMask);
+    DeleteObject(ctx.bmp);
+    DeleteDC(ctx.dc);
+    return icon;
+}
+
+// Select the foreground color brush; background stays transparent (black = 0).
+static void BeginDraw(HDC dc) {
+    SelectObject(dc, CreateSolidBrush(g_fgColor));
+    SelectObject(dc, GetStockObject(NULL_PEN));
+}
+
+static void RightTri(HDC dc, int xtip, int ymid, int xb, int yt, int yb) {
+    POINT p[3] = {{xtip,ymid},{xb,yt},{xb,yb}}; Polygon(dc, p, 3);
+}
+static void LeftTri(HDC dc, int xtip, int ymid, int xb, int yt, int yb) {
+    POINT p[3] = {{xtip,ymid},{xb,yt},{xb,yb}}; Polygon(dc, p, 3);
+}
+
+static HICON MakePlayIcon()  { IconCtx c=MakeIconDC(); BeginDraw(c.dc); RightTri(c.dc,13,8,2,1,15);                              return FinalizeIcon(c); }
+static HICON MakePauseIcon() { IconCtx c=MakeIconDC(); BeginDraw(c.dc); Rectangle(c.dc,2,2,6,14); Rectangle(c.dc,10,2,14,14);    return FinalizeIcon(c); }
+static HICON MakePrevIcon()  { IconCtx c=MakeIconDC(); BeginDraw(c.dc); Rectangle(c.dc,1,2,4,14); LeftTri(c.dc,4,8,13,1,15);    return FinalizeIcon(c); }
+static HICON MakeNextIcon()  { IconCtx c=MakeIconDC(); BeginDraw(c.dc); RightTri(c.dc,11,8,2,1,15); Rectangle(c.dc,12,2,15,14); return FinalizeIcon(c); }
+
+// ---- button management -----------------------------------------------------
+
+static void DoAddButtons() {
+    if (!g_taskbar || g_buttonsAdded || !g_hwnd) return;
+
+    THUMBBUTTON btns[3]{};
+    btns[0] = {THB_ICON|THB_TOOLTIP|THB_FLAGS, TB_ID_PREV,      0, g_icoPrev,  {}, THBF_ENABLED};
+    btns[1] = {THB_ICON|THB_TOOLTIP|THB_FLAGS, TB_ID_PLAYPAUSE, 0, g_isPlaying ? g_icoPause : g_icoPlay, {}, THBF_ENABLED};
+    btns[2] = {THB_ICON|THB_TOOLTIP|THB_FLAGS, TB_ID_NEXT,      0, g_icoNext,  {}, THBF_ENABLED};
+    wcsncpy(btns[0].szTip, L"Previous", 259);
+    wcsncpy(btns[1].szTip, g_isPlaying ? L"Pause" : L"Play", 259);
+    wcsncpy(btns[2].szTip, L"Next", 259);
+
+    HRESULT hr = g_taskbar->ThumbBarAddButtons(g_hwnd, 3, btns);
+    if (SUCCEEDED(hr)) { g_buttonsAdded = true; TBDbg("ThumbBarAddButtons OK"); }
+    else                { TBDbg("ThumbBarAddButtons FAILED 0x%08X", (unsigned)hr); }
+}
+
+static void DoUpdatePlayPause(int playing) {
+    g_isPlaying = playing;
+    if (!g_buttonsAdded || !g_taskbar || !g_hwnd) return;
+
+    THUMBBUTTON btn{};
+    btn.dwMask  = THB_ICON | THB_TOOLTIP | THB_FLAGS;
+    btn.iId     = TB_ID_PLAYPAUSE;
+    btn.hIcon   = playing ? g_icoPause : g_icoPlay;
+    wcsncpy(btn.szTip, playing ? L"Pause" : L"Play", 259);
+    btn.dwFlags = THBF_ENABLED;
+
+    HRESULT hr = g_taskbar->ThumbBarUpdateButtons(g_hwnd, 1, &btn);
+    TBDbg("ThumbBarUpdateButtons %s", SUCCEEDED(hr) ? "OK" : "FAIL");
+}
+
+// ---- subclass WndProc ------------------------------------------------------
+
+static LRESULT CALLBACK ThumbSubclassProc(
+    HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
+    UINT_PTR uIdSubclass, DWORD_PTR)
+{
+    if (msg == g_wmTBCreated && g_wmTBCreated != 0) {
+        TBDbg("WM_TASKBARBUTTONCREATED — re-adding buttons");
+        g_buttonsAdded = false;
+        DoAddButtons();
+        return 0;
+    }
+    if (msg == WM_TB_SETPLAYING) {
+        DoUpdatePlayPause(static_cast<int>(wParam));
+        return 0;
+    }
+    if (msg == WM_COMMAND && HIWORD(wParam) == THBN_CLICKED_VAL) {
+        switch (LOWORD(wParam)) {
+            case TB_ID_PREV:      TBDbg("prev");      goThumbBarPrev();      return 0;
+            case TB_ID_PLAYPAUSE: TBDbg("playpause"); goThumbBarPlayPause(); return 0;
+            case TB_ID_NEXT:      TBDbg("next");      goThumbBarNext();      return 0;
+        }
+    }
+    if (msg == WM_DESTROY)
+        RemoveWindowSubclass(hwnd, ThumbSubclassProc, uIdSubclass);
+
+    return DefSubclassProc(hwnd, msg, wParam, lParam);
+}
+
+}  // namespace
+
+// ---- public C ABI ----------------------------------------------------------
+
+extern "C" {
+
+// ThumbBarInit must be called on the Win32 message thread (via InvokeAsync).
+// All COM work is done synchronously here; the subclass handles future events.
+void ThumbBarInit(void* hwnd, int playing) {
+    if (g_subclassed) { TBDbg("already init"); return; }
+    if (!hwnd)        { TBDbg("null HWND");    return; }
+
+    g_hwnd      = static_cast<HWND>(hwnd);
+    g_isPlaying = playing;
+
+    g_wmTBCreated = RegisterWindowMessageW(L"TaskbarButtonCreated");
+    if (g_wmTBCreated)
+        ChangeWindowMessageFilterEx(g_hwnd, g_wmTBCreated, MSGFLT_ALLOW, nullptr);
+
+    // COM — called on the message thread. S_FALSE = already init'd; fine.
+    // RPC_E_CHANGED_MODE = different model (MTA); ITaskbarList3 still works.
+    HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    if (FAILED(hr) && hr != (HRESULT)RPC_E_CHANGED_MODE) {
+        TBDbg("CoInitializeEx FAILED 0x%08X", (unsigned)hr);
+        return;
+    }
+
+    hr = CoCreateInstance(CLSID_TaskbarList, nullptr, CLSCTX_INPROC_SERVER,
+                          IID_ITaskbarList3, reinterpret_cast<void**>(&g_taskbar));
+    if (FAILED(hr) || !g_taskbar) { TBDbg("CoCreateInstance FAILED 0x%08X", (unsigned)hr); return; }
+
+    hr = g_taskbar->HrInit();
+    if (FAILED(hr)) { TBDbg("HrInit FAILED 0x%08X", (unsigned)hr); g_taskbar->Release(); g_taskbar=nullptr; return; }
+
+    g_icoPlay  = MakePlayIcon();
+    g_icoPause = MakePauseIcon();
+    g_icoPrev  = MakePrevIcon();
+    g_icoNext  = MakeNextIcon();
+
+    // Install subclass for WM_COMMAND (clicks), WM_TB_SETPLAYING (updates),
+    // and WM_TASKBARBUTTONCREATED (Explorer restart). Called on message thread ✓
+    if (!SetWindowSubclass(g_hwnd, ThumbSubclassProc, SUBCLASS_ID, 0)) {
+        TBDbg("SetWindowSubclass FAILED %lu", GetLastError());
+    }
+    g_subclassed = true;
+
+    // Add buttons synchronously — we're on the message thread and COM is ready.
+    // If Explorer hasn't built the taskbar button yet, WM_TASKBARBUTTONCREATED
+    // will arrive and DoAddButtons() will retry.
+    DoAddButtons();
+    TBDbg("ThumbBarInit done (playing=%d, buttonsAdded=%d)", playing, (int)g_buttonsAdded);
+}
+
+void ThumbBarSetPlaying(int playing) {
+    if (g_subclassed && g_hwnd)
+        PostMessageW(g_hwnd, WM_TB_SETPLAYING, static_cast<WPARAM>(playing), 0);
+}
+
+void ThumbBarStop(void) {
+    if (!g_subclassed) return;
+    g_subclassed = false;
+    if (g_hwnd) { RemoveWindowSubclass(g_hwnd, ThumbSubclassProc, SUBCLASS_ID); g_hwnd = nullptr; }
+    if (g_taskbar) { g_taskbar->Release(); g_taskbar = nullptr; }
+    if (g_icoPlay)  { DestroyIcon(g_icoPlay);  g_icoPlay  = nullptr; }
+    if (g_icoPause) { DestroyIcon(g_icoPause); g_icoPause = nullptr; }
+    if (g_icoPrev)  { DestroyIcon(g_icoPrev);  g_icoPrev  = nullptr; }
+    if (g_icoNext)  { DestroyIcon(g_icoNext);  g_icoNext  = nullptr; }
+    g_buttonsAdded = false;
+    TBDbg("ThumbBarStop done");
+}
+
+}  // extern "C"

--- a/internal/infra/wails/thumbbar_windows.h
+++ b/internal/infra/wails/thumbbar_windows.h
@@ -1,0 +1,39 @@
+/*
+ * thumbbar_windows.h — C-ABI bridge for Windows Taskbar Thumbnail Toolbar.
+ *
+ * Implemented in thumbbar_windows.cpp (compiled by CXX/g++ via cgo). The Go
+ * layer (thumbbar_manager_windows.go) calls ThumbBar*; the native layer calls
+ * back into the goThumbBar* functions exported from Go.
+ *
+ * Displays Prev / Play-Pause / Next buttons in the taskbar thumbnail popup.
+ */
+#ifndef THUMBBAR_WINDOWS_H
+#define THUMBBAR_WINDOWS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Initialize the thumbnail toolbar for the given HWND.
+ * Must be called on the Win32 message thread (via application.InvokeAsync).
+ * playing != 0 → initial icon shows Pause; else Play. */
+void ThumbBarInit(void* hwnd, int playing);
+
+/* Thread-safe: posts a message to the window thread.
+ * playing != 0 → show Pause icon; else Play icon. */
+void ThumbBarSetPlaying(int playing);
+
+/* Remove the subclass, release COM objects, destroy icons. */
+void ThumbBarStop(void);
+
+/* Implemented in Go (thumbbar_manager_windows.go). Invoked from the
+ * subclass WndProc on WM_COMMAND / THBN_CLICKED on the main message thread. */
+extern void goThumbBarPrev(void);
+extern void goThumbBarPlayPause(void);
+extern void goThumbBarNext(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* THUMBBAR_WINDOWS_H */

--- a/main.go
+++ b/main.go
@@ -209,6 +209,9 @@ func main() {
 	mainWindow.Show()
 	mainWindow.Focus()
 
+	thumbBarMgr := wails.NewThumbBarManager(playerService.GetService())
+	thumbBarMgr.Setup(mainWindow)
+
 	windowService.SetMiniWindowFactory(func() *application.WebviewWindow {
 		w := wailsApp.Window.NewWithOptions(application.WebviewWindowOptions{
 			Title:               "Mini Player",
@@ -345,6 +348,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	thumbBarMgr.Stop()
 	stopFX()
 }
 


### PR DESCRIPTION
Add Prev / Play-Pause / Next buttons to the Windows taskbar thumbnail popup using ITaskbarList3::ThumbBarAddButtons.

- C++ implementation with SetWindowSubclass to intercept WM_COMMAND (THBN_CLICKED) and PostMessageW for thread-safe play state updates
- COM initialised synchronously on the Win32 message thread via application.InvokeAsync inside a WindowFocus hook (once.Do)
- WM_TASKBARBUTTONCREATED handled to re-add buttons after Explorer restart
- White GDI icons (16x16 top-down 32bpp DIB) on transparent background: Prev, Play, Pause, Next drawn with Polygon/Rectangle
- Go ThumbBarManager wires buttons to PlayerService.Previous, TogglePause, Next; status listener drives play/pause icon swap
- No-op stub for non-Windows platforms