### PR TITLE
fix(audio): resume from paused position on macOS instead of restarting

### DIFF
--- a/internal/infra/audio/native_player_darwin.m
+++ b/internal/infra/audio/native_player_darwin.m
@@ -117,6 +117,16 @@ extern void goHandleRemoteSeek(double position);
 // --- Playback ---
 
 - (void)play {
+    // Resume from the paused position. playReturningError: restarts the
+    // AVAudioEngine and can reset the decoder to frame 0, so a paused track
+    // must be resumed via -resume (per SFBAudioPlayer semantics).
+    if (self.sfbPlayer.playbackState == SFBAudioPlayerPlaybackStatePaused) {
+        [self.sfbPlayer resume];
+        self.isPlaying = YES;
+        [self updatePlaybackRate];
+        return;
+    }
+
     NSError *err = nil;
     [self.sfbPlayer playReturningError:&err];
     if (err) {


### PR DESCRIPTION
## Problem

Sometimes pausing a playing track then clicking play reset the position to 0 and replayed the track from the beginning.

## Cause

The macOS native `play` method always called `playReturningError:`. Per SFBAudioPlayer semantics, that starts the AVAudioEngine and begins rendering — from a paused state it can reset the decoder to frame 0. Paused playback must use `-resume`.

## Fix

In `native_player_darwin.m`, `play` now calls `-resume` when `playbackState == SFBAudioPlayerPlaybackStatePaused`, falling back to `playReturningError:` otherwise.