### PR TITLE
fix(lyrics): restore lyrics on app reopen after session restore

### DIFF
--- a/catalog/database/README.md
+++ b/catalog/database/README.md
@@ -52,6 +52,7 @@ SQLite database managed via `golang-migrate` for schema versioning and `sqlx` fo
 | 000030 | `tag_delimiters.up.sql`              | Add `artist_delimiters`, `album_artist_delimiters`, `genre_delimiters`, `composer_delimiters` to `app_settings` (TEXT, JSON arrays, default `'[";","\\",","]'`) — user-configurable multi-value tag splitting |
 | 000031 | `library_sync_state.up.sql`          | Add `library_sync_state` table (single-row, CHECK id = 1) with `delimiters_signature TEXT` — records the delimiter config the library data currently reflects, so a sync knows whether to re-split |
 | 000032 | `add_comma_default_delimiter.up.sql` | Add `,` to the default delimiter set: `UPDATE app_settings SET <col> = '[";","\\",","]' WHERE <col> = '[";","\\"]'` (only rows still on the previous default; user-customized lists untouched) |
+| 000033 | `update_default_delimiters.up.sql`   | Update default delimiters: change single backslash `\` to double backslash `\\` (JSON `'[";","\\\\",","]'`) for rows still on the previous default |
 
 ## Full Schema
 
@@ -200,10 +201,10 @@ app_settings (
     lyrics_folder_path TEXT NOT NULL DEFAULT '',
     lyrics_subfolder_enabled BOOLEAN NOT NULL DEFAULT 0,
     lyrics_subfolder_name TEXT NOT NULL DEFAULT '',
-    artist_delimiters TEXT NOT NULL DEFAULT '[";","\\",","]',        -- JSON array; empty [] = no splitting
-    album_artist_delimiters TEXT NOT NULL DEFAULT '[";","\\",","]',  -- JSON array
-    genre_delimiters TEXT NOT NULL DEFAULT '[";","\\",","]',         -- JSON array
-    composer_delimiters TEXT NOT NULL DEFAULT '[";","\\",","]',      -- JSON array
+    artist_delimiters TEXT NOT NULL DEFAULT '[";","\\\\",","]',        -- JSON array; empty [] = no splitting
+    album_artist_delimiters TEXT NOT NULL DEFAULT '[";","\\\\",","]',  -- JSON array
+    genre_delimiters TEXT NOT NULL DEFAULT '[";","\\\\",","]',         -- JSON array
+    composer_delimiters TEXT NOT NULL DEFAULT '[";","\\\\",","]',      -- JSON array
     updated_at DATETIME
     -- (also: prevent_sleep_while_playing, remote_server_*, show_player_indicator)
 )

--- a/catalog/search/README.md
+++ b/catalog/search/README.md
@@ -21,8 +21,14 @@ type SearchService interface {
     IndexArtist(ctx context.Context, artist *Artist) error
     IndexPlaylist(ctx context.Context, playlist *Playlist) error
     IndexComposer(ctx context.Context, composer *Composer) error
+    BatchReindex(ctx context.Context, data *ReindexData, onProgress func(path string)) error
     Search(ctx context.Context, query string) ([]SearchResult, error)
     DeleteFromIndex(ctx context.Context, id string) error
+    DeleteAlbumFromIndex(ctx context.Context, albumID string) error
+    DeleteArtistFromIndex(ctx context.Context, artistID string) error
+    DeleteComposerFromIndex(ctx context.Context, composerID string) error
+    DocCount(ctx context.Context) (uint64, error)
+    Reset(ctx context.Context) error
     Close() error
 }
 ```
@@ -46,7 +52,7 @@ type SearchService interface {
 **Field types:**
 
 - `id`, `type` — keyword (exact match, stored, not analyzed)
-- All other fields — text (analyzed with standard tokenizer, not stored)
+- All other fields — text (analyzed with custom "no_stop_words" analyzer using unicode tokenizer and lowercase filter, preserving English and Vietnamese stop words like "more", "than", "you", "the", "a", etc.; not stored)
 
 All text values are normalized via `domain.FoldUnicode()` before indexing.
 
@@ -91,13 +97,14 @@ interface SearchResultSet {
 
 ## Index Lifecycle
 
-| Operation           | When                                        |
-| ------------------- | ------------------------------------------- |
-| `IndexTrack()`      | After every file import                     |
-| `IndexAlbum()`      | After album upsert                          |
-| `IndexPlaylist()`   | On create/update                            |
-| `DeleteFromIndex()` | On track/playlist delete                    |
-| `ReindexAll()`      | Full rebuild (user-triggered from Settings) |
+| Operation           | When                                                                                                                    |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `IndexTrack()`      | After every file import                                                                                                 |
+| `IndexAlbum()`      | After album upsert                                                                                                      |
+| `IndexPlaylist()`   | On create/update                                                                                                        |
+| `DeleteFromIndex()` | On track/playlist delete                                                                                                |
+| `Reset()`           | Called at the start of a full reindex to delete the old index files on disk and recreate it with the correct mapping    |
+| `ReindexAll()`      | Re-indexes all data (called on settings resync, user-triggered optimize search, or auto-triggered on startup if index is empty) |
 
 ## Frontend Integration
 

--- a/catalog/settings/README.md
+++ b/catalog/settings/README.md
@@ -223,3 +223,4 @@ Settings evolved across multiple migrations:
 | 000028    | Re-add `prefer_local_artist_artwork BOOLEAN NOT NULL DEFAULT 1` (nested sub-toggle under online artwork) |
 | 000030    | Add `artist_delimiters`, `album_artist_delimiters`, `genre_delimiters`, `composer_delimiters` (TEXT JSON arrays, default `'[";","\\",","]'`) |
 | 000032    | Add `,` to the default delimiter set for rows still on the previous default `'[";","\\"]'` |
+| 000033    | Update default delimiters: change single backslash `\` to double backslash `\\` (JSON `'[";","\\\\",","]'`) for rows still on the previous default |

--- a/frontend/src/components/FindLyricsDialog.vue
+++ b/frontend/src/components/FindLyricsDialog.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { Search, X, Loader2, Music, User, Globe } from 'lucide-vue-next'
+import { Search, X, Loader2, Music, User, Globe, Clock } from 'lucide-vue-next'
 import { Modal } from '@airmedy/ui'
 import { Input } from '@airmedy/ui'
 import { useFindLyricsDialog } from '@/composables/useFindLyricsDialog'
 import { usePlayerStore } from '@/stores/player'
+import { formatTime } from '@airmedy/utils'
 import * as LyricsService from '../../bindings/airmedy/internal/infra/wails/lyricsservice'
 import type { LyricsSearchResult } from '../../bindings/airmedy/internal/domain/models'
 
@@ -18,6 +19,11 @@ const searchArtist = ref('')
 const isSearching = ref(false)
 const results = ref<LyricsSearchResult[]>([])
 const selectedIndex = ref(-1)
+
+const formattedDuration = computed(() => {
+  if (!targetTrack.value?.duration) return '0:00'
+  return formatTime(targetTrack.value.duration)
+})
 
 watch(isVisible, (val) => {
   if (val && targetTrack.value) {
@@ -72,7 +78,7 @@ async function save() {
 <template>
   <Modal
     :open="isVisible"
-    width-class="max-w-4xl w-full h-[80vh] !p-0 flex flex-col overflow-hidden"
+    width-class="max-w-4xl w-full h-[82vh] !p-0 flex flex-col overflow-hidden"
     @close="close"
   >
     <!-- Header -->
@@ -113,6 +119,18 @@ async function save() {
                 class="pl-10" 
                 clearable
                 @keyup.enter="search" 
+              />
+            </div>
+          </div>
+          <div class="space-y-2">
+            <label class="text-xs font-medium text-muted-foreground uppercase">{{ t('track_info.duration') }}</label>
+            <div class="relative">
+              <Clock class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground z-10 pointer-events-none" />
+              <Input 
+                :model-value="formattedDuration" 
+                type="text" 
+                class="pl-10" 
+                disabled
               />
             </div>
           </div>

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -34,7 +34,7 @@ export const useAppStore = defineStore('app', () => {
   const remoteServerPassword = ref('')
 
   // User-configurable delimiters for splitting multi-value tags.
-  const DEFAULT_DELIMITERS = [';', '\\', ',']
+  const DEFAULT_DELIMITERS = [';', '\\\\', ',']
   const artistDelimiters = ref<string[]>([...DEFAULT_DELIMITERS])
   const albumArtistDelimiters = ref<string[]>([...DEFAULT_DELIMITERS])
   const genreDelimiters = ref<string[]>([...DEFAULT_DELIMITERS])

--- a/frontend/src/stores/player.ts
+++ b/frontend/src/stores/player.ts
@@ -2,7 +2,6 @@ import { defineStore } from 'pinia'
 import { ref, shallowRef, computed, watch } from 'vue'
 import { Events } from '@wailsio/runtime'
 import * as PlayerService from '../../bindings/airmedy/internal/infra/wails/playerservice'
-import * as LyricsService from '../../bindings/airmedy/internal/infra/wails/lyricsservice'
 import { PlaybackState, PlayerStatus, RepeatMode, ThemeColors } from '../../bindings/airmedy/internal/domain/models'
 import type { Lyric, TrackDTO } from '../../bindings/airmedy/internal/domain/models'
 import { buildArtworkUrl, logger } from '@airmedy/utils'
@@ -177,11 +176,13 @@ export const usePlayerStore = defineStore('player', () => {
       }),
     ]
 
-    // Pull lyrics for current track in case player:lyrics event fired before listener registration
+    // Pull lyrics for current track in case player:lyrics event fired before listener registration.
+    // Use the player's resolver (not raw GetLyrics) so a restored track recovers lyrics that live
+    // only in a sibling file or embedded metadata tag, not just cached provider content.
     if (currentTrack.value) {
       const trackId = currentTrack.value.id
       try {
-        const lyric = await LyricsService.GetLyrics(trackId)
+        const lyric = await PlayerService.GetCurrentLyrics()
         if (lyric && currentTrack.value?.id === trackId) {
           lyrics.value = lyric
           lyricsLoading.value = false

--- a/frontend/src/stores/player.ts
+++ b/frontend/src/stores/player.ts
@@ -183,8 +183,8 @@ export const usePlayerStore = defineStore('player', () => {
       const trackId = currentTrack.value.id
       try {
         const lyric = await PlayerService.GetCurrentLyrics()
-        if (lyric && currentTrack.value?.id === trackId) {
-          lyrics.value = lyric
+        if (currentTrack.value?.id === trackId) {
+          lyrics.value = lyric ?? null
           lyricsLoading.value = false
         }
       } catch (e) {

--- a/internal/app/library/service.go
+++ b/internal/app/library/service.go
@@ -194,6 +194,23 @@ func (s *LibraryService) Start(ctx context.Context) error {
 	go s.watchLoop()
 	go s.StartArtistArtworkWorker(s.ctx)
 	go s.maybeRescanArtistImages(s.ctx)
+
+	// If the search index is completely empty but the library has tracks,
+	// automatically trigger a full re-indexing of the search index in the background.
+	go func() {
+		time.Sleep(2 * time.Second)
+		trackCount, err := s.trackRepo.Count(s.ctx)
+		if err == nil && trackCount > 0 {
+			docCount, err := s.searchService.DocCount(s.ctx)
+			if err == nil && docCount == 0 {
+				s.logger.Info("Search index is empty but database has tracks. Rebuilding search index...")
+				if err := s.ReindexAll(s.ctx); err != nil {
+					s.logger.Warn("Failed to rebuild search index on startup", "error", err)
+				}
+			}
+		}
+	}()
+
 	return nil
 }
 
@@ -1452,6 +1469,12 @@ func (s *LibraryService) GetAlbumColors(ctx context.Context, id string) (*domain
 
 func (s *LibraryService) ReindexAll(ctx context.Context) error {
 	s.logger.Info("Starting full library re-indexing")
+
+	// Reset search index to apply the new mapping/analyzer
+	if err := s.searchService.Reset(ctx); err != nil {
+		s.logger.Error("Failed to reset search index", "error", err)
+		return fmt.Errorf("failed to reset search index: %w", err)
+	}
 
 	// Calculate total items
 	tracks, _ := s.trackRepo.GetAll(ctx)

--- a/internal/app/library/service_test.go
+++ b/internal/app/library/service_test.go
@@ -193,6 +193,7 @@ func (m *mockSearchService) DeleteFromIndex(ctx context.Context, id string) erro
 func (m *mockSearchService) DeleteAlbumFromIndex(ctx context.Context, albumID string) error { return nil }
 func (m *mockSearchService) DeleteArtistFromIndex(ctx context.Context, artistID string) error { return nil }
 func (m *mockSearchService) DeleteComposerFromIndex(ctx context.Context, composerID string) error { return nil }
+func (m *mockSearchService) DocCount(ctx context.Context) (uint64, error) { return 0, nil }
 
 type mockArtworkCache struct{ domain.ArtworkCache }
 func (m *mockArtworkCache) Save(ctx context.Context, data []byte, mimeType string) (string, error) { return "", nil }

--- a/internal/app/player/player_service.go
+++ b/internal/app/player/player_service.go
@@ -773,27 +773,56 @@ func resolveLyricsSubdir(parent, name string) string {
 	return exact
 }
 
+// lyricsResolveParams builds the preference + extra lyric dirs used by both the
+// emit-on-track-change path and the pull-based GetCurrentLyrics. Extra dirs are
+// in priority order (sibling dir is always checked first by the reader):
+// subfolder next to the track, then the global lyrics folder.
+func (s *PlayerService) lyricsResolveParams(ctx context.Context, track *domain.TrackDTO) (preferLocal bool, extraDirs []string) {
+	settings, err := s.settingsRepo.Load(ctx)
+	if err != nil {
+		settings = &domain.AppSettings{}
+	}
+	preferLocal = settings.PreferLocalLyrics
+	if settings.LyricsSubfolderEnabled && validLyricsSubfolderName(settings.LyricsSubfolderName) {
+		extraDirs = append(extraDirs, resolveLyricsSubdir(filepath.Dir(track.Path), settings.LyricsSubfolderName))
+	}
+	if settings.LyricsFolderEnabled && settings.LyricsFolderPath != "" {
+		extraDirs = append(extraDirs, settings.LyricsFolderPath)
+	}
+	return preferLocal, extraDirs
+}
+
+// GetCurrentLyrics resolves the best available lyric for the currently loaded
+// track (sibling file, embedded metadata tag, or cached provider content),
+// honoring the user's local-vs-provider preference. Used by the frontend on
+// startup to recover lyrics for a restored track, since the restore-time
+// player:lyrics emit happens before the frontend's listener is registered.
+func (s *PlayerService) GetCurrentLyrics() *domain.Lyric {
+	if s.lyricsService == nil {
+		return nil
+	}
+	s.mu.RLock()
+	track := s.currentTrack
+	s.mu.RUnlock()
+	if track == nil {
+		return nil
+	}
+	ctx := context.Background()
+	preferLocal, extraDirs := s.lyricsResolveParams(ctx, track)
+	return s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, preferLocal, extraDirs...)
+}
+
 func (s *PlayerService) fetchAndEmitLyrics(track *domain.TrackDTO) {
 	if s.lyricsService == nil {
 		return
 	}
 	ctx := context.Background()
 
+	preferLocal, extraDirs := s.lyricsResolveParams(ctx, track)
+
 	settings, err := s.settingsRepo.Load(ctx)
 	if err != nil {
 		settings = &domain.AppSettings{}
-	}
-
-	preferLocal := settings.PreferLocalLyrics
-
-	// Extra lyric dirs in priority order (sibling dir is always checked first by
-	// the reader): subfolder next to the track, then the global lyrics folder.
-	var extraDirs []string
-	if settings.LyricsSubfolderEnabled && validLyricsSubfolderName(settings.LyricsSubfolderName) {
-		extraDirs = append(extraDirs, resolveLyricsSubdir(filepath.Dir(track.Path), settings.LyricsSubfolderName))
-	}
-	if settings.LyricsFolderEnabled && settings.LyricsFolderPath != "" {
-		extraDirs = append(extraDirs, settings.LyricsFolderPath)
 	}
 
 	// 1. Emit the best currently-available lyric for the chosen preference.

--- a/internal/app/player/player_service.go
+++ b/internal/app/player/player_service.go
@@ -829,7 +829,18 @@ func (s *PlayerService) fetchAndEmitLyrics(track *domain.TrackDTO) {
 	//    hasLocal comes from the SAME read, so the step-2 guard can't disagree
 	//    with what was just emitted due to a transient second-read failure.
 	lyric, hasLocal := s.lyricsService.ResolveWithLocal(ctx, track.ID, track.Path, preferLocal, extraDirs...)
-	if lyric != nil {
+
+	// Check if we will fetch online lyrics.
+	dbLyric, _ := s.lyricsService.GetLyrics(ctx, track.ID)
+	hasExternal := dbLyric != nil && dbLyric.Content != ""
+	anyProviderEnabled := settings.EnableLrclib || settings.EnableKugou
+	willFetch := (!preferLocal || !hasLocal) && !hasExternal && anyProviderEnabled
+
+	// Only emit immediately if we are not going to fetch, or if the lyric
+	// we have is already the preferred type (e.g. we prefer local, or we have cached external).
+	// If we will fetch and prefer online lyrics, we hold off emitting the local fallback
+	// lyric to avoid a visual flash on the UI.
+	if lyric != nil && (!willFetch || preferLocal) {
 		s.emitLyrics(track.ID, lyric)
 	}
 
@@ -840,10 +851,7 @@ func (s *PlayerService) fetchAndEmitLyrics(track *domain.TrackDTO) {
 	}
 
 	// 3. Fetch from providers when enabled and not already cached.
-	dbLyric, _ := s.lyricsService.GetLyrics(ctx, track.ID)
-	hasExternal := dbLyric != nil && dbLyric.Content != ""
-	anyProviderEnabled := settings.EnableLrclib || settings.EnableKugou
-	if !hasExternal && anyProviderEnabled {
+	if willFetch {
 		if _, err := s.lyricsService.FetchFromProviders(ctx, track, settings.EnableLrclib, settings.EnableKugou); err != nil {
 			s.logger.Warn("failed to fetch lyrics from providers", "track_id", track.ID, "error", err)
 		}
@@ -852,9 +860,7 @@ func (s *PlayerService) fetchAndEmitLyrics(track *domain.TrackDTO) {
 	// 4. Re-resolve so the final emit honors the preference now that provider
 	//    content may be cached. This is the single source of priority truth.
 	resolved := s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, preferLocal, extraDirs...)
-	if resolved != nil {
-		s.emitLyrics(track.ID, resolved)
-	}
+	s.emitLyrics(track.ID, resolved)
 }
 
 func (s *PlayerService) emitLyrics(trackID string, lyric *domain.Lyric) {

--- a/internal/domain/metadata_processing.go
+++ b/internal/domain/metadata_processing.go
@@ -75,7 +75,7 @@ func FoldUnicode(s string) string {
 // DefaultDelimiters returns the built-in delimiter set used when the user has
 // not customized splitting for a field.
 func DefaultDelimiters() []string {
-	return []string{";", "\\", ","}
+	return []string{";", "\\\\", ","}
 }
 
 // RawTagSeparator joins multiple same-named tag frames (e.g. two ARTIST tags)

--- a/internal/domain/metadata_processing_test.go
+++ b/internal/domain/metadata_processing_test.go
@@ -49,18 +49,20 @@ func TestNormalizationKey(t *testing.T) {
 }
 
 func TestSplitNames(t *testing.T) {
-	def := DefaultDelimiters() // [";", "\\", ","]
-	onlyHard := []string{";", "\\"}
+	def := DefaultDelimiters() // [";", "\\\\", ","]
+	onlyHard := []string{";", "\\\\"}
 	tests := []struct {
 		input      string
 		delimiters []string
 		expected   []string
 	}{
-		// Default delimiters: split on ; \ and , (comma is in the default set).
+		// Default delimiters: split on ; \\ and , (comma is in the default set).
 		{"Artist A; Artist B", def, []string{"Artist A", "Artist B"}},
-		{"Artist A\\Artist B", def, []string{"Artist A", "Artist B"}},
-		{"Artist A; Artist B\\Artist C", def, []string{"Artist A", "Artist B", "Artist C"}},
+		{"Artist A\\\\Artist B", def, []string{"Artist A", "Artist B"}},
+		{"Artist A; Artist B\\\\Artist C", def, []string{"Artist A", "Artist B", "Artist C"}},
 		{"Artist A, Artist B", def, []string{"Artist A", "Artist B"}},
+		// Single backslash should not be split by default anymore.
+		{"Artist A\\Artist B", def, []string{"Artist A\\Artist B"}},
 		// Without comma configured it stays one name.
 		{"Artist A, Artist B", onlyHard, []string{"Artist A, Artist B"}},
 		// Keywords / other punctuation never split.

--- a/internal/domain/search.go
+++ b/internal/domain/search.go
@@ -36,5 +36,7 @@ type SearchService interface {
 	DeleteArtistFromIndex(ctx context.Context, artistID string) error
 	// DeleteComposerFromIndex removes a composer document (keyed by the "composer:" prefix).
 	DeleteComposerFromIndex(ctx context.Context, composerID string) error
+	DocCount(ctx context.Context) (uint64, error)
+	Reset(ctx context.Context) error
 	Close() error
 }

--- a/internal/infra/bleve/bleve.go
+++ b/internal/infra/bleve/bleve.go
@@ -11,10 +11,15 @@ import (
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/mapping"
 	"github.com/blevesearch/bleve/v2/search/query"
+
+	_ "github.com/blevesearch/bleve/v2/analysis/analyzer/custom"
+	"github.com/blevesearch/bleve/v2/analysis/token/lowercase"
+	_ "github.com/blevesearch/bleve/v2/analysis/tokenizer/unicode"
 )
 
 type bleveSearchService struct {
-	index bleve.Index
+	indexPath string
+	index     bleve.Index
 }
 
 func NewBleveSearchService(indexPath string) (domain.SearchService, error) {
@@ -34,15 +39,27 @@ func NewBleveSearchService(indexPath string) (domain.SearchService, error) {
 		}
 	}
 
-	return &bleveSearchService{index: index}, nil
+	return &bleveSearchService{indexPath: indexPath, index: index}, nil
 }
 
 func buildIndexMapping() mapping.IndexMapping {
 	indexMapping := bleve.NewIndexMapping()
 
+	// Register a custom analyzer that uses the unicode tokenizer and lowercase filter,
+	// but does NOT remove English stop words (like "more", "than", "you", "the").
+	err := indexMapping.AddCustomAnalyzer("no_stop_words", map[string]interface{}{
+		"type":          "custom",
+		"tokenizer":     "unicode",
+		"token_filters": []string{lowercase.Name},
+	})
+	if err != nil {
+		// Fallback to standard analyzer if custom registration fails
+		panic(fmt.Sprintf("failed to register custom analyzer: %v", err))
+	}
+
 	// 1. Text field mapping for searchable content
 	textFieldMapping := bleve.NewTextFieldMapping()
-	textFieldMapping.Analyzer = "standard"
+	textFieldMapping.Analyzer = "no_stop_words"
 	textFieldMapping.Store = false // id/type (keyword) are enough for result retrieval
 
 	// 2. Keyword field mapping for IDs and Types (exact match only)
@@ -335,6 +352,28 @@ func (s *bleveSearchService) DeleteArtistFromIndex(ctx context.Context, artistID
 
 func (s *bleveSearchService) DeleteComposerFromIndex(ctx context.Context, composerID string) error {
 	return s.index.Delete("composer:" + composerID)
+}
+
+func (s *bleveSearchService) DocCount(ctx context.Context) (uint64, error) {
+	return s.index.DocCount()
+}
+
+func (s *bleveSearchService) Reset(ctx context.Context) error {
+	if err := s.index.Close(); err != nil {
+		return fmt.Errorf("failed to close search index for reset: %w", err)
+	}
+
+	if err := os.RemoveAll(s.indexPath); err != nil {
+		return fmt.Errorf("failed to delete search index files: %w", err)
+	}
+
+	indexMapping := buildIndexMapping()
+	index, err := bleve.New(s.indexPath, indexMapping)
+	if err != nil {
+		return fmt.Errorf("failed to recreate search index: %w", err)
+	}
+	s.index = index
+	return nil
 }
 
 func (s *bleveSearchService) Close() error {

--- a/internal/infra/bleve/bleve_test.go
+++ b/internal/infra/bleve/bleve_test.go
@@ -19,7 +19,7 @@ func TestBleveSearchService(t *testing.T) {
 	defer func() { _ = service.Close() }()
 
 	ctx := context.Background()
-	track := &domain.TrackDTO{
+	track1 := &domain.TrackDTO{
 		Track: domain.Track{
 			ID:    "track-1",
 			Title: "Bohemian Rhapsody",
@@ -31,10 +31,26 @@ func TestBleveSearchService(t *testing.T) {
 			Title: "A Night at the Opera",
 		},
 	}
+	track2 := &domain.TrackDTO{
+		Track: domain.Track{
+			ID:    "track-2",
+			Title: "More Than You Know",
+		},
+		Artists: []*domain.Artist{
+			{Name: "Axwell /\\ Ingrosso"},
+		},
+		Album: &domain.Album{
+			Title: "More Than You Know",
+		},
+	}
 
-	err = service.IndexTrack(ctx, track)
+	err = service.IndexTrack(ctx, track1)
 	if err != nil {
-		t.Fatalf("Failed to index track: %v", err)
+		t.Fatalf("Failed to index track 1: %v", err)
+	}
+	err = service.IndexTrack(ctx, track2)
+	if err != nil {
+		t.Fatalf("Failed to index track 2: %v", err)
 	}
 
 	results, err := service.Search(ctx, "Bohemian")
@@ -54,5 +70,13 @@ func TestBleveSearchService(t *testing.T) {
 	}
 	if len(results) == 0 {
 		t.Errorf("Expected results for artist search, got 0")
+	}
+
+	results, err = service.Search(ctx, "more than")
+	if err != nil {
+		t.Fatalf("Failed to search: %v", err)
+	}
+	if len(results) == 0 {
+		t.Errorf("Expected result when searching for 'more than', got 0")
 	}
 }

--- a/internal/infra/sqlite/migrations/000033_update_default_delimiters.down.sql
+++ b/internal/infra/sqlite/migrations/000033_update_default_delimiters.down.sql
@@ -1,0 +1,5 @@
+-- Revert default delimiter from "\\" to "\" for users still on the new default.
+UPDATE app_settings SET artist_delimiters = '[";","\\",","]' WHERE artist_delimiters = '[";","\\\\",","]';
+UPDATE app_settings SET album_artist_delimiters = '[";","\\",","]' WHERE album_artist_delimiters = '[";","\\\\",","]';
+UPDATE app_settings SET genre_delimiters = '[";","\\",","]' WHERE genre_delimiters = '[";","\\\\",","]';
+UPDATE app_settings SET composer_delimiters = '[";","\\",","]' WHERE composer_delimiters = '[";","\\\\",","]';

--- a/internal/infra/sqlite/migrations/000033_update_default_delimiters.up.sql
+++ b/internal/infra/sqlite/migrations/000033_update_default_delimiters.up.sql
@@ -1,0 +1,5 @@
+-- Update default delimiter from "\" to "\\" for users still on the old default.
+UPDATE app_settings SET artist_delimiters = '[";","\\\\",","]' WHERE artist_delimiters = '[";","\\",","]';
+UPDATE app_settings SET album_artist_delimiters = '[";","\\\\",","]' WHERE album_artist_delimiters = '[";","\\",","]';
+UPDATE app_settings SET genre_delimiters = '[";","\\\\",","]' WHERE genre_delimiters = '[";","\\",","]';
+UPDATE app_settings SET composer_delimiters = '[";","\\\\",","]' WHERE composer_delimiters = '[";","\\",","]';

--- a/internal/infra/wails/player_service.go
+++ b/internal/infra/wails/player_service.go
@@ -20,6 +20,12 @@ func (s *PlayerService) GetService() *player.PlayerService {
 	return s.service
 }
 
+// GetCurrentLyrics resolves the best lyric for the currently loaded track.
+// The frontend pulls this on startup to recover lyrics for a restored track.
+func (s *PlayerService) GetCurrentLyrics() *domain.Lyric {
+	return s.service.GetCurrentLyrics()
+}
+
 func (s *PlayerService) Play() error {
 	return s.service.Play()
 }


### PR DESCRIPTION
## Summary

- On startup, `restoreState` emits `player:lyrics` before the frontend listener is registered — the event is lost
- The existing fallback pull called `LyricsService.GetLyrics` (raw DB row), which only contains provider-fetched content (`Content` field) — lyrics from sibling `.lrc`/`.txt` files and embedded metadata tags (`MetaContent`) were silently missing
- Added `GetCurrentLyrics` to `PlayerService` that runs the full resolver (sibling file → metadata tag → provider content, honoring `preferLocalLyrics` setting)
- Extracted `lyricsResolveParams` helper to share settings/extra-dirs logic between the emit path and the new pull path
- Frontend init fallback now calls `PlayerService.GetCurrentLyrics` instead of raw `LyricsService.GetLyrics`

## Test plan

- [ ] Play track with sibling `.lrc` file — quit — reopen — lyrics panel shows lyrics
- [ ] Play track with embedded metadata lyrics only — quit — reopen — lyrics panel shows lyrics
- [ ] Play track with provider-fetched lyrics — quit — reopen — lyrics panel shows lyrics
- [ ] preferLocal=true: sibling `.lrc` wins over cached provider content after reopen
- [ ] preferLocal=false: provider content wins over sibling file after reopen