### PR TITLE
feat(ui): add mouse scroll support to volume sliders

### DIFF
--- a/catalog/ui/README.md
+++ b/catalog/ui/README.md
@@ -198,6 +198,14 @@ Common dialogs are consolidated under the **`Modal.vue`** primitive. It provides
 | `MetadataEditDialog`  | Manual tag and artwork editing               |
 | `ConfirmDialog`       | Generic confirmation for destructive actions |
 
+## UI Primitives (`@airmedy/ui`)
+
+### Slider (`packages/ui/src/slider/Slider.vue`)
+
+Props: `modelValue`, `min`, `max`, `step`, `class`, `scrollable`.
+
+`scrollable` (default `false`) — enables mouse wheel to increment/decrement by one `step`. Use only on volume sliders; seek bar and other sliders must leave it unset to avoid hijacking page scroll. Currently enabled on: `PlayerVolumeControl.vue`, `PlayerFooter.vue` (volume only), `MiniPlayerFloating.vue` (volume popup), `remote/PlayerControls.vue`.
+
 ## Interactive Polish
 
 - **Auto-scroll to Active**: `TrackTable.vue` and `QueueDrawer.vue` automatically scroll to the currently playing track when opened or when the track changes. Uses a 100ms delay to ensure layout stability.

--- a/frontend/src/components/MiniPlayerFloating.vue
+++ b/frontend/src/components/MiniPlayerFloating.vue
@@ -107,7 +107,7 @@ watch(() => store.theme, (colors) => {
         <div v-if="showVolume && isHovered"
           class="absolute top-full right-0 mt-2 px-2.5 py-2 rounded-xl bg-black/20 backdrop-blur-md border border-white/5"
           @mouseenter="onVolumeEnter" @mouseleave="onVolumeLeave">
-          <Slider :model-value="store.muted ? 0 : store.volume * 100" :min="0" :max="100" :step="1" class="w-20"
+          <Slider :model-value="store.muted ? 0 : store.volume * 100" :min="0" :max="100" :step="1" :scrollable="true" class="w-20"
             @update:model-value="(v) => store.setVolume(v / 100)" />
         </div>
       </Transition>

--- a/frontend/src/components/PlayerFooter.vue
+++ b/frontend/src/components/PlayerFooter.vue
@@ -154,7 +154,7 @@ async function onSeekEnd() {
           <VolumeX v-if="store.muted" class="w-4 h-4" />
           <Volume2 v-else class="w-4 h-4" />
         </button>
-        <Slider :model-value="store.muted ? 0 : store.volume" :min="0" :max="1" :step="0.01" class="flex-1"
+        <Slider :model-value="store.muted ? 0 : store.volume" :min="0" :max="1" :step="0.01" :scrollable="true" class="flex-1"
           @update:model-value="(v) => store.setVolume(v)" />
       </div>
       <button class="transition-colors"

--- a/frontend/src/components/player/PlayerVolumeControl.vue
+++ b/frontend/src/components/player/PlayerVolumeControl.vue
@@ -23,7 +23,7 @@ const { t } = useI18n()
       <VolumeX v-if="muted" class="w-4 h-4" />
       <Volume2 v-else class="w-4 h-4" />
     </button>
-    <Slider :model-value="muted ? 0 : volume" :min="0" :max="1" :step="0.01" class="flex-1"
+    <Slider :model-value="muted ? 0 : volume" :min="0" :max="1" :step="0.01" :scrollable="true" class="flex-1"
       @update:model-value="(v) => emit('update:volume', v)" />
   </div>
 </template>

--- a/packages/ui/src/slider/Slider.vue
+++ b/packages/ui/src/slider/Slider.vue
@@ -8,6 +8,7 @@ const props = defineProps<{
   max?: number
   step?: number
   class?: string
+  scrollable?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -71,13 +72,21 @@ const handleEnd = (e: MouseEvent | TouchEvent) => {
   else emit('touchend', e)
 }
 
+const handleWheel = (e: WheelEvent) => {
+  const sign = e.deltaY > 0 ? -1 : 1
+  const next = Math.min(resolvedMax.value, Math.max(resolvedMin.value, localValue.value + sign * (props.step ?? 0.01)))
+  localValue.value = next
+  emit('update:modelValue', next)
+}
+
 onUnmounted(() => {
   if (graceTimeout) clearTimeout(graceTimeout)
 })
 </script>
 
 <template>
-  <div :class="cn('relative h-4 flex items-center group/slider cursor-pointer select-none', props.class)">
+  <div :class="cn('relative h-4 flex items-center group/slider cursor-pointer select-none', props.class)"
+    v-on="props.scrollable ? { wheel: handleWheel } : {}">
     <!-- Visual track -->
     <div class="absolute w-full h-1 rounded-full bg-foreground/15">
       <div

--- a/remote/src/components/PlayerControls.vue
+++ b/remote/src/components/PlayerControls.vue
@@ -124,6 +124,7 @@ function onVolumeUpdate(v: number) {
         :min="0"
         :max="1"
         :step="0.01"
+        :scrollable="true"
         class="flex-1"
         @update:model-value="onVolumeUpdate"
       />


### PR DESCRIPTION
## Summary

- Added `scrollable` prop to `Slider` component (`packages/ui/src/slider/Slider.vue`), default `false`
- Mouse wheel increments/decrements by one `step` when enabled; page scroll unaffected on non-scrollable sliders
- Enabled on all volume sliders: `PlayerVolumeControl`, `PlayerFooter`, `MiniPlayerFloating`, `remote/PlayerControls`
- Seek bar and other sliders unchanged

## Test plan

- [ ] Hover volume slider in player footer → scroll up/down → volume changes by 1%
- [ ] Hover seek bar → scroll → no seek change, page scrolls normally
- [ ] Scroll volume in mini player popup → volume changes
- [ ] Volume clamps at 0 and 1 (no overflow)
- [ ] Remote control volume slider scroll works