### PR TITLE
feat(artwork): strict online gate + prefer-local artist artwork toggle

### DIFF
--- a/catalog/artwork/README.md
+++ b/catalog/artwork/README.md
@@ -50,7 +50,7 @@ Variants are used by the frontend: `sm` for mini player and track rows, `md` for
 
 ## Palette Extraction (`palette.go`)
 
-Called via `LibraryService.GetAlbumColors(albumID)` or `LibraryService.GetArtistColors(artistID)` — fetches colors from cached artwork. The artist variant resolves the artist's displayed artwork key (`Artist.ResolveArtworkKey(preferLocal)`) before extraction.
+Called via `LibraryService.GetAlbumColors(albumID)` or `LibraryService.GetArtistColors(artistID)` — fetches colors from cached artwork. The artist variant resolves the artist's displayed artwork key (`Artist.ResolveArtworkKey(useOnline, preferLocal)`) before extraction.
 
 ### Algorithm
 
@@ -130,13 +130,31 @@ no re-fetch or re-scan.
 | Local file | `artwork_key_local`  | Scanned `artist.jpg/jpeg/png` from disk |
 | Online     | `artwork_key_online` | Background Deezer fetch                 |
 
-**Read-time resolution** (`domain.Artist.ResolveArtworkKey(preferLocal)`):
-`manual` always wins; otherwise a single setting, **`use_online_artist_artwork`**,
-picks the local/online order — on → Deezer first, off → local first
-(`preferLocal = !use_online_artist_artwork`). Turning online off still shows an
-already-downloaded Deezer image if no local one exists (it stops new fetches and
-deletes nothing); the displayed image switches instantly because resolution is
-client-side.
+**Read-time resolution** (`domain.Artist.ResolveArtworkKey(useOnline, preferLocal)`)
+is governed by two settings — **`use_online_artist_artwork`** (gates whether the
+Deezer image may ever be shown) and **`prefer_local_artist_artwork`** (a nested
+sub-toggle, only relevant/shown when online is on). `manual` always wins; then:
+
+| `use_online` | `prefer_local` | Order (after manual)             |
+| ------------ | -------------- | -------------------------------- |
+| off          | —              | local only (online **never**)    |
+| on           | on             | local → online                   |
+| on           | off            | online → local                   |
+
+Turning online **off** never shows the Deezer image, even one already
+downloaded (nothing is deleted — it is just not resolved, so re-enabling shows it
+again instantly). With online on + prefer-local on, an existing manual/local image
+suppresses online entirely (it is neither fetched nor shown). Resolution is
+client-side, so toggling either switch swaps the displayed image instantly with no
+re-fetch. The Wails layer reads both flags via
+`LibraryService.artistArtworkPrefs(ctx) (useOnline, preferLocal)` (defaults
+`false, true` when settings are unreadable).
+
+Whether an online fetch is even worthwhile is centralized in
+`domain.Artist.ShouldFetchOnline(useOnline, preferLocal)` — true only when online
+is on, no manual image exists, no local image suppresses it (under prefer-local),
+and no online key is cached yet. All enqueue/worker sites use it so a Deezer image
+that would never be displayed is never fetched.
 
 Files (in `internal/app/library/`):
 
@@ -198,14 +216,17 @@ artist images already on disk after upgrading. Stores the current version after.
 
 ### Online (Deezer) fetch
 
-1. `LibraryService.GetArtistArtwork(artistID, eventID)` resolves the display key;
-   if non-empty, returns its URL.
-2. If nothing is showable **and** `UseOnlineArtistArtwork` is on **and** no online
-   key exists yet, the request is queued (`artistArtworkQueue`).
-3. The background worker (`StartArtistArtworkWorker`) skips if an online key
-   already exists, otherwise searches Deezer
-   (`https://api.deezer.com/search/artist?q={name}`), downloads `picture_medium`,
-   and stores it via `writeArtistArtworkSource` with source `online`.
+1. `LibraryService.GetArtistArtwork(artistID, eventID)` resolves the display key
+   (via both toggles); if non-empty, returns its URL.
+2. If `Artist.ShouldFetchOnline(useOnline, preferLocal)` (online on, no manual,
+   not suppressed by a local image under prefer-local, no online key yet) the
+   request is queued (`artistArtworkQueue`).
+3. The background worker (`StartArtistArtworkWorker`) re-checks `ShouldFetchOnline`
+   against current settings + artist state and bails if no longer needed; otherwise
+   searches Deezer (`https://api.deezer.com/search/artist?q={name}`), downloads
+   `picture_medium`, and stores it via `writeArtistArtworkSource` with source
+   `online`. The folder-removal path (`service.go`) likewise clears the local source
+   then enqueues only when `ShouldFetchOnline` holds.
 
 ### Custom image & cache cleanup
 

--- a/catalog/database/README.md
+++ b/catalog/database/README.md
@@ -47,6 +47,7 @@ SQLite database managed via `golang-migrate` for schema versioning and `sqlx` fo
 | 000026 | `drop_prefer_local_artist_artwork.up.sql` | Drop `prefer_local_artist_artwork` — replaced by deriving from `use_online_artist_artwork` |
 | 000025 | `artist_artwork_multi_source.up.sql` | Replace `artwork_key`/`artwork_source` with per-source `artwork_key_manual`/`_local`/`_online` (backfilled), then drop the old two |
 | 000027 | `lyrics_folder.up.sql`               | Add `lyrics_folder_enabled`, `lyrics_folder_path`, `lyrics_subfolder_enabled`, `lyrics_subfolder_name` to `app_settings` (dedicated folder + per-track subfolder lyrics lookup) |
+| 000028 | `prefer_local_artist_artwork.up.sql` | Re-add `prefer_local_artist_artwork BOOLEAN NOT NULL DEFAULT 1` — nested sub-toggle: when online artwork is on, a local/manual image suppresses the Deezer one |
 
 ## Full Schema
 
@@ -186,6 +187,7 @@ app_settings (
     eq_enabled BOOLEAN DEFAULT 0,
     lrclib_mode TEXT DEFAULT 'prefer_metadata',
     use_online_artist_artwork BOOLEAN NOT NULL DEFAULT 1,
+    prefer_local_artist_artwork BOOLEAN NOT NULL DEFAULT 1, -- re-added (000028)
     last_scan_version TEXT NOT NULL DEFAULT '',
     enable_lrclib BOOLEAN NOT NULL DEFAULT 1,
     enable_kugou BOOLEAN NOT NULL DEFAULT 1,

--- a/catalog/settings/README.md
+++ b/catalog/settings/README.md
@@ -33,7 +33,8 @@ type AppSettings struct {
     LyricsFolderPath       string              // chosen dedicated lyrics folder (flat, basename match)
     LyricsSubfolderEnabled bool                // also search a subfolder next to each track
     LyricsSubfolderName    string              // subfolder name (single safe path segment)
-    UseOnlineArtistArtwork bool                // on: prefer Deezer image; off: prefer local artist.jpg/png
+    UseOnlineArtistArtwork bool                // gate: off → Deezer image never shown (even if cached)
+    PreferLocalArtistArtwork bool              // nested (online on only): local/manual image suppresses online
     LastScanVersion        string              // app version of last artist-image rescan
     PreventSleepWhilePlaying bool             // prevent OS sleep during playback
 }
@@ -108,6 +109,7 @@ interface AppStore {
   updateLyricsSubfolderEnabled(enabled: boolean): Promise<void>;
   updateLyricsSubfolderName(name: string): Promise<void>;
   updateUseOnlineArtistArtwork(enabled: boolean): Promise<void>;
+  updatePreferLocalArtistArtwork(enabled: boolean): Promise<void>;
   updatePreventSleepWhilePlaying(enabled: boolean): Promise<void>;
   checkForUpdate(): Promise<void>;
   applyUpdate(): Promise<void>;
@@ -203,3 +205,4 @@ Settings evolved across multiple migrations:
 | 000026    | Drop `prefer_local_artist_artwork` (derived from online toggle)   |
 | 000025    | Split artist artwork into per-source key columns                 |
 | 000027    | Add `lyrics_folder_enabled`, `lyrics_folder_path`, `lyrics_subfolder_enabled`, `lyrics_subfolder_name` (folder + subfolder lyrics lookup) |
+| 000028    | Re-add `prefer_local_artist_artwork BOOLEAN NOT NULL DEFAULT 1` (nested sub-toggle under online artwork) |

--- a/frontend/src/components/ArtistCard.vue
+++ b/frontend/src/components/ArtistCard.vue
@@ -25,12 +25,15 @@ const keys = reactive({
   online: props.artist.artwork_key_online as string | null,
 })
 
+// Online may be shown only when enabled and not suppressed by prefer-local (a
+// local image then wins). Online off → never fall back to it, even if cached.
+const canShowOnline = computed(() =>
+  appStore.useOnlineArtistArtwork && !(appStore.preferLocalArtistArtwork && keys.local)
+)
+
 const resolvedKey = computed(() => {
   if (keys.manual) return keys.manual
-  // Single toggle: online on → prefer Deezer image; off → prefer local.
-  return appStore.useOnlineArtistArtwork
-    ? (keys.online || keys.local)
-    : (keys.local || keys.online)
+  return canShowOnline.value ? (keys.online || keys.local) : keys.local
 })
 
 const imageUrl = ref<string | null>(null)
@@ -47,10 +50,10 @@ const seedKeys = () => {
   keys.online = props.artist.artwork_key_online as string | null
 }
 
-// Fetch the Deezer image when online is enabled and none is cached yet (even if a
-// local image exists, so it's ready and shown per the toggle).
+// Fetch the Deezer image only when it would actually be shown (online enabled, no
+// manual, and not suppressed by a local image under prefer-local) and none cached.
 const maybeFetchOnline = () => {
-  if (!appStore.useOnlineArtistArtwork || keys.online) return
+  if (!canShowOnline.value || keys.manual || keys.online) return
   LibraryService.GetArtistArtwork(props.artist.id, `artist-artwork:${props.artist.id}`)
     .catch((err) => console.error(`[ArtistCard] artwork fetch failed for ${props.artist.name}:`, err))
 }
@@ -73,9 +76,9 @@ watch(() => props.artist.id, () => {
   maybeFetchOnline()
 })
 
-watch(() => appStore.useOnlineArtistArtwork, (enabled) => {
-  // Re-attempt a fetch when online is re-enabled and nothing is shown.
-  if (enabled) maybeFetchOnline()
+watch(() => [appStore.useOnlineArtistArtwork, appStore.preferLocalArtistArtwork], () => {
+  // Re-attempt a fetch when the toggles change such that online is now wanted.
+  maybeFetchOnline()
 })
 
 onMounted(() => {

--- a/frontend/src/components/settings/IntegrationsSettings.vue
+++ b/frontend/src/components/settings/IntegrationsSettings.vue
@@ -198,6 +198,18 @@ onMounted(() => {
           <Switch :model-value="appStore.useOnlineArtistArtwork"
             @update:model-value="appStore.updateUseOnlineArtistArtwork" />
         </div>
+        <div v-if="appStore.useOnlineArtistArtwork" class="p-5 flex items-center justify-between gap-x-2">
+          <div>
+            <p class="text-sm font-semibold">
+              {{ t('settings.integrations.prefer_local_artist_artwork', 'Prefer Local Artist Artwork') }}
+            </p>
+            <p class="text-xs text-foreground opacity-60 mt-1">
+              {{ t('settings.integrations.prefer_local_artist_artwork_desc', 'Use local artist.jpg/png files when available instead of fetching online') }}
+            </p>
+          </div>
+          <Switch :model-value="appStore.preferLocalArtistArtwork"
+            @update:model-value="appStore.updatePreferLocalArtistArtwork" />
+        </div>
       </div>
     </section>
 

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -79,6 +79,8 @@
       "title": "Integrationen",
       "online_artist_artwork": "Online-Künstlerbilder",
       "online_artist_artwork_desc": "An: Künstlerbilder von Deezer; aus: lokale artist.jpg/png-Dateien",
+      "prefer_local_artist_artwork": "Lokale Künstlerbilder bevorzugen",
+      "prefer_local_artist_artwork_desc": "Lokale artist.jpg/png-Dateien verwenden, falls vorhanden, statt online abzurufen",
       "enable_lrclib": "LRCLIB.NET Songtexte",
       "enable_lrclib_desc": "Songtexte von LRCLIB.NET abrufen",
       "enable_kugou": "KuGou Songtexte",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -79,6 +79,8 @@
       "title": "Integrations",
       "online_artist_artwork": "Online Artist Artwork",
       "online_artist_artwork_desc": "When on, use artist images from Deezer; when off, use local artist.jpg/png files",
+      "prefer_local_artist_artwork": "Prefer Local Artist Artwork",
+      "prefer_local_artist_artwork_desc": "Use local artist.jpg/png files when available instead of fetching online",
       "enable_lrclib": "LRCLIB.NET Lyrics",
       "enable_lrclib_desc": "Fetch lyrics from LRCLIB.NET",
       "enable_kugou": "KuGou Lyrics",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -79,6 +79,8 @@
       "title": "Integraciones",
       "online_artist_artwork": "Carátulas de artistas en línea",
       "online_artist_artwork_desc": "Activado: imágenes de artistas de Deezer; desactivado: archivos locales artist.jpg/png",
+      "prefer_local_artist_artwork": "Preferir carátulas de artistas locales",
+      "prefer_local_artist_artwork_desc": "Usar archivos locales artist.jpg/png cuando estén disponibles en lugar de buscar en línea",
       "enable_lrclib": "Letras de LRCLIB.NET",
       "enable_lrclib_desc": "Obtener letras de LRCLIB.NET",
       "enable_kugou": "Letras de KuGou",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -79,6 +79,8 @@
       "title": "Intégrations",
       "online_artist_artwork": "Photos d'artistes en ligne",
       "online_artist_artwork_desc": "Activé : images d'artistes depuis Deezer ; désactivé : fichiers locaux artist.jpg/png",
+      "prefer_local_artist_artwork": "Privilégier les photos d'artistes locales",
+      "prefer_local_artist_artwork_desc": "Utiliser les fichiers locaux artist.jpg/png s'ils existent au lieu de les récupérer en ligne",
       "enable_lrclib": "Paroles LRCLIB.NET",
       "enable_lrclib_desc": "Récupérer les paroles depuis LRCLIB.NET",
       "enable_kugou": "Paroles KuGou",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -79,6 +79,8 @@
       "title": "Integrazioni",
       "online_artist_artwork": "Immagini artisti online",
       "online_artist_artwork_desc": "Attivo: immagini artista da Deezer; disattivo: file locali artist.jpg/png",
+      "prefer_local_artist_artwork": "Preferisci immagini artista locali",
+      "prefer_local_artist_artwork_desc": "Usa i file locali artist.jpg/png quando disponibili invece di scaricarli online",
       "enable_lrclib": "Testi LRCLIB.NET",
       "enable_lrclib_desc": "Recupera i testi da LRCLIB.NET",
       "enable_kugou": "Testi KuGou",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -79,6 +79,8 @@
       "title": "連携",
       "online_artist_artwork": "オンラインのアーティスト画像",
       "online_artist_artwork_desc": "オン: Deezer のアーティスト画像を使用、オフ: ローカルの artist.jpg/png を使用",
+      "prefer_local_artist_artwork": "ローカルのアーティスト画像を優先",
+      "prefer_local_artist_artwork_desc": "オンライン取得の代わりに、ローカルの artist.jpg/png があればそれを使用",
       "enable_lrclib": "LRCLIB.NET の歌詞",
       "enable_lrclib_desc": "LRCLIB.NET から歌詞を取得",
       "enable_kugou": "KuGou の歌詞",

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -79,6 +79,8 @@
       "title": "연동",
       "online_artist_artwork": "온라인 아티스트 아트워크",
       "online_artist_artwork_desc": "켜짐: Deezer 아티스트 이미지 사용, 꺼짐: 로컬 artist.jpg/png 사용",
+      "prefer_local_artist_artwork": "로컬 아티스트 아트워크 우선",
+      "prefer_local_artist_artwork_desc": "온라인에서 가져오는 대신 사용 가능한 로컬 artist.jpg/png 파일 사용",
       "enable_lrclib": "LRCLIB.NET 가사",
       "enable_lrclib_desc": "LRCLIB.NET에서 가사 가져오기",
       "enable_kugou": "KuGou 가사",

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -79,6 +79,8 @@
       "title": "Integrações",
       "online_artist_artwork": "Capas de artistas online",
       "online_artist_artwork_desc": "Ligado: imagens de artistas do Deezer; desligado: arquivos locais artist.jpg/png",
+      "prefer_local_artist_artwork": "Preferir capas de artistas locais",
+      "prefer_local_artist_artwork_desc": "Usar arquivos locais artist.jpg/png quando disponíveis em vez de buscar online",
       "enable_lrclib": "Letras do LRCLIB.NET",
       "enable_lrclib_desc": "Buscar letras do LRCLIB.NET",
       "enable_kugou": "Letras do KuGou",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -79,6 +79,8 @@
       "title": "Интеграции",
       "online_artist_artwork": "Обложки исполнителей онлайн",
       "online_artist_artwork_desc": "Вкл.: изображения исполнителей с Deezer; выкл.: локальные файлы artist.jpg/png",
+      "prefer_local_artist_artwork": "Предпочитать локальные обложки исполнителей",
+      "prefer_local_artist_artwork_desc": "Использовать локальные файлы artist.jpg/png при наличии вместо загрузки из сети",
       "enable_lrclib": "Тексты LRCLIB.NET",
       "enable_lrclib_desc": "Загружать тексты с LRCLIB.NET",
       "enable_kugou": "Тексты KuGou",

--- a/frontend/src/locales/th.json
+++ b/frontend/src/locales/th.json
@@ -79,6 +79,8 @@
       "title": "การเชื่อมต่อ",
       "online_artist_artwork": "รูปภาพศิลปินออนไลน์",
       "online_artist_artwork_desc": "เปิด: ใช้รูปภาพศิลปินจาก Deezer; ปิด: ใช้ไฟล์ artist.jpg/png ในเครื่อง",
+      "prefer_local_artist_artwork": "ใช้รูปภาพศิลปินในเครื่องก่อน",
+      "prefer_local_artist_artwork_desc": "ใช้ไฟล์ artist.jpg/png ในเครื่องเมื่อมี แทนการดึงจากออนไลน์",
       "enable_lrclib": "เนื้อเพลงจาก LRCLIB.NET",
       "enable_lrclib_desc": "ดึงเนื้อเพลงจาก LRCLIB.NET",
       "enable_kugou": "เนื้อเพลงจาก KuGou",

--- a/frontend/src/locales/vi.json
+++ b/frontend/src/locales/vi.json
@@ -79,6 +79,8 @@
       "title": "Tích hợp",
       "online_artist_artwork": "Ảnh nghệ sĩ trực tuyến",
       "online_artist_artwork_desc": "Khi bật, dùng ảnh nghệ sĩ từ Deezer; khi tắt, dùng tệp artist.jpg/png cục bộ",
+      "prefer_local_artist_artwork": "Ưu tiên ảnh nghệ sĩ cục bộ",
+      "prefer_local_artist_artwork_desc": "Dùng tệp artist.jpg/png cục bộ khi có thay vì tải trực tuyến",
       "enable_lrclib": "Lời bài hát LRCLIB.NET",
       "enable_lrclib_desc": "Tải lời bài hát từ LRCLIB.NET",
       "enable_kugou": "Lời bài hát KuGou",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -79,6 +79,8 @@
       "title": "集成",
       "online_artist_artwork": "在线艺术家封面",
       "online_artist_artwork_desc": "开启：使用 Deezer 艺术家图片；关闭：使用本地 artist.jpg/png 文件",
+      "prefer_local_artist_artwork": "优先使用本地艺术家封面",
+      "prefer_local_artist_artwork_desc": "有本地 artist.jpg/png 文件时优先使用，而不是在线获取",
       "enable_lrclib": "LRCLIB.NET 歌词",
       "enable_lrclib_desc": "从 LRCLIB.NET 获取歌词",
       "enable_kugou": "酷狗歌词",

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -22,6 +22,7 @@ export const useAppStore = defineStore('app', () => {
   const lyricsSubfolderEnabled = ref(false)
   const lyricsSubfolderName = ref('')
   const useOnlineArtistArtwork = ref(true)
+  const preferLocalArtistArtwork = ref(true)
   // Round-tripped only (set by the backend's version-gated rescan); never edited
   // in the UI, but must be preserved across saves so saving settings doesn't
   // wipe it and re-trigger a rescan.
@@ -78,6 +79,7 @@ export const useAppStore = defineStore('app', () => {
         lyricsSubfolderEnabled.value = !!settings.lyrics_subfolder_enabled
         lyricsSubfolderName.value = settings.lyrics_subfolder_name || ''
         useOnlineArtistArtwork.value = settings.use_online_artist_artwork !== false
+        preferLocalArtistArtwork.value = settings.prefer_local_artist_artwork !== false
         lastScanVersion.value = settings.last_scan_version || ''
         preventSleepWhilePlaying.value = !!settings.prevent_sleep_while_playing
         showPlayerIndicator.value = settings.show_player_indicator !== false
@@ -149,6 +151,7 @@ export const useAppStore = defineStore('app', () => {
         lyrics_subfolder_enabled: lyricsSubfolderEnabled.value,
         lyrics_subfolder_name: lyricsSubfolderName.value,
         use_online_artist_artwork: useOnlineArtistArtwork.value,
+        prefer_local_artist_artwork: preferLocalArtistArtwork.value,
         last_scan_version: lastScanVersion.value,
         prevent_sleep_while_playing: preventSleepWhilePlaying.value,
         show_player_indicator: showPlayerIndicator.value,
@@ -238,6 +241,11 @@ export const useAppStore = defineStore('app', () => {
     await saveSettings()
   }
 
+  const updatePreferLocalArtistArtwork = async (enabled: boolean) => {
+    preferLocalArtistArtwork.value = enabled
+    await saveSettings()
+  }
+
   const updatePreventSleepWhilePlaying = async (enabled: boolean) => {
     preventSleepWhilePlaying.value = enabled
     await saveSettings()
@@ -287,6 +295,7 @@ export const useAppStore = defineStore('app', () => {
     lyricsSubfolderEnabled,
     lyricsSubfolderName,
     useOnlineArtistArtwork,
+    preferLocalArtistArtwork,
     preventSleepWhilePlaying,
     showPlayerIndicator,
     updateInfo,
@@ -315,6 +324,7 @@ export const useAppStore = defineStore('app', () => {
     updateLyricsSubfolderEnabled,
     updateLyricsSubfolderName,
     updateUseOnlineArtistArtwork,
+    updatePreferLocalArtistArtwork,
     updatePreventSleepWhilePlaying,
     updateShowPlayerIndicator,
     remoteServerEnabled,

--- a/internal/app/library/artist_artwork.go
+++ b/internal/app/library/artist_artwork.go
@@ -42,14 +42,10 @@ func (s *LibraryService) processArtistArtworkJob(ctx context.Context, job artist
 		s.pendingArtistArtworkMu.Unlock()
 	}()
 
-	// 1. Check if online artwork is enabled
+	// 1. Load settings
 	settings, err := s.settingsRepo.Load(ctx)
 	if err != nil {
 		s.logger.Error("Failed to load settings in artwork worker", "error", err)
-		return
-	}
-	if !settings.UseOnlineArtistArtwork {
-		s.logger.Info("Online artist artwork disabled in settings, skipping job", "artistID", job.ArtistID)
 		return
 	}
 
@@ -60,9 +56,10 @@ func (s *LibraryService) processArtistArtworkJob(ctx context.Context, job artist
 		return
 	}
 
-	// 3. Already have an online image — don't refetch (it's kept even when the
-	//    online toggle is later turned off).
-	if artist.ArtworkKeyOnline != nil && *artist.ArtworkKeyOnline != "" {
+	// 3. Fetch only if the online image is wanted and not already cached (online
+	//    enabled, no manual, and not suppressed by a local image under prefer-local).
+	if !artist.ShouldFetchOnline(settings.UseOnlineArtistArtwork, settings.PreferLocalArtistArtwork) {
+		s.logger.Info("Online artist artwork not needed, skipping job", "artistID", job.ArtistID)
 		return
 	}
 

--- a/internal/app/library/service.go
+++ b/internal/app/library/service.go
@@ -392,8 +392,10 @@ func (s *LibraryService) handleArtistImageEvent(event fsnotify.Event) {
 				s.logger.Warn("Failed to clear local artist artwork after image removal", "artistID", id, "error", err)
 				continue
 			}
-			// If nothing else is available and online is enabled, fetch from Deezer.
-			if settings.UseOnlineArtistArtwork && artist.ArtworkKeyManual == nil && artist.ArtworkKeyOnline == nil {
+			// Reflect the just-cleared local source, then fetch from Deezer only if the
+			// online image would now actually be shown.
+			artist.ArtworkKeyLocal = nil
+			if artist.ShouldFetchOnline(settings.UseOnlineArtistArtwork, settings.PreferLocalArtistArtwork) {
 				s.EnqueueArtistArtwork(id, fmt.Sprintf("artist-artwork:%s", id))
 			}
 		}

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -88,30 +88,39 @@ type Artist struct {
 	UpdatedAt  time.Time `json:"updated_at" db:"updated_at"`
 }
 
-// ResolveArtworkKey picks which stored artwork to show. Manual always wins; the
-// local/online order follows the user's preference. An existing online image is
-// shown regardless of whether online fetching is currently enabled.
-func (a *Artist) ResolveArtworkKey(preferLocal bool) string {
+// ResolveArtworkKey picks which stored artwork to show. Manual always wins. The
+// online (Deezer) image is shown only when useOnline is true and not suppressed by
+// preferLocal: when preferLocal is set, an existing local image takes precedence
+// over online. When online is disabled it is never shown, even if already cached.
+func (a *Artist) ResolveArtworkKey(useOnline, preferLocal bool) string {
 	if a.ArtworkKeyManual != nil && *a.ArtworkKeyManual != "" {
 		return *a.ArtworkKeyManual
 	}
-	local, online := "", ""
+	local := ""
 	if a.ArtworkKeyLocal != nil {
 		local = *a.ArtworkKeyLocal
 	}
-	if a.ArtworkKeyOnline != nil {
-		online = *a.ArtworkKeyOnline
-	}
-	if preferLocal {
-		if local != "" {
-			return local
-		}
-		return online
-	}
-	if online != "" {
-		return online
+	if useOnline && (!preferLocal || local == "") &&
+		a.ArtworkKeyOnline != nil && *a.ArtworkKeyOnline != "" {
+		return *a.ArtworkKeyOnline
 	}
 	return local
+}
+
+// ShouldFetchOnline reports whether an online (Deezer) image is wanted but not yet
+// cached: i.e. online is enabled, no manual image exists, the local image does not
+// suppress online (per preferLocal), and no online image is stored yet.
+func (a *Artist) ShouldFetchOnline(useOnline, preferLocal bool) bool {
+	if !useOnline {
+		return false
+	}
+	if a.ArtworkKeyManual != nil && *a.ArtworkKeyManual != "" {
+		return false
+	}
+	if preferLocal && a.ArtworkKeyLocal != nil && *a.ArtworkKeyLocal != "" {
+		return false
+	}
+	return a.ArtworkKeyOnline == nil || *a.ArtworkKeyOnline == ""
 }
 
 // ArtworkKeyForSource returns the stored key for a given source ("" if unset).
@@ -218,6 +227,7 @@ type AppSettings struct {
 	LyricsSubfolderEnabled   bool   `json:"lyrics_subfolder_enabled"`
 	LyricsSubfolderName      string `json:"lyrics_subfolder_name"`
 	UseOnlineArtistArtwork   bool   `json:"use_online_artist_artwork"`
+	PreferLocalArtistArtwork bool   `json:"prefer_local_artist_artwork"`
 	LastScanVersion          string `json:"last_scan_version"`
 	PreventSleepWhilePlaying bool   `json:"prevent_sleep_while_playing"`
 	RemoteServerEnabled      bool   `json:"remote_server_enabled"`

--- a/internal/infra/sqlite/migrations/000028_prefer_local_artist_artwork.down.sql
+++ b/internal/infra/sqlite/migrations/000028_prefer_local_artist_artwork.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE app_settings DROP COLUMN prefer_local_artist_artwork;

--- a/internal/infra/sqlite/migrations/000028_prefer_local_artist_artwork.up.sql
+++ b/internal/infra/sqlite/migrations/000028_prefer_local_artist_artwork.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE app_settings ADD COLUMN prefer_local_artist_artwork BOOLEAN NOT NULL DEFAULT 1;

--- a/internal/infra/sqlite/settings_repository.go
+++ b/internal/infra/sqlite/settings_repository.go
@@ -18,8 +18,8 @@ func NewSettingsRepository(db *DB) domain.SettingsRepository {
 
 func (r *settingsRepository) Save(ctx context.Context, settings *domain.AppSettings) error {
 	_, err := r.db.ExecContext(ctx,
-		`INSERT INTO app_settings (id, language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, last_scan_version, enable_lrclib, enable_kugou, prefer_local_lyrics, lyrics_folder_enabled, lyrics_folder_path, lyrics_subfolder_enabled, lyrics_subfolder_name, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator, updated_at)
-		 VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		`INSERT INTO app_settings (id, language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, prefer_local_artist_artwork, last_scan_version, enable_lrclib, enable_kugou, prefer_local_lyrics, lyrics_folder_enabled, lyrics_folder_path, lyrics_subfolder_enabled, lyrics_subfolder_name, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator, updated_at)
+		 VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		 ON CONFLICT(id) DO UPDATE SET
 		   language = excluded.language,
 		   theme = excluded.theme,
@@ -29,6 +29,7 @@ func (r *settingsRepository) Save(ctx context.Context, settings *domain.AppSetti
 		   show_tray_icon = excluded.show_tray_icon,
 		   eq_enabled = excluded.eq_enabled,
 		   use_online_artist_artwork = excluded.use_online_artist_artwork,
+		   prefer_local_artist_artwork = excluded.prefer_local_artist_artwork,
 		   last_scan_version = excluded.last_scan_version,
 		   enable_lrclib = excluded.enable_lrclib,
 		   enable_kugou = excluded.enable_kugou,
@@ -51,6 +52,7 @@ func (r *settingsRepository) Save(ctx context.Context, settings *domain.AppSetti
 		settings.ShowTrayIcon,
 		settings.EQEnabled,
 		settings.UseOnlineArtistArtwork,
+		settings.PreferLocalArtistArtwork,
 		settings.LastScanVersion,
 		settings.EnableLrclib,
 		settings.EnableKugou,
@@ -81,6 +83,7 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 		ShowTrayIcon             bool           `db:"show_tray_icon"`
 		EQEnabled                bool           `db:"eq_enabled"`
 		UseOnlineArtistArtwork   bool           `db:"use_online_artist_artwork"`
+		PreferLocalArtistArtwork bool           `db:"prefer_local_artist_artwork"`
 		LastScanVersion          string         `db:"last_scan_version"`
 		EnableLrclib             bool           `db:"enable_lrclib"`
 		EnableKugou              bool           `db:"enable_kugou"`
@@ -96,7 +99,7 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 		ShowPlayerIndicator      bool           `db:"show_player_indicator"`
 	}
 	err := r.db.GetContext(ctx, &row,
-		`SELECT language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, last_scan_version, enable_lrclib, enable_kugou, prefer_local_lyrics, lyrics_folder_enabled, lyrics_folder_path, lyrics_subfolder_enabled, lyrics_subfolder_name, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator FROM app_settings WHERE id = 1`,
+		`SELECT language, theme, lastfm_username, auto_check_update, start_at_login, show_tray_icon, eq_enabled, use_online_artist_artwork, prefer_local_artist_artwork, last_scan_version, enable_lrclib, enable_kugou, prefer_local_lyrics, lyrics_folder_enabled, lyrics_folder_path, lyrics_subfolder_enabled, lyrics_subfolder_name, prevent_sleep_while_playing, remote_server_enabled, remote_server_port, remote_server_password, show_player_indicator FROM app_settings WHERE id = 1`,
 	)
 	if err == sql.ErrNoRows {
 		return &domain.AppSettings{
@@ -110,6 +113,7 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 			EnableKugou:              true,
 			PreferLocalLyrics:        true,
 			UseOnlineArtistArtwork:   true,
+			PreferLocalArtistArtwork: true,
 			PreventSleepWhilePlaying: false,
 			ShowPlayerIndicator:      true,
 		}, nil
@@ -134,6 +138,7 @@ func (r *settingsRepository) Load(ctx context.Context) (*domain.AppSettings, err
 		LyricsSubfolderEnabled:   row.LyricsSubfolderEnabled,
 		LyricsSubfolderName:      row.LyricsSubfolderName.String,
 		UseOnlineArtistArtwork:   row.UseOnlineArtistArtwork,
+		PreferLocalArtistArtwork: row.PreferLocalArtistArtwork,
 		LastScanVersion:          row.LastScanVersion,
 		PreventSleepWhilePlaying: row.PreventSleepWhilePlaying,
 		RemoteServerEnabled:      row.RemoteServerEnabled,

--- a/internal/infra/wails/library_service.go
+++ b/internal/infra/wails/library_service.go
@@ -220,9 +220,9 @@ func (s *LibraryService) GetAllArtists() ([]*domain.Artist, error) {
 	if err != nil {
 		return nil, err
 	}
-	preferLocal := s.preferLocalArtistArtwork(ctx)
+	useOnline, preferLocal := s.artistArtworkPrefs(ctx)
 	for _, a := range artists {
-		a.ArtworkKey = a.ResolveArtworkKey(preferLocal)
+		a.ArtworkKey = a.ResolveArtworkKey(useOnline, preferLocal)
 	}
 	return artists, nil
 }
@@ -233,19 +233,21 @@ func (s *LibraryService) GetArtistByID(id string) (*domain.Artist, error) {
 	if err != nil || artist == nil {
 		return artist, err
 	}
-	artist.ArtworkKey = artist.ResolveArtworkKey(s.preferLocalArtistArtwork(ctx))
+	useOnline, preferLocal := s.artistArtworkPrefs(ctx)
+	artist.ArtworkKey = artist.ResolveArtworkKey(useOnline, preferLocal)
 	return artist, nil
 }
 
-// preferLocalArtistArtwork reports whether local images should be preferred over
-// the Deezer image. There is a single user toggle, "Online Artist Artwork":
-// when off (or settings unreadable) local images win.
-func (s *LibraryService) preferLocalArtistArtwork(ctx context.Context) bool {
+// artistArtworkPrefs returns the two user toggles governing artist artwork:
+// "Online Artist Artwork" (whether the Deezer image may be shown) and "Prefer
+// Local Artist Artwork" (whether a local image suppresses online). When settings
+// are unreadable, online is treated as off and local preferred.
+func (s *LibraryService) artistArtworkPrefs(ctx context.Context) (useOnline, preferLocal bool) {
 	settings, err := s.libService.GetSettings(ctx)
 	if err != nil || settings == nil {
-		return true
+		return false, true
 	}
-	return !settings.UseOnlineArtistArtwork
+	return settings.UseOnlineArtistArtwork, settings.PreferLocalArtistArtwork
 }
 
 func (s *LibraryService) GetAllGenres() ([]*domain.Genre, error) {
@@ -300,7 +302,8 @@ func (s *LibraryService) GetArtistColors(id string) (*domain.ThemeColors, error)
 		return nil, fmt.Errorf("artist not found: %s", id)
 	}
 
-	key := artist.ResolveArtworkKey(s.preferLocalArtistArtwork(ctx))
+	useOnline, preferLocal := s.artistArtworkPrefs(ctx)
+	key := artist.ResolveArtworkKey(useOnline, preferLocal)
 	if key == "" {
 		return nil, nil
 	}
@@ -318,17 +321,15 @@ func (s *LibraryService) GetArtistArtwork(artistID, eventID string) (*string, er
 		return nil, fmt.Errorf("artist not found")
 	}
 
-	settings, _ := s.libService.GetSettings(ctx)
-	useOnline := settings != nil && settings.UseOnlineArtistArtwork
-	preferLocal := !useOnline
+	useOnline, preferLocal := s.artistArtworkPrefs(ctx)
 
-	// When online is enabled and no Deezer image is cached yet, fetch it (even if a
-	// local image exists, so it's ready and shown per preference).
-	if useOnline && artist.ArtworkKeyOnline == nil {
+	// Fetch the Deezer image only when it would actually be shown (online enabled,
+	// no manual, and not suppressed by a local image under prefer-local).
+	if artist.ShouldFetchOnline(useOnline, preferLocal) {
 		s.libService.EnqueueArtistArtwork(artistID, eventID)
 	}
 
-	if key := artist.ResolveArtworkKey(preferLocal); key != "" {
+	if key := artist.ResolveArtworkKey(useOnline, preferLocal); key != "" {
 		url := fmt.Sprintf("/artwork/%s", key)
 		return &url, nil
 	}


### PR DESCRIPTION
## Summary
Rework artist artwork into two independent settings and centralize fetch logic.

- **`use_online_artist_artwork`** — strict gate. Off → Deezer image never shown, even if already cached (nothing deleted; re-enabling shows it again instantly).
- **`prefer_local_artist_artwork`** — nested sub-toggle, shown only when online is on. A local/manual image suppresses online.

| use_online | prefer_local | Order (after manual) |
| --- | --- | --- |
| off | — | local only (online never) |
| on | on | local → online |
| on | off | online → local |

## Changes
- `domain.Artist.ResolveArtworkKey(useOnline, preferLocal)` — read-time resolution; manual always wins.
- `domain.Artist.ShouldFetchOnline(useOnline, preferLocal)` — single source of truth for whether a Deezer fetch is worthwhile; used by all enqueue/worker sites so an image that would never display is never fetched.
- Migration `000028` re-adds `prefer_local_artist_artwork BOOLEAN NOT NULL DEFAULT 1`; settings repo save/load updated.
- Wails `artistArtworkPrefs(ctx) (useOnline, preferLocal)` replaces `preferLocalArtistArtwork`.
- Frontend: app store flag + `updatePreferLocalArtistArtwork`, nested Switch in IntegrationsSettings, `ArtistCard.vue` resolution/fetch gating, locale strings (12 languages).
- Docs updated (catalog/artwork, database, settings READMEs).

## Test plan
- [ ] Toggle online off → artist shows local only, no Deezer fetch
- [ ] Online on + prefer-local on → local image suppresses online; no fetch when local exists
- [ ] Online on + prefer-local off → online preferred, fetched if absent
- [ ] Manual image always wins
- [ ] Migration up/down applies cleanly
