### PR TITLE
fix: track table compact blank space, network iface detection, tray icon enforcement

### DIFF
--- a/frontend/src/components/TrackTable.vue
+++ b/frontend/src/components/TrackTable.vue
@@ -134,6 +134,11 @@ let ro: ResizeObserver | null = null
 
 const effectiveHeaderHeight = computed(() => props.hideHeader ? 0 : HEADER_HEIGHT)
 
+const keeps = computed(() => {
+  if (containerHeight.value === 0) return 60
+  return Math.ceil(containerHeight.value / rowHeight.value) + BUFFER * 2
+})
+
 // ── Selection ──────────────────────────────────────────────────────────────
 const selectedIds = ref(new Set<string>())
 const lastSelectedIndex = ref<number | null>(null)
@@ -305,9 +310,11 @@ defineExpose({ scrollToCurrentTrack, optionalColumns })
 
         <VirtualList
           ref="scrollerRef"
+          :key="rowHeight"
           v-model="displayTracks"
           data-key="id"
           :size="rowHeight"
+          :keeps="keeps"
           handle=".dnd-handle"
           :sortable="allowDnd"
           :animation="150"

--- a/frontend/src/components/settings/GeneralSettings.vue
+++ b/frontend/src/components/settings/GeneralSettings.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
+import { useDeviceStore } from '@/stores/device'
 import { AppWindow, Sun, Moon, Monitor, Languages, Circle } from 'lucide-vue-next'
 import { Switch } from '@airmedy/ui'
 import RestartModal from '../RestartModal.vue'
@@ -15,6 +16,7 @@ import {
 
 const { t } = useI18n()
 const appStore = useAppStore()
+const deviceStore = useDeviceStore()
 const showRestartDialog = ref(false)
 
 const toggleStartAtLogin = async (enabled: boolean) => {
@@ -63,12 +65,12 @@ const toggleAutoCheckUpdate = async (enabled: boolean) => {
           />
         </div>
 
-        <div class="p-5 flex items-center justify-between gap-x-2">
+        <div v-if="!deviceStore.isWindows && !deviceStore.isLinux" class="p-5 flex items-center justify-between gap-x-2">
           <div>
             <p class="text-sm font-semibold">{{ t('settings.behavior.show_tray_icon', 'Show Tray Icon') }}</p>
             <p class="text-xs text-foreground opacity-60 mt-1">{{ t('settings.behavior.show_tray_icon_desc', 'Show Airmedy icon in system tray/menu bar') }}</p>
           </div>
-          <Switch 
+          <Switch
             :model-value="appStore.showTrayIcon"
             @update:model-value="toggleShowTrayIcon"
           />

--- a/internal/app/appsettings/service.go
+++ b/internal/app/appsettings/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"runtime"
 	"sync"
 
 	"airmedy/internal/app/config"
@@ -60,6 +61,9 @@ func (s *SettingsService) GetSettings(ctx context.Context) (*domain.AppSettings,
 		}
 		return s.cache, nil
 	}
+	if runtime.GOOS == "windows" || runtime.GOOS == "linux" {
+		settings.ShowTrayIcon = true
+	}
 	s.cache = settings
 	return settings, nil
 }
@@ -67,6 +71,10 @@ func (s *SettingsService) GetSettings(ctx context.Context) (*domain.AppSettings,
 func (s *SettingsService) SaveSettings(ctx context.Context, settings *domain.AppSettings) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if runtime.GOOS == "windows" || runtime.GOOS == "linux" {
+		settings.ShowTrayIcon = true
+	}
 
 	err := s.repo.Save(ctx, settings)
 	if err != nil {

--- a/internal/infra/wails/remote_server_iface_darwin.go
+++ b/internal/infra/wails/remote_server_iface_darwin.go
@@ -1,0 +1,54 @@
+//go:build darwin
+
+package wails
+
+import (
+	"bufio"
+	"bytes"
+	"os/exec"
+	"strings"
+)
+
+// buildIfaceKindMap shells out to networksetup to learn the true hardware type
+// of each interface (Wi-Fi vs Ethernet vs Thunderbolt Bridge, etc.).
+// Returns a map of interface name → kind string ("wifi" | "ethernet" | "virtual").
+// Returns an empty map on any error so callers fall back to name-based heuristics.
+func buildIfaceKindMap() map[string]string {
+	out, err := exec.Command("networksetup", "-listallhardwareports").Output()
+	if err != nil {
+		return map[string]string{}
+	}
+	return parseNetworksetupOutput(out)
+}
+
+func parseNetworksetupOutput(out []byte) map[string]string {
+	result := map[string]string{}
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+
+	var currentPort string
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if rest, ok := strings.CutPrefix(line, "Hardware Port:"); ok {
+			currentPort = strings.TrimSpace(rest)
+		} else if rest, ok := strings.CutPrefix(line, "Device:"); ok {
+			device := strings.TrimSpace(rest)
+			if device != "" && currentPort != "" {
+				result[device] = hardwarePortToKind(currentPort)
+			}
+			currentPort = ""
+		}
+	}
+	return result
+}
+
+func hardwarePortToKind(port string) string {
+	lower := strings.ToLower(port)
+	if strings.Contains(lower, "wi-fi") || strings.Contains(lower, "wifi") || strings.Contains(lower, "airport") {
+		return "wifi"
+	}
+	if strings.Contains(lower, "thunderbolt bridge") || strings.Contains(lower, "bridge") {
+		return "virtual"
+	}
+	// Thunderbolt, USB, Ethernet Adapter, Ethernet → all treated as ethernet
+	return "ethernet"
+}

--- a/internal/infra/wails/remote_server_iface_linux.go
+++ b/internal/infra/wails/remote_server_iface_linux.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package wails
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+// buildIfaceKindMap uses sysfs to detect true interface types on Linux.
+// /sys/class/net/<iface>/wireless/ exists → wifi
+// /sys/class/net/<iface>/type contains the ARPHRD type code → 772 = loopback, 1 = ether, etc.
+func buildIfaceKindMap() map[string]string {
+	result := map[string]string{}
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return result
+	}
+	for _, iface := range ifaces {
+		result[iface.Name] = linuxIfaceKind(iface.Name)
+	}
+	return result
+}
+
+func linuxIfaceKind(name string) string {
+	// Wireless: wireless/ subdir exists in sysfs
+	if _, err := os.Stat(fmt.Sprintf("/sys/class/net/%s/wireless", name)); err == nil {
+		return "wifi"
+	}
+	// Virtual bridges / tun devices
+	if _, err := os.Stat(fmt.Sprintf("/sys/class/net/%s/bridge", name)); err == nil {
+		return "virtual"
+	}
+	return "ethernet"
+}

--- a/internal/infra/wails/remote_server_iface_other.go
+++ b/internal/infra/wails/remote_server_iface_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux && !windows
+
+package wails
+
+// buildIfaceKindMap returns an empty map on non-macOS platforms.
+// classifyInterface falls back to name-based heuristics.
+func buildIfaceKindMap() map[string]string {
+	return map[string]string{}
+}

--- a/internal/infra/wails/remote_server_iface_windows.go
+++ b/internal/infra/wails/remote_server_iface_windows.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+package wails
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// Windows IANA interface type constants (RFC 3635 / IANAifType).
+const (
+	ifTypeEthernetCSMACD = 6   // wired Ethernet
+	ifTypeIEEE80211      = 71  // Wi-Fi (802.11)
+	ifTypePPP            = 23  // PPP (dial-up / some VPNs)
+	ifTypeTunnel         = 131 // generic tunnel (VPN)
+	ifTypeSoftwareLoop   = 24  // loopback
+)
+
+// buildIfaceKindMap queries GetAdaptersAddresses to get the true interface type
+// for each adapter. The map key is the friendly name (matches net.Interface.Name on Windows).
+func buildIfaceKindMap() map[string]string {
+	result := map[string]string{}
+
+	// First call: get required buffer size.
+	var size uint32
+	_ = windows.GetAdaptersAddresses(windows.AF_UNSPEC, 0, 0, nil, &size)
+	if size == 0 {
+		return result
+	}
+
+	buf := make([]byte, size)
+	addr := (*windows.IpAdapterAddresses)(unsafe.Pointer(&buf[0]))
+	if err := windows.GetAdaptersAddresses(windows.AF_UNSPEC, 0, 0, addr, &size); err != nil {
+		return result
+	}
+
+	for cur := addr; cur != nil; cur = cur.Next {
+		name := windows.UTF16PtrToString(cur.FriendlyName)
+		result[name] = windowsIfTypeToKind(cur.IfType)
+	}
+	return result
+}
+
+func windowsIfTypeToKind(ifType uint32) string {
+	switch ifType {
+	case ifTypeIEEE80211:
+		return "wifi"
+	case ifTypeEthernetCSMACD:
+		return "ethernet"
+	case ifTypePPP, ifTypeTunnel:
+		return "vpn"
+	default:
+		return "virtual"
+	}
+}

--- a/internal/infra/wails/remote_server_service.go
+++ b/internal/infra/wails/remote_server_service.go
@@ -83,6 +83,7 @@ func getLocalAddresses() []LocalAddress {
 	if err != nil {
 		return out
 	}
+	hints := buildIfaceKindMap()
 	for _, iface := range ifaces {
 		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
 			continue
@@ -103,7 +104,7 @@ func getLocalAddresses() []LocalAddress {
 			out = append(out, LocalAddress{
 				IP:    ip.String(),
 				Iface: iface.Name,
-				Kind:  classifyInterface(iface, ip),
+				Kind:  classifyInterface(iface, ip, hints),
 			})
 		}
 	}
@@ -114,9 +115,9 @@ func getLocalAddresses() []LocalAddress {
 }
 
 // classifyInterface maps a network interface + IPv4 address to a coarse kind
-// usable for picking an icon/label in the UI. Detection is name- and
-// flag-based, best-effort and cross-platform (macOS / Linux / Windows).
-func classifyInterface(iface net.Interface, ip net.IP) string {
+// usable for picking an icon/label in the UI. hints (from buildIfaceKindMap)
+// takes priority; name- and flag-based heuristics are the fallback.
+func classifyInterface(iface net.Interface, ip net.IP, hints map[string]string) string {
 	if ip4 := ip.To4(); ip4 != nil && ip4[0] == 169 && ip4[1] == 254 {
 		return "link_local"
 	}
@@ -135,9 +136,13 @@ func classifyInterface(iface net.Interface, ip net.IP) string {
 		return "virtual"
 	}
 
-	// Wi-Fi. Reliable on Linux (wl*) and Windows ("Wi-Fi"); on macOS the radio
-	// is conventionally en0.
-	if hasAnyPrefix(name, "wl", "wlan", "wlp", "wifi", "wi-fi") || name == "en0" {
+	// Platform-supplied hint (e.g. from networksetup on macOS) wins over name guessing.
+	if kind, ok := hints[iface.Name]; ok {
+		return kind
+	}
+
+	// Wi-Fi. Reliable on Linux (wl*) and Windows ("Wi-Fi").
+	if hasAnyPrefix(name, "wl", "wlan", "wlp", "wifi", "wi-fi") {
 		return "wifi"
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "airmedy",
   "private": true,
-  "packageManager": "pnpm@11.0.9",
+  "packageManager": "pnpm@11.9.0",
   "scripts": {
     "dev": "turbo dev",
     "build": "turbo build",
@@ -10,8 +10,5 @@
   },
   "devDependencies": {
     "turbo": "2.9.16"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": ["esbuild"]
   }
 }


### PR DESCRIPTION
## Summary

- Fix blank space at bottom of track table in compact mode — dynamic `keeps` calculation based on container height; remount VirtualList on row height change to clear stale size cache
- Fix network interface type detection per OS — use native APIs (macOS: `networksetup`, Linux: sysfs, Windows: `GetAdaptersAddresses`) instead of fragile name heuristics
- Hide tray icon toggle on Windows/Linux and force-enable it — tray is always required on those platforms; recovers users who had previously disabled it
- Remove deprecated `pnpm` field from `package.json`

## Test plan

- [ ] Compact mode: resize window taller than 1080px, verify no blank space below last track
- [ ] Remote server: verify correct wifi/ethernet label on macOS (non-en0 Wi-Fi), Linux, Windows
- [ ] Settings > General: tray icon toggle hidden on Windows/Linux; still visible on macOS
- [ ] No pnpm warnings on `pnpm install`