### PR TITLE
fix(lyrics): stop online fetch when prefer-local lyrics present

### DIFF
--- a/internal/app/lyrics/lyrics_service.go
+++ b/internal/app/lyrics/lyrics_service.go
@@ -104,6 +104,19 @@ func (s *LyricsService) SaveMetaLyrics(ctx context.Context, trackID, content, so
 //
 // Returns nil if nothing is available (caller may fetch from providers).
 func (s *LyricsService) ResolveLyrics(ctx context.Context, trackID, audioPath string, preferLocal bool, extraDirs ...string) *domain.Lyric {
+	resolved, _ := s.ResolveWithLocal(ctx, trackID, audioPath, preferLocal, extraDirs...)
+	return resolved
+}
+
+// ResolveWithLocal resolves the best lyric (see ResolveLyrics) and additionally
+// reports whether a local-tier lyric is present, derived from the SAME read.
+//
+// Callers that need both the display lyric and the "skip provider fetch"
+// decision must use this instead of pairing ResolveLyrics with a separate
+// HasLocalLyrics call: two independent reads double the chance that a transient
+// DB error (e.g. SQLITE_BUSY during a concurrent sync) makes the presence check
+// silently return false, wrongly triggering an online fetch.
+func (s *LyricsService) ResolveWithLocal(ctx context.Context, trackID, audioPath string, preferLocal bool, extraDirs ...string) (resolved *domain.Lyric, hasLocal bool) {
 	lyric, _ := s.repo.GetByTrackID(ctx, trackID)
 
 	// Build the local tier: sibling file beats embedded metadata tag.
@@ -139,7 +152,7 @@ func (s *LyricsService) ResolveLyrics(ctx context.Context, trackID, audioPath st
 		return &domain.Lyric{TrackID: trackID, Content: providerContent, Source: providerSource}
 	}
 
-	resolved := func() *domain.Lyric {
+	resolved = func() *domain.Lyric {
 		if preferLocal {
 			if l := local(); l != nil {
 				return l
@@ -152,12 +165,14 @@ func (s *LyricsService) ResolveLyrics(ctx context.Context, trackID, audioPath st
 		return local()
 	}()
 
+	hasLocal = localContent != ""
+
 	if resolved != nil {
 		s.logger.Debug("resolved lyrics", "track_id", trackID, "prefer_local", preferLocal, "source", resolved.Source)
 	} else {
 		s.logger.Debug("no lyrics resolved", "track_id", trackID, "prefer_local", preferLocal)
 	}
-	return resolved
+	return resolved, hasLocal
 }
 
 // HasLocalLyrics reports whether a local-tier lyric exists for the track: a

--- a/internal/app/player/player_service.go
+++ b/internal/app/player/player_service.go
@@ -784,14 +784,16 @@ func (s *PlayerService) fetchAndEmitLyrics(track *domain.TrackDTO) {
 	}
 
 	// 1. Emit the best currently-available lyric for the chosen preference.
-	lyric := s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, preferLocal, extraDirs...)
+	//    hasLocal comes from the SAME read, so the step-2 guard can't disagree
+	//    with what was just emitted due to a transient second-read failure.
+	lyric, hasLocal := s.lyricsService.ResolveWithLocal(ctx, track.ID, track.Path, preferLocal, extraDirs...)
 	if lyric != nil {
 		s.emitLyrics(track.ID, lyric)
 	}
 
 	// 2. When local lyrics are preferred and present, they win outright. Don't
 	//    fetch providers, so nothing overrides the displayed local lyric.
-	if preferLocal && s.lyricsService.HasLocalLyrics(ctx, track.ID, track.Path, extraDirs...) {
+	if preferLocal && hasLocal {
 		return
 	}
 


### PR DESCRIPTION
## Problem

With **prefer local lyrics** enabled and a track carrying embedded metadata lyrics, the app sometimes still fetched lyrics online and hung on the provider request. Intermittent, not every play.

## Root cause

`fetchAndEmitLyrics` read local-lyric presence twice:
1. `ResolveLyrics` — to emit the displayed lyric.
2. `HasLocalLyrics` — to gate the provider fetch.

`HasLocalLyrics` swallows the `GetByTrackID` error. On a transient SQLite `BUSY` (e.g. during a concurrent library sync) it returned `false`, so the fetch gate opened and an online request fired even though the metadata lyric was in the DB — blocking up to the 30s provider timeout. Two independent reads doubled the chance of a transient blip, hence the intermittency.

## Fix

Add `ResolveWithLocal`, returning the resolved lyric plus a `hasLocal` flag derived from the **same** read. `fetchAndEmitLyrics` uses it for both the emit and the skip-fetch decision, so they can no longer disagree.