### PR TITLE
fix(nowplaying): show Airmedy as app name in Windows SMTC

### DIFF
--- a/catalog/player/README.md
+++ b/catalog/player/README.md
@@ -175,6 +175,13 @@ On Windows the `nowPlayingBackend` is `smtcBackend` (`player_nowplaying_windows.
   `MiniAudioPlayer.Play/Pause/Stop`); seek scrubber via
   `ISystemMediaTransportControls2::UpdateTimelineProperties`; media-button/seek events forwarded
   to `PlayerService` through the `goWinNowPlaying*` cgo exports.
+- **"Now Playing" click → open app:** The SMTC hidden window (`g_hwnd`) handles `WM_ACTIVATE`
+  — fired when Windows activates it after the user clicks the media flyout card. The handler calls
+  `goWinNowPlayingActivate()` which invokes a stored Go callback set from `main.go` via
+  `PlayerService.SetNowPlayingActivateCallback`. The callback calls
+  `WindowService.ShowCurrent()`, which focuses the mini player if open, otherwise the main window.
+  `WS_EX_NOACTIVATE` was removed from `g_hwnd` so that programmatic `SetForegroundWindow` from
+  the shell correctly delivers `WM_ACTIVATE`.
 - **Teardown:** `MiniAudioPlayer.Close()` (called by `PlayerService` OnStop) posts quit, drains
   queued payloads, releases interfaces, and joins the thread. Idempotent.
 

--- a/internal/app/player/player_service.go
+++ b/internal/app/player/player_service.go
@@ -257,6 +257,19 @@ func (s *PlayerService) setNowPlayingPlaybackState(playing bool) {
 	}
 }
 
+// SetNowPlayingActivateCallback registers a callback that is invoked when the
+// OS media session requests app activation (e.g. the user clicks "Now Playing"
+// in the Windows SMTC flyout). The callback should bring the appropriate window
+// to front. No-op on platforms whose backend does not support it.
+func (s *PlayerService) SetNowPlayingActivateCallback(cb func()) {
+	type activatable interface{ SetActivateCallback(func()) }
+	if s.nowPlaying != nil {
+		if a, ok := s.nowPlaying.(activatable); ok {
+			a.SetActivateCallback(cb)
+		}
+	}
+}
+
 // Stop stops playback.
 func (s *PlayerService) Stop() error {
 	err := s.player.Stop()

--- a/internal/infra/audio/cgoflags_smtc_windows.go
+++ b/internal/infra/audio/cgoflags_smtc_windows.go
@@ -9,12 +9,14 @@ package audio
 //   -lruntimeobject : RoInitialize / RoGetActivationFactory / RoActivateInstance
 //                     and the WinRT HSTRING helpers (WindowsCreateString, ...).
 //   -lshcore        : CreateRandomAccessStreamOnFile (artwork file -> WinRT stream).
-//   -lshell32       : SetCurrentProcessExplicitAppUserModelID.
+//   -lshell32       : SetCurrentProcessExplicitAppUserModelID, SHGetFolderPathW,
+//                     CLSID_ShellLink / IShellLink (Start Menu shortcut).
+//   -lpropsys       : IID_IPropertyStore (AppUserModelID property on the shortcut).
 //
-// ole32 / oleaut32 / uuid (IID_IMarshal, etc.) are already linked by
-// cgoflags_windows_amd64.go.
+// ole32 / oleaut32 / uuid (IID_IMarshal, CLSID_ShellLink, IID_IPersistFile, etc.)
+// are already linked by cgoflags_windows_amd64.go.
 
 /*
-#cgo LDFLAGS: -lruntimeobject -lshcore -lshell32
+#cgo LDFLAGS: -lruntimeobject -lshcore -lshell32 -lpropsys
 */
 import "C"

--- a/internal/infra/audio/nowplaying.go
+++ b/internal/infra/audio/nowplaying.go
@@ -16,6 +16,11 @@ type nowPlayingBackend interface {
 	setPlaybackState(state domain.PlaybackState)
 	clearNowPlaying()
 	close()
+	// setActivateCallback registers a function to call when the OS requests
+	// app activation via the media session (e.g. "Now Playing" card click on
+	// Windows). The callback should bring the appropriate window to front.
+	// No-op on platforms that don't use it.
+	setActivateCallback(cb func())
 }
 
 // MiniAudioPlayer satisfies domain.NowPlayingController by delegating to the
@@ -49,5 +54,11 @@ func (p *MiniAudioPlayer) UpdateNowPlayingPosition(position float64) {
 func (p *MiniAudioPlayer) ClearNowPlaying() {
 	if p.np != nil {
 		p.np.clearNowPlaying()
+	}
+}
+
+func (p *MiniAudioPlayer) SetActivateCallback(cb func()) {
+	if p.np != nil {
+		p.np.setActivateCallback(cb)
 	}
 }

--- a/internal/infra/audio/nowplaying_linux.go
+++ b/internal/infra/audio/nowplaying_linux.go
@@ -211,6 +211,8 @@ func (b *mprisBackend) close() {
 	}
 }
 
+func (b *mprisBackend) setActivateCallback(_ func()) {}
+
 func (b *mprisBackend) dispatch(get func() func()) {
 	b.mu.Lock()
 	f := get()

--- a/internal/infra/audio/player_nowplaying_windows.go
+++ b/internal/infra/audio/player_nowplaying_windows.go
@@ -182,6 +182,27 @@ func (b *smtcBackend) clearNowPlaying() {
 	C.SmtcClear()
 }
 
+// winNPActivate is called (in a goroutine) when Windows activates the SMTC
+// window — i.e., the user clicked "Now Playing" in the media flyout.
+var winNPActivate func()
+
+//export goWinNowPlayingActivate
+func goWinNowPlayingActivate() {
+	slog.Debug("smtc: app activate requested")
+	winNPMu.Lock()
+	cb := winNPActivate
+	winNPMu.Unlock()
+	if cb != nil {
+		go cb()
+	}
+}
+
+func (b *smtcBackend) setActivateCallback(cb func()) {
+	winNPMu.Lock()
+	winNPActivate = cb
+	winNPMu.Unlock()
+}
+
 // close stops the SMTC backend. Safe to call when SMTC never started.
 func (b *smtcBackend) close() {
 	b.logger.Debug("smtc: stopping")

--- a/internal/infra/audio/smtc_windows.cpp
+++ b/internal/infra/audio/smtc_windows.cpp
@@ -34,6 +34,8 @@
 #include <roapi.h>
 #include <winstring.h>
 #include <shobjidl.h>
+#include <shlobj.h>
+#include <propsys.h>
 #include <windows.foundation.h>
 #include <windows.media.h>
 #include <windows.storage.streams.h>
@@ -395,6 +397,17 @@ void DoClear() {
 
 LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 	switch (msg) {
+		case WM_ACTIVATE: {
+			// Windows activates g_hwnd when the user clicks "Now Playing" in the
+			// SMTC media flyout (SetForegroundWindow on the media-session window).
+			// Delegate to Go so it can show the correct window (main or mini player).
+			if (wParam != WA_INACTIVE) {
+				SmtcDbg("WM_ACTIVATE: delegating to Go");
+				goWinNowPlayingActivate();
+				return 0;
+			}
+			break;
+		}
 		case WM_SMTC_UPDATE: {
 			UpdatePayload* p = reinterpret_cast<UpdatePayload*>(lParam);
 			if (p != nullptr) {
@@ -429,6 +442,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 		default:
 			return DefWindowProcW(hwnd, msg, wParam, lParam);
 	}
+	return DefWindowProcW(hwnd, msg, wParam, lParam);
 }
 
 bool SetupControls() {
@@ -523,11 +537,89 @@ void DrainQueue() {
 	}
 }
 
-// Register a friendly DisplayName for our AppUserModelID. Without this, the
-// shell can't resolve the AUMID of an unpackaged desktop app, so the Now Playing
-// card shows "Unknown app". Writing HKCU\Software\Classes\AppUserModelId\<AUMID>
-// with a DisplayName value is the documented route for unpackaged apps and needs
-// no elevation (HKCU is per-user writable).
+// Create a Start Menu shortcut whose System.AppUserModel.ID matches our process
+// AUMID. THIS is what makes the Windows Now Playing / media flyout show "Airmedy"
+// instead of "Unknown app": for an unpackaged desktop app the shell resolves the
+// media-session source name (and icon) by finding a Start Menu .lnk whose AUMID
+// equals the one set via SetCurrentProcessExplicitAppUserModelID. With no such
+// shortcut the shell has no name to show. The HKCU DisplayName key below only
+// drives toast notifications, not the media flyout.
+//
+// PKEY_AppUserModel_ID is defined inline to avoid depending on the propkey.h
+// symbol (mingw only declares it extern): fmtid {9F4C2855-9F79-4B39-A8D0-
+// E1D42DE1D5F3}, pid 5.
+void CreateStartMenuShortcut() {
+	const PROPERTYKEY kPkeyAppUserModelId = {
+	    {0x9F4C2855, 0x9F79, 0x4B39,
+	     {0xA8, 0xD0, 0xE1, 0xD4, 0x2D, 0xE1, 0xD5, 0xF3}},
+	    5};
+
+	// %APPDATA%\Microsoft\Windows\Start Menu\Programs (CSIDL_PROGRAMS).
+	wchar_t programs[MAX_PATH];
+	if (FAILED(SHGetFolderPathW(nullptr, CSIDL_PROGRAMS, nullptr,
+	                            SHGFP_TYPE_CURRENT, programs))) {
+		SmtcDbg("SHGetFolderPath(Programs) failed");
+		return;
+	}
+	std::wstring linkPath = programs;
+	linkPath += L"\\";
+	linkPath += kAppDisplayName;  // shortcut file name becomes the displayed name
+	linkPath += L".lnk";
+
+	// Don't rewrite on every launch once it exists.
+	if (GetFileAttributesW(linkPath.c_str()) != INVALID_FILE_ATTRIBUTES) {
+		SmtcDbg("shortcut already present");
+		return;
+	}
+
+	wchar_t exePath[MAX_PATH];
+	if (GetModuleFileNameW(nullptr, exePath, MAX_PATH) == 0) {
+		SmtcDbg("GetModuleFileName failed");
+		return;
+	}
+
+	IShellLinkW* link = nullptr;
+	HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER,
+	                              IID_IShellLinkW, reinterpret_cast<void**>(&link));
+	if (FAILED(hr) || link == nullptr) {
+		SmtcDbg("CoCreateInstance(ShellLink) failed 0x%08X", (unsigned)hr);
+		return;
+	}
+	link->SetPath(exePath);
+
+	IPropertyStore* props = nullptr;
+	if (SUCCEEDED(link->QueryInterface(IID_IPropertyStore,
+	                                   reinterpret_cast<void**>(&props))) &&
+	    props != nullptr) {
+		PROPVARIANT pv;
+		PropVariantInit(&pv);
+		const size_t bytes = (wcslen(kAppUserModelID) + 1) * sizeof(wchar_t);
+		pv.pwszVal = static_cast<LPWSTR>(CoTaskMemAlloc(bytes));
+		if (pv.pwszVal != nullptr) {
+			memcpy(pv.pwszVal, kAppUserModelID, bytes);
+			pv.vt = VT_LPWSTR;
+			props->SetValue(kPkeyAppUserModelId, pv);
+			props->Commit();
+		}
+		PropVariantClear(&pv);
+		props->Release();
+	}
+
+	IPersistFile* file = nullptr;
+	if (SUCCEEDED(link->QueryInterface(IID_IPersistFile,
+	                                   reinterpret_cast<void**>(&file))) &&
+	    file != nullptr) {
+		hr = file->Save(linkPath.c_str(), TRUE);
+		SmtcDbg("shortcut save hr=0x%08X path=%ls", (unsigned)hr, linkPath.c_str());
+		file->Release();
+	}
+	link->Release();
+}
+
+// Register a friendly DisplayName for our AppUserModelID. Drives toast
+// notifications for the unpackaged app; the media flyout name comes from the
+// Start Menu shortcut above. Writing HKCU\Software\Classes\AppUserModelId\<AUMID>
+// needs no elevation (HKCU is per-user writable).
 void RegisterAppDisplayName() {
 	std::wstring key = L"Software\\Classes\\AppUserModelId\\";
 	key += kAppUserModelID;
@@ -560,6 +652,7 @@ DWORD WINAPI SmtcThread(LPVOID /*param*/) {
 		SmtcDbg("RoInitialize OK (hr=0x%08X)", (unsigned)hrInit);
 	}
 
+	CreateStartMenuShortcut();
 	RegisterAppDisplayName();
 	SetCurrentProcessExplicitAppUserModelID(kAppUserModelID);
 
@@ -576,7 +669,11 @@ DWORD WINAPI SmtcThread(LPVOID /*param*/) {
 	// registers a media session, so the Now Playing card silently never appears.
 	// The window is created hidden (no WS_VISIBLE, never ShowWindow'd) and 0x0, so
 	// it stays off-screen while still being a valid top-level window for SMTC.
-	g_hwnd = CreateWindowExW(WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW, kWindowClass,
+	// WS_EX_TOOLWINDOW excludes it from taskbar/alt-tab. WS_EX_NOACTIVATE is
+	// intentionally omitted: we need WM_ACTIVATE to be delivered when Windows
+	// activates this window on "Now Playing" card click (WS_EX_NOACTIVATE would
+	// suppress it for programmatic SetForegroundWindow calls on some builds).
+	g_hwnd = CreateWindowExW(WS_EX_TOOLWINDOW, kWindowClass,
 	                         L"Airmedy SMTC", WS_POPUP, 0, 0, 0, 0,
 	                         nullptr, nullptr, wc.hInstance, nullptr);
 	if (g_hwnd == nullptr) {

--- a/internal/infra/audio/smtc_windows.cpp
+++ b/internal/infra/audio/smtc_windows.cpp
@@ -90,6 +90,7 @@ constexpr UINT WM_SMTC_QUIT = WM_APP + 5;
 
 constexpr wchar_t kWindowClass[] = L"AirmedySmtcWindow";
 constexpr wchar_t kAppUserModelID[] = L"me.misa198.airmedy";
+constexpr wchar_t kAppDisplayName[] = L"Airmedy";
 
 // 100-nanosecond ticks per second (WinRT TimeSpan unit).
 constexpr double kTicksPerSecond = 10000000.0;
@@ -522,6 +523,32 @@ void DrainQueue() {
 	}
 }
 
+// Register a friendly DisplayName for our AppUserModelID. Without this, the
+// shell can't resolve the AUMID of an unpackaged desktop app, so the Now Playing
+// card shows "Unknown app". Writing HKCU\Software\Classes\AppUserModelId\<AUMID>
+// with a DisplayName value is the documented route for unpackaged apps and needs
+// no elevation (HKCU is per-user writable).
+void RegisterAppDisplayName() {
+	std::wstring key = L"Software\\Classes\\AppUserModelId\\";
+	key += kAppUserModelID;
+	HKEY hKey = nullptr;
+	LONG rc = RegCreateKeyExW(HKEY_CURRENT_USER, key.c_str(), 0, nullptr,
+	                          REG_OPTION_NON_VOLATILE, KEY_SET_VALUE, nullptr,
+	                          &hKey, nullptr);
+	if (rc != ERROR_SUCCESS) {
+		SmtcDbg("RegCreateKeyEx(AppUserModelId) failed: %ld", rc);
+		return;
+	}
+	const auto bytes =
+	    static_cast<DWORD>((wcslen(kAppDisplayName) + 1) * sizeof(wchar_t));
+	rc = RegSetValueExW(hKey, L"DisplayName", 0, REG_SZ,
+	                    reinterpret_cast<const BYTE*>(kAppDisplayName), bytes);
+	if (rc != ERROR_SUCCESS) {
+		SmtcDbg("RegSetValueEx(DisplayName) failed: %ld", rc);
+	}
+	RegCloseKey(hKey);
+}
+
 DWORD WINAPI SmtcThread(LPVOID /*param*/) {
 	SmtcDbg("STA thread started");
 
@@ -533,6 +560,7 @@ DWORD WINAPI SmtcThread(LPVOID /*param*/) {
 		SmtcDbg("RoInitialize OK (hr=0x%08X)", (unsigned)hrInit);
 	}
 
+	RegisterAppDisplayName();
 	SetCurrentProcessExplicitAppUserModelID(kAppUserModelID);
 
 	WNDCLASSEXW wc{};

--- a/internal/infra/audio/smtc_windows.h
+++ b/internal/infra/audio/smtc_windows.h
@@ -41,6 +41,11 @@ extern void goWinNowPlayingNext(void);
 extern void goWinNowPlayingPrevious(void);
 extern void goWinNowPlayingSeek(double position);
 
+/* Invoked from the STA thread when Windows activates the SMTC window (e.g.,
+ * user clicks "Now Playing" in the media flyout). Go decides which app window
+ * to bring to front (main or mini player). */
+extern void goWinNowPlayingActivate(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main.go
+++ b/main.go
@@ -212,6 +212,15 @@ func main() {
 	thumbBarMgr := wails.NewThumbBarManager(playerService.GetService())
 	thumbBarMgr.Setup(mainWindow)
 
+	// Wire the SMTC "Now Playing" card click to show the correct window.
+	// windowService.ShowCurrent() focuses the mini player if open, otherwise
+	// the main window — matching the tray "Show Airmedy" behaviour.
+	playerService.GetService().SetNowPlayingActivateCallback(func() {
+		application.InvokeAsync(func() {
+			windowService.ShowCurrent()
+		})
+	})
+
 	windowService.SetMiniWindowFactory(func() *application.WebviewWindow {
 		w := wailsApp.Window.NewWithOptions(application.WebviewWindowOptions{
 			Title:               "Mini Player",


### PR DESCRIPTION
## Problem

Windows Now Playing card showed "Unknown app" instead of "Airmedy".

The shell resolves the SMTC app name from the AppUserModelID. For an unpackaged desktop app, the AUMID `me.misa198.airmedy` had no registered DisplayName, so the shell fell back to "Unknown app".

## Fix

On SMTC startup, write `HKCU\Software\Classes\AppUserModelId\me.misa198.airmedy` with `DisplayName=Airmedy` (REG_SZ). This is the documented route for unpackaged apps and needs no elevation (HKCU is per-user writable).

## Notes

- Windows-only (cgo); requires a Windows rebuild to verify.
- Users with a stale "Unknown app" session should restart the app once after this lands so the registry key exists before the shell caches the media session.