### PR TITLE
fix(lyrics): auto-scroll synced view + tint artist hero from artwork

### DIFF
--- a/catalog/artwork/README.md
+++ b/catalog/artwork/README.md
@@ -50,7 +50,7 @@ Variants are used by the frontend: `sm` for mini player and track rows, `md` for
 
 ## Palette Extraction (`palette.go`)
 
-Called via `LibraryService.GetAlbumColors(albumID)` — fetches colors from cached artwork.
+Called via `LibraryService.GetAlbumColors(albumID)` or `LibraryService.GetArtistColors(artistID)` — fetches colors from cached artwork. The artist variant resolves the artist's displayed artwork key (`Artist.ResolveArtworkKey(preferLocal)`) before extraction.
 
 ### Algorithm
 
@@ -157,6 +157,9 @@ On every change it emits a global `artist-artwork-updated` Wails event
 `{ artist_id, source, key }` (empty `key` = cleared). `ArtistCard.vue` keeps a
 reactive copy of the three keys, updates the changed slot, and recomputes the
 displayed image — so live changes and preference toggles both reflect instantly.
+`ArtistDetailView.vue` also listens for this event and re-runs
+`GetArtistColors` so the hero tint follows async artwork changes (e.g. a Deezer
+fetch completing).
 
 ### Local file scan
 

--- a/catalog/library/README.md
+++ b/catalog/library/README.md
@@ -78,6 +78,7 @@ ReindexAll(): void                       // rebuild Bleve index from DB
 GetSyncStatus(): SyncProgress | null     // stub; used for frontend type generation
 // Metadata & artwork
 GetAlbumColors(id: string): ThemeColors
+GetArtistColors(id: string): ThemeColors | null   // palette of artist's resolved artwork
 GetArtistArtwork(artistID: string, eventID: string): string | null
 SelectAndSetArtistArtwork(artistID: string): string   // pick file → manual artwork
 RemoveArtistArtwork(artistID: string): void           // clear custom artwork

--- a/catalog/ui/README.md
+++ b/catalog/ui/README.md
@@ -100,6 +100,11 @@ root.style.setProperty("--dynamic-glow", hexToRgba(vibrant, 0.4));
 
 Transition: `1.5s ease-in-out` for smooth color shifts between tracks.
 
+Detail views override `--dynamic-surface` locally on their own hero element so
+the tint reflects the viewed entity, not the playing track: `DetailHero.vue`
+(albums/playlists, via a `theme` prop) and `ArtistDetailView.vue` (artist, via
+`GetArtistColors`). Each falls back to `var(--bg-glass)` when no colors.
+
 ## Glass-Morphism Implementation
 
 ```css

--- a/frontend/src/components/SyncedLyricsView.vue
+++ b/frontend/src/components/SyncedLyricsView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import type { LyricLine } from '../composables/useLyrics'
 
 const props = defineProps<{
@@ -21,15 +21,29 @@ const activeIndex = computed(() => {
 const scrollContainer = ref<HTMLElement | null>(null)
 const lineRefs = ref<HTMLElement[]>([])
 
-watch(activeIndex, (newIndex) => {
-  if (newIndex === -1 || !lineRefs.value[newIndex] || !scrollContainer.value) return
+// Reset stale refs when the track's lines change so indexes stay aligned.
+watch(() => props.lines, () => {
+  lineRefs.value = []
+})
+
+function scrollToActive(index: number) {
+  if (index === -1) return
   const container = scrollContainer.value
-  const el = lineRefs.value[newIndex]
+  const el = lineRefs.value[index]
+  // Container may be hidden (clientHeight 0) or refs not laid out yet.
+  if (!container || !el || container.clientHeight === 0) return
   container.scrollTo({
     top: el.offsetTop - container.clientHeight / 2 + el.clientHeight / 2,
     behavior: 'smooth',
   })
-})
+}
+
+// flush:'post' → DOM patched + layout settled before measuring offsets.
+// immediate + nextTick handles first paint and the lyrics-just-loaded race
+// where the active line exists before its ref is populated.
+watch(activeIndex, (newIndex) => {
+  nextTick(() => scrollToActive(newIndex))
+}, { flush: 'post', immediate: true })
 </script>
 
 <template>

--- a/frontend/src/views/ArtistDetailView.vue
+++ b/frontend/src/views/ArtistDetailView.vue
@@ -4,11 +4,13 @@ import { useContextMenu } from '@/composables/useContextMenu'
 import { useGroupContextMenu } from '@/composables/useGroupContextMenu'
 import { sortTracksGrouped } from '@/lib/trackSort'
 import { DetailsButton } from '@airmedy/ui'
+import { hexToRgba } from '@airmedy/utils'
 import { Disc, ImagePlus, MoreVertical, Music, Play, Shuffle, Trash2 } from 'lucide-vue-next'
-import { computed, onMounted, ref, shallowRef, watch } from 'vue'
+import { Events } from '@wailsio/runtime'
+import { computed, onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
-import type { AlbumDTO, Artist, TrackDTO } from '../../bindings/airmedy/internal/domain/models'
+import type { AlbumDTO, Artist, ThemeColors, TrackDTO } from '../../bindings/airmedy/internal/domain/models'
 import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
 import ContextMenu from '../components/ContextMenu.vue'
 import GroupedAlbumList from '../components/GroupedAlbumList.vue'
@@ -22,6 +24,7 @@ const playerStore = usePlayerStore()
 const artist = ref<Artist | null>(null)
 const albums = shallowRef<AlbumDTO[]>([])
 const tracks = shallowRef<TrackDTO[]>([])
+const artistTheme = shallowRef<ThemeColors | null>(null)
 const isLoading = ref(true)
 
 const contextMenu = useContextMenu()
@@ -32,8 +35,18 @@ function openContextMenu(e: MouseEvent) {
   contextMenu.open(e, buildMenuItems(tracks.value))
 }
 
+const loadTheme = async (id: string) => {
+  artistTheme.value = null
+  try {
+    artistTheme.value = await LibraryService.GetArtistColors(id)
+  } catch (err) {
+    console.error('Failed to load artist colors:', err)
+  }
+}
+
 const loadArtistDetails = async (id: string) => {
   isLoading.value = true
+  loadTheme(id)
   try {
     const [artistData, albumsData, tracksData] = await Promise.all([
       LibraryService.GetArtistByID(id),
@@ -92,9 +105,24 @@ function openArtworkMenu(e: MouseEvent) {
   ])
 }
 
+let offArtworkUpdated: (() => void) | null = null
+
 onMounted(() => {
   const id = route.params.id as string
   if (id) loadArtistDetails(id)
+
+  // Artwork can change asynchronously (e.g. Deezer online fetch completes);
+  // re-extract colors so the hero tint follows the new image.
+  offArtworkUpdated = Events.On('artist-artwork-updated', (ev) => {
+    const data = ev.data as { artist_id?: string } | undefined
+    if (data?.artist_id && data.artist_id === artist.value?.id) {
+      loadTheme(data.artist_id)
+    }
+  })
+})
+
+onUnmounted(() => {
+  if (offArtworkUpdated) offArtworkUpdated()
 })
 
 watch(() => route.params.id, (newId) => {
@@ -111,7 +139,8 @@ watch(() => route.params.id, (newId) => {
     <div v-else-if="artist" class="flex-1 overflow-y-auto">
       <!-- Artist Hero Section -->
       <div
-        class="p-8 md:p-12 flex flex-col md:flex-row gap-8 items-center bg-gradient-to-b from-dynamic-surface to-transparent border-b border-foreground/[0.06]">
+        class="p-8 md:p-12 flex flex-col md:flex-row gap-8 items-center bg-gradient-to-b from-dynamic-surface to-transparent border-b border-foreground/[0.06]"
+        :style="{ '--dynamic-surface': artistTheme ? hexToRgba(artistTheme.dominant, 0.15) : 'var(--bg-glass)' }">
         <div
           class="group relative w-32 h-32 xl:w-42 xl:h-42 rounded-full shadow-2xl overflow-hidden ring-2 ring-foreground/[0.08] bg-foreground/5 flex-shrink-0"
           @contextmenu="openArtworkMenu">

--- a/internal/infra/wails/library_service.go
+++ b/internal/infra/wails/library_service.go
@@ -9,6 +9,7 @@ import (
 
 	"airmedy/internal/app/library"
 	"airmedy/internal/domain"
+	"airmedy/internal/infra/artwork"
 	"github.com/wailsapp/wails/v3/pkg/application"
 )
 
@@ -286,6 +287,25 @@ func (s *LibraryService) UpdateTrackMetadata(trackID string, update domain.Metad
 
 func (s *LibraryService) GetAlbumColors(id string) (*domain.ThemeColors, error) {
 	return s.libService.GetAlbumColors(context.Background(), id)
+}
+
+// GetArtistColors returns the theme colors for an artist's resolved artwork.
+func (s *LibraryService) GetArtistColors(id string) (*domain.ThemeColors, error) {
+	ctx := context.Background()
+	artist, err := s.artistRepo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if artist == nil {
+		return nil, fmt.Errorf("artist not found: %s", id)
+	}
+
+	key := artist.ResolveArtworkKey(s.preferLocalArtistArtwork(ctx))
+	if key == "" {
+		return nil, nil
+	}
+
+	return artwork.ExtractPalette(s.artworkCache.GetPath(key))
 }
 
 func (s *LibraryService) GetArtistArtwork(artistID, eventID string) (*string, error) {


### PR DESCRIPTION
## Summary

- Fix synced lyrics view so it auto-scrolls reliably to the active line
- Tint the artist hero background using colors extracted from artist artwork
- Document `GetArtistColors` and the per-view hero tint behavior in the catalog

## Changes

- **fix(lyrics):** synced view now tracks the current line and keeps it in view
- **feat(artist):** hero header derives its tint from artist artwork colors
- **docs(catalog):** document `GetArtistColors` and per-view hero tint
