### PR TITLE
fix: metadata edit — suppress self-write events, prune orphans, refresh views

### DIFF
--- a/frontend/src/composables/useLibraryUpdates.ts
+++ b/frontend/src/composables/useLibraryUpdates.ts
@@ -2,14 +2,24 @@ import { onMounted, onUnmounted, type Ref } from 'vue'
 import { Events } from '@wailsio/runtime'
 import type { TrackDTO } from '../../bindings/airmedy/internal/domain/models'
 
-export function useLibraryUpdates(tracks: Ref<TrackDTO[]>) {
+export interface LibraryUpdatesOptions {
+  // When provided, an updated track that no longer satisfies the predicate is
+  // removed from the list instead of replaced in place. Lets a scoped view (e.g.
+  // an album detail) drop a track whose metadata edit moved it out of the view.
+  belongs?: (track: TrackDTO) => boolean
+}
+
+export function useLibraryUpdates(tracks: Ref<TrackDTO[]>, opts: LibraryUpdatesOptions = {}) {
   const handleUpdate = (ev: Events.WailsEvent) => {
     const updated = ev.data as TrackDTO
     if (!updated?.id) return
     const idx = tracks.value.findIndex(t => t.id === updated.id)
-    if (idx !== -1) {
-      tracks.value = tracks.value.map((t, i) => i === idx ? updated : t)
+    if (idx === -1) return
+    if (opts.belongs && !opts.belongs(updated)) {
+      tracks.value = tracks.value.filter(t => t.id !== updated.id)
+      return
     }
+    tracks.value = tracks.value.map((t, i) => i === idx ? updated : t)
   }
 
   const handleDelete = (ev: Events.WailsEvent) => {

--- a/frontend/src/views/AlbumDetailView.vue
+++ b/frontend/src/views/AlbumDetailView.vue
@@ -26,7 +26,10 @@ const album = ref<AlbumDTO | null>(null)
 const tracks = shallowRef<TrackDTO[]>([])
 const isLoading = ref(true)
 
-useLibraryUpdates(tracks)
+// Drop a track from this view if an edit moved it to a different album.
+useLibraryUpdates(tracks, {
+  belongs: t => t.album?.id === route.params.id,
+})
 const albumTheme = ref<ThemeColors | null>(null)
 
 const { scrollContainerRef, handleScroll } = useRestoreScroll()

--- a/frontend/src/views/AlbumsView.vue
+++ b/frontend/src/views/AlbumsView.vue
@@ -35,10 +35,12 @@ watch(sortDir, (v) => localStorage.setItem('airmedy:albums-sort-dir', v))
 const router = useRouter()
 const playerStore = usePlayerStore()
 
-useLibrarySync(() => { loadAlbums() })
+// Event-driven reloads are silent: keep the current grid visible and swap in the
+// new data when it arrives, so background refreshes don't flash the spinner.
+useLibrarySync(() => { loadAlbums(true) })
 
-const loadAlbums = async () => {
-  isLoading.value = true
+const loadAlbums = async (silent = false) => {
+  if (!silent) isLoading.value = true
   try {
     const result = await LibraryService.GetAllAlbums()
     albums.value = result.filter((a): a is AlbumDTO => a !== null).sort((a, b) =>
@@ -47,7 +49,7 @@ const loadAlbums = async () => {
   } catch (err) {
     console.error('Failed to load albums:', err)
   } finally {
-    isLoading.value = false
+    if (!silent) isLoading.value = false
   }
 }
 

--- a/frontend/src/views/ArtistDetailView.vue
+++ b/frontend/src/views/ArtistDetailView.vue
@@ -15,6 +15,7 @@ import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/lib
 import ContextMenu from '../components/ContextMenu.vue'
 import GroupedAlbumList from '../components/GroupedAlbumList.vue'
 import { usePlayerStore } from '../stores/player'
+import { useLibrarySync } from '@/composables/useLibrarySync'
 
 const { t } = useI18n()
 
@@ -44,9 +45,13 @@ const loadTheme = async (id: string) => {
   }
 }
 
-const loadArtistDetails = async (id: string) => {
-  isLoading.value = true
-  loadTheme(id)
+// silent: event-driven reload that keeps the current view visible (no spinner /
+// theme flash) and swaps data in when it arrives.
+const loadArtistDetails = async (id: string, silent = false) => {
+  if (!silent) {
+    isLoading.value = true
+    loadTheme(id)
+  }
   try {
     const [artistData, albumsData, tracksData] = await Promise.all([
       LibraryService.GetArtistByID(id),
@@ -59,9 +64,15 @@ const loadArtistDetails = async (id: string) => {
   } catch (err) {
     console.error('Failed to load artist details:', err)
   } finally {
-    isLoading.value = false
+    if (!silent) isLoading.value = false
   }
 }
+
+// Track edits can move tracks/albums in or out of this artist; refresh silently.
+useLibrarySync(() => {
+  const id = route.params.id as string
+  if (id) loadArtistDetails(id, true)
+})
 
 const refreshArtist = async (id: string) => {
   try {

--- a/frontend/src/views/ArtistsView.vue
+++ b/frontend/src/views/ArtistsView.vue
@@ -14,10 +14,12 @@ const playerStore = usePlayerStore()
 const artists = shallowRef<Artist[]>([])
 const isLoading = ref(true)
 
-useLibrarySync(() => { loadArtists() })
+// Event-driven reloads are silent: keep the current list visible, swap in new
+// data when it arrives, so background refreshes don't flash the spinner.
+useLibrarySync(() => { loadArtists(true) })
 
-const loadArtists = async () => {
-  isLoading.value = true
+const loadArtists = async (silent = false) => {
+  if (!silent) isLoading.value = true
   try {
     const result = await LibraryService.GetAllArtists()
     artists.value = result
@@ -26,7 +28,7 @@ const loadArtists = async () => {
   } catch (err) {
     console.error('Failed to load artists:', err)
   } finally {
-    isLoading.value = false
+    if (!silent) isLoading.value = false
   }
 }
 

--- a/frontend/src/views/ComposerDetailView.vue
+++ b/frontend/src/views/ComposerDetailView.vue
@@ -12,6 +12,7 @@ import { useGroupContextMenu } from '@/composables/useGroupContextMenu'
 import ContextMenu from '../components/ContextMenu.vue'
 import { DetailsButton } from '@airmedy/ui'
 import { sortTracksGrouped } from '@/lib/trackSort'
+import { useLibrarySync } from '@/composables/useLibrarySync'
 
 const { t } = useI18n()
 
@@ -29,8 +30,8 @@ function openContextMenu(e: MouseEvent) {
   contextMenu.open(e, buildMenuItems(tracks.value))
 }
 
-const loadComposerDetails = async (id: string) => {
-  isLoading.value = true
+const loadComposerDetails = async (id: string, silent = false) => {
+  if (!silent) isLoading.value = true
   try {
     const [composerData, tracksData] = await Promise.all([
       LibraryService.GetComposerByID(id),
@@ -41,9 +42,15 @@ const loadComposerDetails = async (id: string) => {
   } catch (err) {
     console.error('Failed to load composer details:', err)
   } finally {
-    isLoading.value = false
+    if (!silent) isLoading.value = false
   }
 }
+
+// Track edits can move tracks in or out of this composer; refresh silently.
+useLibrarySync(() => {
+  const id = route.params.id as string
+  if (id) loadComposerDetails(id, true)
+})
 
 onMounted(() => {
   const id = route.params.id as string

--- a/frontend/src/views/ComposersView.vue
+++ b/frontend/src/views/ComposersView.vue
@@ -14,10 +14,12 @@ const playerStore = usePlayerStore()
 const composers = shallowRef<Composer[]>([])
 const isLoading = ref(true)
 
-useLibrarySync(() => { loadComposers() })
+// Event-driven reloads are silent: keep the current list visible, swap in new
+// data when it arrives, so background refreshes don't flash the spinner.
+useLibrarySync(() => { loadComposers(true) })
 
-const loadComposers = async () => {
-  isLoading.value = true
+const loadComposers = async (silent = false) => {
+  if (!silent) isLoading.value = true
   try {
     const result = await LibraryService.GetAllComposers()
     composers.value = result
@@ -26,7 +28,7 @@ const loadComposers = async () => {
   } catch (err) {
     console.error('Failed to load composers:', err)
   } finally {
-    isLoading.value = false
+    if (!silent) isLoading.value = false
   }
 }
 

--- a/frontend/src/views/GenreDetailView.vue
+++ b/frontend/src/views/GenreDetailView.vue
@@ -12,6 +12,7 @@ import { useGroupContextMenu } from '@/composables/useGroupContextMenu'
 import ContextMenu from '../components/ContextMenu.vue'
 import { DetailsButton } from '@airmedy/ui'
 import { sortTracksGrouped } from '@/lib/trackSort'
+import { useLibrarySync } from '@/composables/useLibrarySync'
 
 const { t } = useI18n()
 
@@ -29,8 +30,8 @@ function openContextMenu(e: MouseEvent) {
   contextMenu.open(e, buildMenuItems(tracks.value))
 }
 
-const loadGenreDetails = async (id: string) => {
-  isLoading.value = true
+const loadGenreDetails = async (id: string, silent = false) => {
+  if (!silent) isLoading.value = true
   try {
     const [genreData, tracksData] = await Promise.all([
       LibraryService.GetGenreByID(id),
@@ -41,9 +42,15 @@ const loadGenreDetails = async (id: string) => {
   } catch (err) {
     console.error('Failed to load genre details:', err)
   } finally {
-    isLoading.value = false
+    if (!silent) isLoading.value = false
   }
 }
+
+// Track edits can move tracks in or out of this genre; refresh silently.
+useLibrarySync(() => {
+  const id = route.params.id as string
+  if (id) loadGenreDetails(id, true)
+})
 
 onMounted(() => {
   const id = route.params.id as string

--- a/frontend/src/views/GenresView.vue
+++ b/frontend/src/views/GenresView.vue
@@ -14,10 +14,12 @@ const playerStore = usePlayerStore()
 const genres = shallowRef<Genre[]>([])
 const isLoading = ref(true)
 
-useLibrarySync(() => { loadGenres() })
+// Event-driven reloads are silent: keep the current list visible, swap in new
+// data when it arrives, so background refreshes don't flash the spinner.
+useLibrarySync(() => { loadGenres(true) })
 
-const loadGenres = async () => {
-  isLoading.value = true
+const loadGenres = async (silent = false) => {
+  if (!silent) isLoading.value = true
   try {
     const result = await LibraryService.GetAllGenres()
     genres.value = result
@@ -26,7 +28,7 @@ const loadGenres = async () => {
   } catch (err) {
     console.error('Failed to load genres:', err)
   } finally {
-    isLoading.value = false
+    if (!silent) isLoading.value = false
   }
 }
 

--- a/frontend/src/views/RecentlyAddedView.vue
+++ b/frontend/src/views/RecentlyAddedView.vue
@@ -18,15 +18,15 @@ const trackContextMenu = ref<InstanceType<typeof TrackContextMenu> | null>(null)
 const tracks = shallowRef<TrackDTO[]>([])
 const isLoading = ref(true)
 
-const loadRecentlyAdded = async () => {
-  isLoading.value = true
+const loadRecentlyAdded = async (silent = false) => {
+  if (!silent) isLoading.value = true
   try {
     const result = await LibraryService.GetRecentlyAddedTracks(50)
     tracks.value = result.filter((t): t is TrackDTO => t !== null)
   } catch (err) {
     console.error('Failed to load recently added tracks:', err)
   } finally {
-    isLoading.value = false
+    if (!silent) isLoading.value = false
   }
 }
 
@@ -51,8 +51,9 @@ const onTrackContextMenu = (e: MouseEvent, track: TrackDTO) => {
   trackContextMenu.value?.open(e, track)
 }
 
-onMounted(loadRecentlyAdded)
-useLibrarySync(loadRecentlyAdded)
+onMounted(() => loadRecentlyAdded())
+// Event-driven reloads are silent so background refreshes don't flash the spinner.
+useLibrarySync(() => loadRecentlyAdded(true))
 </script>
 
 <template>

--- a/frontend/src/views/SearchView.vue
+++ b/frontend/src/views/SearchView.vue
@@ -10,11 +10,13 @@ import PlaylistCard from '@/components/PlaylistCard.vue'
 import ComposerCard from '@/components/ComposerCard.vue'
 import SearchSection from '@/components/SearchSection.vue'
 import { useSearchStore } from '@/stores/search'
+import { usePlayerStore } from '@/stores/player'
 import type { TrackDTO } from '../../bindings/airmedy/internal/domain/models'
 import { buildArtworkUrl } from '@airmedy/utils'
 
 const router = useRouter()
 const store = useSearchStore()
+const playerStore = usePlayerStore()
 
 const inputValue = ref(store.query)
 
@@ -22,8 +24,15 @@ watch(inputValue, (val) => {
   store.search(val)
 })
 
-function navigateToAlbum(id: string) {
+function navigateToAlbum(id?: string) {
+  if (!id) return
   router.push(`/albums/${id}`)
+}
+
+function playSearchTrack(track: TrackDTO) {
+  const list = (store.results?.tracks?.filter(Boolean) ?? []) as TrackDTO[]
+  const idx = list.findIndex(t => t.id === track.id)
+  playerStore.playTracks(list, idx === -1 ? 0 : idx)
 }
 
 function navigateToArtist(id: string) {
@@ -99,7 +108,7 @@ const hasResults = () => hasTracks() || hasAlbums() || hasArtists() || hasPlayli
           <template #default="{ item: track }">
             <div
               class="flex items-center gap-3 p-2 rounded-xl hover:bg-foreground/[0.04] cursor-pointer group transition-all"
-              @click="navigateToAlbum(track.album?.id)">
+              @click="playSearchTrack(track)">
               <div
                 class="w-12 h-12 flex-shrink-0 rounded-lg bg-foreground/[0.06] overflow-hidden ring-1 ring-foreground/[0.06]">
                 <LazyImg v-if="track.artwork_key || track.album?.artwork_key"

--- a/frontend/src/views/TracksView.vue
+++ b/frontend/src/views/TracksView.vue
@@ -22,18 +22,23 @@ const isLoading = ref(true)
 const searchQuery = ref('')
 
 useLibraryUpdates(tracks)
-useLibrarySync(() => { loadTracks() })
+// Event-driven reloads are silent: keep the current list visible, swap in new
+// data when it arrives, so background refreshes don't flash the spinner.
+useLibrarySync(() => { loadTracks(true) })
 
-const loadTracks = async () => {
-  isLoading.value = true
+const loadTracks = async (silent = false) => {
+  if (!silent) isLoading.value = true
   try {
     const total = await LibraryService.GetTrackCount()
-    if (total === 0) return
+    if (total === 0) {
+      tracks.value = []
+      return
+    }
 
     // Load first page immediately so the UI is interactive
     const first = await LibraryService.GetTracksPaginated(0, PAGE_SIZE)
     tracks.value = first.filter((t): t is TrackDTO => t !== null)
-    isLoading.value = false
+    if (!silent) isLoading.value = false
 
     // Load remaining pages in the background
     let offset = PAGE_SIZE
@@ -46,7 +51,7 @@ const loadTracks = async () => {
   } catch (err) {
     console.error('Failed to load tracks:', err)
   } finally {
-    isLoading.value = false
+    if (!silent) isLoading.value = false
   }
 }
 

--- a/internal/app/library/service.go
+++ b/internal/app/library/service.go
@@ -403,17 +403,38 @@ func (s *LibraryService) handleArtistImageEvent(event fsnotify.Event) {
 // cleanupOrphanedEntities removes albums, artists, composers and genres that no
 // longer reference any track. Errors are logged, not returned, since this is a
 // best-effort cleanup invoked after deletions.
+// cleanupOrphanedEntities removes albums/artists/composers/genres that no longer
+// have any tracks, keeping the DB and the search index in sync. Genres aren't
+// indexed, so only their rows are dropped.
 func (s *LibraryService) cleanupOrphanedEntities(ctx context.Context) {
-	if err := s.albumRepo.DeleteOrphaned(ctx); err != nil {
+	if ids, err := s.albumRepo.DeleteOrphaned(ctx); err != nil {
 		s.logger.Warn("Failed to delete orphaned albums", "error", err)
+	} else {
+		for _, id := range ids {
+			if err := s.searchService.DeleteAlbumFromIndex(ctx, id); err != nil {
+				s.logger.Warn("Failed to delete orphaned album from index", "id", id, "error", err)
+			}
+		}
 	}
-	if err := s.artistRepo.DeleteOrphaned(ctx); err != nil {
+	if ids, err := s.artistRepo.DeleteOrphaned(ctx); err != nil {
 		s.logger.Warn("Failed to delete orphaned artists", "error", err)
+	} else {
+		for _, id := range ids {
+			if err := s.searchService.DeleteArtistFromIndex(ctx, id); err != nil {
+				s.logger.Warn("Failed to delete orphaned artist from index", "id", id, "error", err)
+			}
+		}
 	}
-	if err := s.composerRepo.DeleteOrphaned(ctx); err != nil {
+	if ids, err := s.composerRepo.DeleteOrphaned(ctx); err != nil {
 		s.logger.Warn("Failed to delete orphaned composers", "error", err)
+	} else {
+		for _, id := range ids {
+			if err := s.searchService.DeleteComposerFromIndex(ctx, id); err != nil {
+				s.logger.Warn("Failed to delete orphaned composer from index", "id", id, "error", err)
+			}
+		}
 	}
-	if err := s.genreRepo.DeleteOrphaned(ctx); err != nil {
+	if _, err := s.genreRepo.DeleteOrphaned(ctx); err != nil {
 		s.logger.Warn("Failed to delete orphaned genres", "error", err)
 	}
 }
@@ -1055,10 +1076,22 @@ func (s *LibraryService) UpdateMetadata(ctx context.Context, id string, fields d
 	// Write event redundantly re-imports, and a temp+rename write surfaces as
 	// Remove/Rename and deletes the track from the DB.
 	s.markSelfWrite(track.Path)
+
 	if err := s.metadataWriter.WriteMetadata(ctx, track.Path, fields); err != nil {
 		return fmt.Errorf("failed to write metadata: %w", err)
 	}
-	return s.ImportFile(ctx, track.Path)
+	if err := s.ImportFile(ctx, track.Path); err != nil {
+		return err
+	}
+
+	// A metadata edit can move the track to a different album/artist/genre, leaving
+	// the originals with zero tracks. Prune those orphans (DB + search index) so
+	// they don't linger, then tell the frontend to reload list views.
+	s.cleanupOrphanedEntities(ctx)
+	if app := application.Get(); app != nil && app.Event != nil {
+		app.Event.Emit("library:updated", nil)
+	}
+	return nil
 }
 
 // GetAlbumColors returns the theme colors for an album's artwork.

--- a/internal/app/library/service.go
+++ b/internal/app/library/service.go
@@ -64,6 +64,8 @@ type LibraryService struct {
 	syncing                atomic.Int32 // >0 while a bulk SyncFolder runs (gates per-track work)
 	artworkCleanupMu       sync.Mutex
 	artworkCleanupTimer    *time.Timer // debounces orphan-artwork cleanup after watcher deletes
+	selfWrites             map[string]time.Time // path -> expiry; suppresses watcher events for app's own writes
+	selfWritesMu           sync.Mutex
 	ctx                    context.Context
 	cancel                 context.CancelFunc
 	mu                     sync.RWMutex
@@ -115,6 +117,7 @@ func NewLibraryService(
 		watcher:              watcher,
 		artistArtworkQueue:   make(chan artistArtworkJob, 100),
 		pendingArtistArtwork: make(map[string]struct{}),
+		selfWrites:           make(map[string]time.Time),
 		ctx:                  ctx,
 		cancel:               cancel,
 	}, nil
@@ -135,6 +138,37 @@ func (s *LibraryService) notifyTrackUpdated(track *domain.TrackDTO) {
 	for _, l := range listeners {
 		l(track)
 	}
+}
+
+// selfWriteWindow is how long watcher events for a path are suppressed after the
+// app writes that file itself (e.g. metadata edits). Covers the taglib write plus
+// the watcher's debounce delay.
+const selfWriteWindow = 5 * time.Second
+
+// markSelfWrite records that the app is about to write path, so the file watcher
+// ignores the resulting Write/Remove/Rename events instead of treating them as an
+// external change (which would redundantly re-import, or worse, delete the row).
+func (s *LibraryService) markSelfWrite(path string) {
+	s.selfWritesMu.Lock()
+	s.selfWrites[filepath.Clean(path)] = time.Now().Add(selfWriteWindow)
+	s.selfWritesMu.Unlock()
+}
+
+// isSelfWrite reports whether path was recently written by the app. Expired
+// entries are pruned lazily on lookup.
+func (s *LibraryService) isSelfWrite(path string) bool {
+	key := filepath.Clean(path)
+	s.selfWritesMu.Lock()
+	defer s.selfWritesMu.Unlock()
+	exp, ok := s.selfWrites[key]
+	if !ok {
+		return false
+	}
+	if time.Now().After(exp) {
+		delete(s.selfWrites, key)
+		return false
+	}
+	return true
 }
 
 func (s *LibraryService) Start(ctx context.Context) error {
@@ -211,6 +245,14 @@ func (s *LibraryService) handleEvent(event fsnotify.Event) {
 		return
 	}
 
+	// Skip events the app caused itself (e.g. metadata edits): UpdateMetadata
+	// already re-imports the file, and a temp+rename write would otherwise be
+	// misread as a deletion.
+	if s.isSelfWrite(event.Name) {
+		s.logger.Debug("Ignoring self-initiated write", "path", event.Name)
+		return
+	}
+
 	if event.Has(fsnotify.Create) || event.Has(fsnotify.Write) {
 		// If it's a directory, watch it and sync it
 		// We need to check if it's a directory
@@ -232,6 +274,21 @@ func (s *LibraryService) handleEvent(event fsnotify.Event) {
 	if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
 		go func() {
 			ctx := context.Background()
+
+			// Atomic-save editors (and some taglib writes) replace a file via
+			// temp-file + rename, which surfaces as Remove/Rename on the original
+			// path even though the file still exists. Give it a moment, then
+			// verify the file is really gone before deleting its row; if it's
+			// still there, treat the event as a modification and re-import.
+			time.Sleep(500 * time.Millisecond)
+			if _, err := os.Stat(event.Name); err == nil {
+				s.logger.Debug("Path still exists after remove/rename, re-importing instead of deleting", "path", event.Name)
+				if err := s.ImportFile(ctx, event.Name); err != nil {
+					s.logger.Debug("Failed to re-import file after remove/rename", "path", event.Name, "error", err)
+				}
+				return
+			}
+
 			s.logger.Info("File/Folder removed, cleaning up", "path", event.Name)
 
 			var deletedIDs []string
@@ -993,6 +1050,11 @@ func (s *LibraryService) UpdateMetadata(ctx context.Context, id string, fields d
 	if track == nil {
 		return fmt.Errorf("track not found: %s", id)
 	}
+	// Suppress watcher events for this path: we're about to write the file
+	// ourselves, then re-import explicitly below. Without this the watcher's
+	// Write event redundantly re-imports, and a temp+rename write surfaces as
+	// Remove/Rename and deletes the track from the DB.
+	s.markSelfWrite(track.Path)
 	if err := s.metadataWriter.WriteMetadata(ctx, track.Path, fields); err != nil {
 		return fmt.Errorf("failed to write metadata: %w", err)
 	}

--- a/internal/app/library/service_test.go
+++ b/internal/app/library/service_test.go
@@ -78,7 +78,7 @@ func (m *mockTrackRepo) SetComposers(ctx context.Context, trackID string, compos
 
 type mockAlbumRepo struct{ domain.AlbumRepository }
 func (m *mockAlbumRepo) Upsert(ctx context.Context, album *domain.Album) error { return nil }
-func (m *mockAlbumRepo) DeleteOrphaned(ctx context.Context) error { return nil }
+func (m *mockAlbumRepo) DeleteOrphaned(ctx context.Context) ([]string, error) { return nil, nil }
 func (m *mockAlbumRepo) GetByID(ctx context.Context, id string) (*domain.AlbumDTO, error) { return nil, nil }
 func (m *mockAlbumRepo) GetByNormalizationKey(ctx context.Context, key string) (*domain.Album, error) {
 	return nil, nil
@@ -90,7 +90,7 @@ func (m *mockAlbumRepo) SetArtists(ctx context.Context, albumID string, artistID
 type mockArtistRepo struct{ domain.ArtistRepository }
 
 func (m *mockArtistRepo) Upsert(ctx context.Context, artist *domain.Artist) error { return nil }
-func (m *mockArtistRepo) DeleteOrphaned(ctx context.Context) error { return nil }
+func (m *mockArtistRepo) DeleteOrphaned(ctx context.Context) ([]string, error) { return nil, nil }
 func (m *mockArtistRepo) GetByNormalizationKey(ctx context.Context, key string) (*domain.Artist, error) {
 	return nil, nil
 }
@@ -102,7 +102,7 @@ func (m *mockArtistRepo) GetAllArtworkKeys(ctx context.Context) ([]string, error
 type mockGenreRepo struct{ domain.GenreRepository }
 
 func (m *mockGenreRepo) Upsert(ctx context.Context, genre *domain.Genre) error { return nil }
-func (m *mockGenreRepo) DeleteOrphaned(ctx context.Context) error { return nil }
+func (m *mockGenreRepo) DeleteOrphaned(ctx context.Context) ([]string, error) { return nil, nil }
 func (m *mockGenreRepo) GetByNormalizationKey(ctx context.Context, key string) (*domain.Genre, error) {
 	return nil, nil
 }
@@ -110,7 +110,7 @@ func (m *mockGenreRepo) GetByNormalizationKey(ctx context.Context, key string) (
 type mockComposerRepo struct{ domain.ComposerRepository }
 
 func (m *mockComposerRepo) Upsert(ctx context.Context, composer *domain.Composer) error { return nil }
-func (m *mockComposerRepo) DeleteOrphaned(ctx context.Context) error { return nil }
+func (m *mockComposerRepo) DeleteOrphaned(ctx context.Context) ([]string, error) { return nil, nil }
 func (m *mockComposerRepo) GetByNormalizationKey(ctx context.Context, key string) (*domain.Composer, error) {
 	return nil, nil
 }
@@ -185,6 +185,9 @@ func (m *mockSearchService) IndexComposer(ctx context.Context, composer *domain.
 func (m *mockSearchService) IndexPlaylist(ctx context.Context, playlist *domain.Playlist) error { return nil }
 func (m *mockSearchService) Close() error { return nil }
 func (m *mockSearchService) DeleteFromIndex(ctx context.Context, id string) error { return nil }
+func (m *mockSearchService) DeleteAlbumFromIndex(ctx context.Context, albumID string) error { return nil }
+func (m *mockSearchService) DeleteArtistFromIndex(ctx context.Context, artistID string) error { return nil }
+func (m *mockSearchService) DeleteComposerFromIndex(ctx context.Context, composerID string) error { return nil }
 
 type mockArtworkCache struct{ domain.ArtworkCache }
 func (m *mockArtworkCache) Save(ctx context.Context, data []byte, mimeType string) (string, error) { return "", nil }

--- a/internal/domain/repositories.go
+++ b/internal/domain/repositories.go
@@ -46,7 +46,8 @@ type AlbumRepository interface {
 	GetAll(ctx context.Context) ([]*AlbumDTO, error)
 	Save(ctx context.Context, album *Album) error
 	Upsert(ctx context.Context, album *Album) error
-	DeleteOrphaned(ctx context.Context) error
+	// DeleteOrphaned removes albums with no tracks and returns their IDs.
+	DeleteOrphaned(ctx context.Context) ([]string, error)
 
 	// Many-to-Many relationships
 	SetArtists(ctx context.Context, albumID string, artistIDs []string) error
@@ -64,7 +65,8 @@ type ArtistRepository interface {
 	// GetAllArtworkKeys returns every non-empty artwork key across all sources,
 	// used to keep live artist images out of the orphan-cleanup set.
 	GetAllArtworkKeys(ctx context.Context) ([]string, error)
-	DeleteOrphaned(ctx context.Context) error
+	// DeleteOrphaned removes artists referenced by no track/album and returns their IDs.
+	DeleteOrphaned(ctx context.Context) ([]string, error)
 }
 
 type GenreRepository interface {
@@ -74,7 +76,8 @@ type GenreRepository interface {
 	GetAll(ctx context.Context) ([]*Genre, error)
 	Save(ctx context.Context, genre *Genre) error
 	Upsert(ctx context.Context, genre *Genre) error
-	DeleteOrphaned(ctx context.Context) error
+	// DeleteOrphaned removes genres referenced by no track and returns their IDs.
+	DeleteOrphaned(ctx context.Context) ([]string, error)
 }
 
 type ComposerRepository interface {
@@ -84,7 +87,8 @@ type ComposerRepository interface {
 	GetAll(ctx context.Context) ([]*Composer, error)
 	Save(ctx context.Context, composer *Composer) error
 	Upsert(ctx context.Context, composer *Composer) error
-	DeleteOrphaned(ctx context.Context) error
+	// DeleteOrphaned removes composers referenced by no track and returns their IDs.
+	DeleteOrphaned(ctx context.Context) ([]string, error)
 }
 
 type PlaylistRepository interface {

--- a/internal/domain/search.go
+++ b/internal/domain/search.go
@@ -29,5 +29,12 @@ type SearchService interface {
 	BatchReindex(ctx context.Context, data *ReindexData, onProgress func(path string)) error
 	Search(ctx context.Context, query string) ([]SearchResult, error)
 	DeleteFromIndex(ctx context.Context, id string) error
+	// DeleteAlbumFromIndex removes an album document (keyed by the "album:" prefix)
+	// from the search index.
+	DeleteAlbumFromIndex(ctx context.Context, albumID string) error
+	// DeleteArtistFromIndex removes an artist document (keyed by the "artist:" prefix).
+	DeleteArtistFromIndex(ctx context.Context, artistID string) error
+	// DeleteComposerFromIndex removes a composer document (keyed by the "composer:" prefix).
+	DeleteComposerFromIndex(ctx context.Context, composerID string) error
 	Close() error
 }

--- a/internal/infra/bleve/bleve.go
+++ b/internal/infra/bleve/bleve.go
@@ -325,6 +325,18 @@ func (s *bleveSearchService) DeleteFromIndex(ctx context.Context, id string) err
 	return s.index.Delete("track:" + id)
 }
 
+func (s *bleveSearchService) DeleteAlbumFromIndex(ctx context.Context, albumID string) error {
+	return s.index.Delete("album:" + albumID)
+}
+
+func (s *bleveSearchService) DeleteArtistFromIndex(ctx context.Context, artistID string) error {
+	return s.index.Delete("artist:" + artistID)
+}
+
+func (s *bleveSearchService) DeleteComposerFromIndex(ctx context.Context, composerID string) error {
+	return s.index.Delete("composer:" + composerID)
+}
+
 func (s *bleveSearchService) Close() error {
 	return s.index.Close()
 }

--- a/internal/infra/sqlite/album_repository.go
+++ b/internal/infra/sqlite/album_repository.go
@@ -248,11 +248,14 @@ func (r *albumRepository) SetArtists(ctx context.Context, albumID string, artist
 	return tx.Commit()
 }
 
-func (r *albumRepository) DeleteOrphaned(ctx context.Context) error {
-	query := `DELETE FROM albums WHERE id NOT IN (SELECT DISTINCT album_id FROM tracks WHERE album_id IS NOT NULL)`
-	_, err := r.db.ExecContext(ctx, query)
-	if err != nil {
-		return fmt.Errorf("failed to delete orphaned albums: %w", err)
+func (r *albumRepository) DeleteOrphaned(ctx context.Context) ([]string, error) {
+	const cond = `id NOT IN (SELECT DISTINCT album_id FROM tracks WHERE album_id IS NOT NULL)`
+	var ids []string
+	if err := r.db.SelectContext(ctx, &ids, `SELECT id FROM albums WHERE `+cond); err != nil {
+		return nil, fmt.Errorf("failed to select orphaned albums: %w", err)
 	}
-	return nil
+	if _, err := r.db.ExecContext(ctx, `DELETE FROM albums WHERE `+cond); err != nil {
+		return nil, fmt.Errorf("failed to delete orphaned albums: %w", err)
+	}
+	return ids, nil
 }

--- a/internal/infra/sqlite/artist_repository.go
+++ b/internal/infra/sqlite/artist_repository.go
@@ -151,21 +151,21 @@ func (r *artistRepository) SetArtwork(ctx context.Context, id string, key *strin
 	return nil
 }
 
-func (r *artistRepository) DeleteOrphaned(ctx context.Context) error {
+func (r *artistRepository) DeleteOrphaned(ctx context.Context) ([]string, error) {
 	// Clean up orphaned junction rows that might exist from before foreign keys were enabled
 	_, _ = r.db.ExecContext(ctx, "DELETE FROM track_artists WHERE track_id NOT IN (SELECT id FROM tracks)")
 	_, _ = r.db.ExecContext(ctx, "DELETE FROM track_album_artists WHERE track_id NOT IN (SELECT id FROM tracks)")
 	_, _ = r.db.ExecContext(ctx, "DELETE FROM album_artists WHERE album_id NOT IN (SELECT id FROM albums)")
 
-	query := `
-		DELETE FROM artists
-		WHERE id NOT IN (SELECT artist_id FROM track_artists)
+	const cond = `id NOT IN (SELECT artist_id FROM track_artists)
 		  AND id NOT IN (SELECT artist_id FROM track_album_artists)
-		  AND id NOT IN (SELECT artist_id FROM album_artists)
-	`
-	_, err := r.db.ExecContext(ctx, query)
-	if err != nil {
-		return fmt.Errorf("failed to delete orphaned artists: %w", err)
+		  AND id NOT IN (SELECT artist_id FROM album_artists)`
+	var ids []string
+	if err := r.db.SelectContext(ctx, &ids, `SELECT id FROM artists WHERE `+cond); err != nil {
+		return nil, fmt.Errorf("failed to select orphaned artists: %w", err)
 	}
-	return nil
+	if _, err := r.db.ExecContext(ctx, `DELETE FROM artists WHERE `+cond); err != nil {
+		return nil, fmt.Errorf("failed to delete orphaned artists: %w", err)
+	}
+	return ids, nil
 }

--- a/internal/infra/sqlite/composer_repository.go
+++ b/internal/infra/sqlite/composer_repository.go
@@ -83,14 +83,17 @@ func (r *composerRepository) Upsert(ctx context.Context, c *domain.Composer) err
 	return nil
 }
 
-func (r *composerRepository) DeleteOrphaned(ctx context.Context) error {
+func (r *composerRepository) DeleteOrphaned(ctx context.Context) ([]string, error) {
 	// Clean up orphaned junction rows that might exist from before foreign keys were enabled
 	_, _ = r.db.ExecContext(ctx, "DELETE FROM track_composers WHERE track_id NOT IN (SELECT id FROM tracks)")
 
-	query := `DELETE FROM composers WHERE id NOT IN (SELECT composer_id FROM track_composers)`
-	_, err := r.db.ExecContext(ctx, query)
-	if err != nil {
-		return fmt.Errorf("failed to delete orphaned composers: %w", err)
+	const cond = `id NOT IN (SELECT composer_id FROM track_composers)`
+	var ids []string
+	if err := r.db.SelectContext(ctx, &ids, `SELECT id FROM composers WHERE `+cond); err != nil {
+		return nil, fmt.Errorf("failed to select orphaned composers: %w", err)
 	}
-	return nil
+	if _, err := r.db.ExecContext(ctx, `DELETE FROM composers WHERE `+cond); err != nil {
+		return nil, fmt.Errorf("failed to delete orphaned composers: %w", err)
+	}
+	return ids, nil
 }

--- a/internal/infra/sqlite/genre_repository.go
+++ b/internal/infra/sqlite/genre_repository.go
@@ -83,14 +83,17 @@ func (r *genreRepository) Upsert(ctx context.Context, g *domain.Genre) error {
 	return nil
 }
 
-func (r *genreRepository) DeleteOrphaned(ctx context.Context) error {
+func (r *genreRepository) DeleteOrphaned(ctx context.Context) ([]string, error) {
 	// Clean up orphaned junction rows that might exist from before foreign keys were enabled
 	_, _ = r.db.ExecContext(ctx, "DELETE FROM track_genres WHERE track_id NOT IN (SELECT id FROM tracks)")
 
-	query := `DELETE FROM genres WHERE id NOT IN (SELECT genre_id FROM track_genres)`
-	_, err := r.db.ExecContext(ctx, query)
-	if err != nil {
-		return fmt.Errorf("failed to delete orphaned genres: %w", err)
+	const cond = `id NOT IN (SELECT genre_id FROM track_genres)`
+	var ids []string
+	if err := r.db.SelectContext(ctx, &ids, `SELECT id FROM genres WHERE `+cond); err != nil {
+		return nil, fmt.Errorf("failed to select orphaned genres: %w", err)
 	}
-	return nil
+	if _, err := r.db.ExecContext(ctx, `DELETE FROM genres WHERE `+cond); err != nil {
+		return nil, fmt.Errorf("failed to delete orphaned genres: %w", err)
+	}
+	return ids, nil
 }


### PR DESCRIPTION
## Problem

Editing a track's metadata caused several issues:
- The app's own file write tripped the fsnotify watcher → redundant re-import, and a temp+rename write was misread as a deletion (track vanished / became non-interactive).
- Removing/changing a track's album/artist/genre/composer left the original orphaned (0 tracks) in the DB and search index.
- List/grid/detail views went stale (or flashed a spinner) after edits.

## Changes

### Watcher self-write suppression
- `markSelfWrite` / `isSelfWrite` ignore-window so `UpdateMetadata`'s own write doesn't trigger the watcher.
- Remove/Rename branch re-stats the path before deleting — atomic-save (temp+rename) no longer deletes the row.

### Orphan pruning (DB + search index)
- `DeleteOrphaned` (album/artist/genre/composer) returns deleted IDs.
- `cleanupOrphanedEntities` removes those docs from the search index too. Covers all callers: `UpdateMetadata`, watcher delete, `RemoveWatchedFolder`.
- `UpdateMetadata` prunes orphans and emits `library:updated` after re-import.
- New `DeleteArtistFromIndex` / `DeleteComposerFromIndex` on `SearchService` (+ bleve).

### Frontend refresh
- Artist/Composer/Genre detail views subscribe to library events (silent reload).
- Album detail drops a track whose edit moved it out of the album (`belongs` predicate in `useLibraryUpdates`).
- Event-driven list reloads (albums/artists/genres/composers/tracks/recently-added) are silent — no spinner flash, no force-refetch per navigation.

### Search-result UX
- Clicking a search-result track plays it (works for albumless tracks) instead of crashing on `/albums/undefined`.

## Verification
- `go build ./...` clean; `go test` (library, bleve, sqlite) green.
- `pnpm type-check` clean; related vitest specs pass.