### PR TITLE
fix(library): stop analysis pool blocking deletion, fix slow folder removal/resync

### DIFF
--- a/catalog/analysis/README.md
+++ b/catalog/analysis/README.md
@@ -101,6 +101,16 @@ pending nor counted in `done`, so `total` undercounts by the failed-track count 
 Dedup via `queued`/`inFlight` maps: re-enqueuing an in-flight track is a no-op;
 re-enqueuing a queued track with `priority=true` promotes it to `boostQueue`.
 
+`Dequeue(trackIDs []string)` drops IDs from both `boostQueue` and `normalQueue`
+(and the `queued` dedup map) without touching `inFlight` — an in-flight track's
+`Analyze()` call is left to finish rather than cancelled mid-decode. Wired to
+library track deletion (see Central Wiring below) so a folder/track removal
+that races a running analysis pass — most visibly right after a large import,
+while the pool is still backfilling hundreds of tracks — doesn't keep
+analyzing (and writing `UpsertFeatures` for) tracks that are being deleted out
+from under it, which otherwise piles unnecessary DB writes onto the same
+SQLite writer the deletion itself needs.
+
 ## Central Wiring (`internal/app/module.go`)
 
 To avoid a `library↔analysis` or `player↔analysis` import cycle, all cross-package
@@ -108,6 +118,7 @@ listeners are wired in one `fx.Invoke` block:
 
 ```go
 lib.AddAnalysisListener(func(trackID string) { analysisSvc.Enqueue(trackID, false) })
+lib.AddTrackDeletedListener(func(trackIDs []string) { analysisSvc.Dequeue(trackIDs) })
 playerSvc.AddStatusListener(func(status domain.PlayerStatus) {
     analysisSvc.SetThrottled(status.PlaybackState == domain.PlaybackStatePlaying)
 })
@@ -115,6 +126,13 @@ playerSvc.AddTrackLoadListener(func(track *domain.TrackDTO) {
     analysisSvc.Enqueue(track.ID, true) // on-play priority boost
 })
 ```
+
+`AddTrackDeletedListener` (on `LibraryService`) fires with the IDs of tracks
+just removed — from `RemoveWatchedFolder` (before the search-index/DB delete
+loop, so the pool stops competing for the DB write as early as possible) and
+from the fsnotify Remove/Rename handler's single-file and directory-removal
+branches (after `deletedIDs` is finalized, alongside the existing
+`library:track-deleted` event emission).
 
 The on-play boost fires on **every** track load, whether or not that track was
 analyzed already — `Enqueue`'s dedup only tracks in-flight/queued state, not

--- a/internal/app/analysis/analysis_service.go
+++ b/internal/app/analysis/analysis_service.go
@@ -232,6 +232,43 @@ func (s *AnalysisService) BoostPriority(trackID string) {
 	s.Enqueue(trackID, true)
 }
 
+// Dequeue drops the given track IDs from the boost/normal queues so a
+// deleted track isn't wastefully analyzed. In-flight tracks (a worker
+// already decoding them) are left alone — cancelling mid-decode isn't worth
+// the complexity, and analyzeOne/UpsertFeatures already no-op safely once
+// the track row is gone (FK-constrained write fails harmlessly, logged).
+// No-op while the pool is disabled.
+func (s *AnalysisService) Dequeue(trackIDs []string) {
+	if len(trackIDs) == 0 {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.enabled {
+		return
+	}
+
+	remove := make(map[string]bool, len(trackIDs))
+	for _, id := range trackIDs {
+		remove[id] = true
+		delete(s.queued, id)
+	}
+
+	filter := func(queue []string) []string {
+		kept := queue[:0]
+		for _, id := range queue {
+			if !remove[id] {
+				kept = append(kept, id)
+			}
+		}
+		return kept
+	}
+	s.boostQueue = filter(s.boostQueue)
+	s.normalQueue = filter(s.normalQueue)
+}
+
 func (s *AnalysisService) promoteToFrontLocked(trackID string) {
 	for i, id := range s.normalQueue {
 		if id == trackID {

--- a/internal/app/analysis/analysis_service_test.go
+++ b/internal/app/analysis/analysis_service_test.go
@@ -208,6 +208,51 @@ func TestPriorityPromotesAheadOfNormalQueue(t *testing.T) {
 	}
 }
 
+func TestDequeueDropsQueuedTracksButLeavesInFlightAlone(t *testing.T) {
+	repo := newMockAnalysisRepo()
+	gate := make(chan struct{})
+	svc := newTestService(repo, &mockAnalyzer{gate: gate}, tracksOf("a", "b", "c"))
+
+	svc.wg.Add(1)
+	go svc.worker(svc.runCtx)
+
+	// "a" is picked up by the single worker and blocks on the gate (in-flight);
+	// "b" and "c" pile up behind it in the queues.
+	svc.Enqueue("a", false)
+	waitFor(t, time.Second, func() bool {
+		svc.mu.Lock()
+		defer svc.mu.Unlock()
+		return svc.inFlight["a"]
+	})
+	svc.Enqueue("b", false)
+	svc.Enqueue("c", true)
+
+	// Simulate a delete racing the pool: drop all three (as the real caller
+	// would, since it doesn't distinguish in-flight from queued).
+	svc.Dequeue([]string{"a", "b", "c"})
+
+	svc.mu.Lock()
+	_, aStillInFlight := svc.inFlight["a"]
+	queueLen := len(svc.normalQueue) + len(svc.boostQueue)
+	bQueued, cQueued := svc.queued["b"], svc.queued["c"]
+	svc.mu.Unlock()
+
+	if !aStillInFlight {
+		t.Fatalf("expected in-flight track to be left alone by Dequeue")
+	}
+	if queueLen != 0 || bQueued || cQueued {
+		t.Fatalf("expected b and c dropped from queues, got queueLen=%d bQueued=%v cQueued=%v", queueLen, bQueued, cQueued)
+	}
+
+	close(gate)
+	waitFor(t, time.Second, func() bool { return repo.callCount() == 1 })
+
+	_ = svc.Stop(context.Background())
+	if got := repo.callCount(); got != 1 {
+		t.Fatalf("expected only the in-flight track to have been analyzed, got %d calls", got)
+	}
+}
+
 func TestBoostPriorityPromotesQueuedTrack(t *testing.T) {
 	repo := newMockAnalysisRepo()
 	svc := newTestService(repo, &mockAnalyzer{}, tracksOf("a", "b"))

--- a/internal/app/library/analysis_listener_test.go
+++ b/internal/app/library/analysis_listener_test.go
@@ -57,6 +57,7 @@ func TestLibraryService_AnalysisListener_FiresOnImportNotOnFavoriteToggle(t *tes
 		&mockMetadataWriter{},
 		&mockArtworkCache{},
 		&mockSearchService{},
+		&mockTxManager{},
 		nil,
 		slog.Default(),
 	)

--- a/internal/app/library/service.go
+++ b/internal/app/library/service.go
@@ -54,17 +54,20 @@ type LibraryService struct {
 	metadataWriter    domain.MetadataWriter
 	artworkCache      domain.ArtworkCache
 	searchService     domain.SearchService
+	txManager         domain.TxManager
 	lyricsService     *lyrics.LyricsService
 	logger            *slog.Logger
 	watcher           *fsnotify.Watcher
 
 	trackUpdateListeners   []func(*domain.TrackDTO)
 	analysisListeners      []func(string)
+	trackDeletedListeners  []func([]string)
 	artistArtworkQueue     chan artistArtworkJob
 	pendingArtistArtwork   map[string]struct{}
 	pendingArtistArtworkMu sync.Mutex
 	artistArtworkLocks     sync.Map     // artistID -> *sync.Mutex; serializes artwork writes
 	syncing                atomic.Int32 // >0 while a bulk SyncFolder runs (gates per-track work)
+	syncEntityCache        *syncEntityCache // non-nil only during a SyncFolder run; caches resolved entity IDs
 	artworkCleanupMu       sync.Mutex
 	artworkCleanupTimer    *time.Timer // debounces orphan-artwork cleanup after watcher deletes
 	selfWrites             map[string]time.Time // path -> expiry; suppresses watcher events for app's own writes
@@ -93,6 +96,7 @@ func NewLibraryService(
 	metadataWriter domain.MetadataWriter,
 	artworkCache domain.ArtworkCache,
 	searchService domain.SearchService,
+	txManager domain.TxManager,
 	lyricsService *lyrics.LyricsService,
 	logger *slog.Logger,
 ) (*LibraryService, error) {
@@ -117,6 +121,7 @@ func NewLibraryService(
 		metadataWriter:       metadataWriter,
 		artworkCache:         artworkCache,
 		searchService:        searchService,
+		txManager:            txManager,
 		lyricsService:        lyricsService,
 		logger:               logger.With("module", "library"),
 		watcher:              watcher,
@@ -164,6 +169,33 @@ func (s *LibraryService) notifyAnalysisPending(trackID string) {
 
 	for _, l := range listeners {
 		l(trackID)
+	}
+}
+
+// AddTrackDeletedListener registers a callback fired with the IDs of tracks
+// that were just removed (single-file delete, directory delete, or
+// RemoveWatchedFolder). Lets the analysis pool drop them from its queue
+// immediately instead of wastefully analyzing/writing features for tracks
+// that no longer exist — otherwise a deletion racing a large in-flight
+// analysis backlog (e.g. right after a big import) keeps competing with the
+// delete for the same DB writer for no reason.
+func (s *LibraryService) AddTrackDeletedListener(l func([]string)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.trackDeletedListeners = append(s.trackDeletedListeners, l)
+}
+
+func (s *LibraryService) notifyTracksDeleted(ids []string) {
+	if len(ids) == 0 {
+		return
+	}
+	s.mu.RLock()
+	listeners := make([]func([]string), len(s.trackDeletedListeners))
+	copy(listeners, s.trackDeletedListeners)
+	s.mu.RUnlock()
+
+	for _, l := range listeners {
+		l(ids)
 	}
 }
 
@@ -359,15 +391,19 @@ func (s *LibraryService) handleEvent(event fsnotify.Event) {
 			tracks, err := s.trackRepo.GetByPathPrefix(ctx, prefix)
 			if err == nil && len(tracks) > 0 {
 				s.logger.Info("Directory removed, deleting tracks inside", "count", len(tracks), "prefix", prefix)
+				var dirDeletedIDs []string
 				for _, t := range tracks {
 					if err := s.trackRepo.Delete(ctx, t.ID); err != nil {
 						s.logger.Warn("Failed to delete track from DB", "id", t.ID, "error", err)
 						continue
 					}
-					deletedIDs = append(deletedIDs, t.ID)
-					if err := s.searchService.DeleteFromIndex(ctx, t.ID); err != nil {
-						s.logger.Warn("Failed to delete track from Search", "id", t.ID, "error", err)
-					}
+					dirDeletedIDs = append(dirDeletedIDs, t.ID)
+				}
+				deletedIDs = append(deletedIDs, dirDeletedIDs...)
+				// Batched: one (or a few) commits instead of one fsync-ing
+				// commit per track — same fix as RemoveWatchedFolder.
+				if err := s.searchService.DeleteTracksFromIndex(ctx, dirDeletedIDs); err != nil {
+					s.logger.Warn("Failed to delete tracks from search index", "count", len(dirDeletedIDs), "error", err)
 				}
 			}
 
@@ -375,6 +411,7 @@ func (s *LibraryService) handleEvent(event fsnotify.Event) {
 				return
 			}
 
+			s.notifyTracksDeleted(deletedIDs)
 			s.cleanupOrphanedEntities(ctx)
 			// Artwork cache cleanup scans the whole cache dir, so it isn't run
 			// inline per event (would thrash on bulk deletes). Debounce it: bulk
@@ -453,35 +490,39 @@ func (s *LibraryService) handleArtistImageEvent(event fsnotify.Event) {
 // have any tracks, keeping the DB and the search index in sync. Genres aren't
 // indexed, so only their rows are dropped.
 func (s *LibraryService) cleanupOrphanedEntities(ctx context.Context) {
+	// Collect every orphaned doc ID across all three indexed entity types and
+	// remove them in one batched commit instead of one fsync-ing
+	// DeleteXFromIndex call per entity — a bulk removal (e.g. a folder with
+	// many distinct albums/artists) can orphan hundreds of rows at once.
+	var docIDs []string
+
 	if ids, err := s.albumRepo.DeleteOrphaned(ctx); err != nil {
 		s.logger.Warn("Failed to delete orphaned albums", "error", err)
 	} else {
 		for _, id := range ids {
-			if err := s.searchService.DeleteAlbumFromIndex(ctx, id); err != nil {
-				s.logger.Warn("Failed to delete orphaned album from index", "id", id, "error", err)
-			}
+			docIDs = append(docIDs, "album:"+id)
 		}
 	}
 	if ids, err := s.artistRepo.DeleteOrphaned(ctx); err != nil {
 		s.logger.Warn("Failed to delete orphaned artists", "error", err)
 	} else {
 		for _, id := range ids {
-			if err := s.searchService.DeleteArtistFromIndex(ctx, id); err != nil {
-				s.logger.Warn("Failed to delete orphaned artist from index", "id", id, "error", err)
-			}
+			docIDs = append(docIDs, "artist:"+id)
 		}
 	}
 	if ids, err := s.composerRepo.DeleteOrphaned(ctx); err != nil {
 		s.logger.Warn("Failed to delete orphaned composers", "error", err)
 	} else {
 		for _, id := range ids {
-			if err := s.searchService.DeleteComposerFromIndex(ctx, id); err != nil {
-				s.logger.Warn("Failed to delete orphaned composer from index", "id", id, "error", err)
-			}
+			docIDs = append(docIDs, "composer:"+id)
 		}
 	}
 	if _, err := s.genreRepo.DeleteOrphaned(ctx); err != nil {
 		s.logger.Warn("Failed to delete orphaned genres", "error", err)
+	}
+
+	if err := s.searchService.BatchDeleteFromIndex(ctx, docIDs); err != nil {
+		s.logger.Warn("Failed to delete orphaned entities from index", "count", len(docIDs), "error", err)
 	}
 }
 
@@ -548,47 +589,78 @@ func (s *LibraryService) RemoveWatchedFolder(ctx context.Context, id string, kee
 		return nil
 	}
 
+	start := time.Now()
 	s.logger.Info("Removing watched folder", "path", folder.Path, "keepTracks", keepTracks)
 
 	// 1. Unwatch
+	step := time.Now()
 	if err := s.watcher.Remove(folder.Path); err != nil {
 		s.logger.Warn("Failed to remove folder from watcher", "path", folder.Path, "error", err)
 	}
+	s.logger.Debug("RemoveWatchedFolder: unwatch done", "path", folder.Path, "took", time.Since(step))
 
 	if !keepTracks {
-		// 2. Get tracks for this folder to remove from search index
+		// 2. Get tracks for this folder to remove from search index. Notify
+		//    analysis listeners first so a running analysis pool drops these
+		//    IDs from its queue right away instead of continuing to burn CPU
+		//    and DB writes racing the deletion below (worst when this runs
+		//    right after a big import, while the pool is still backfilling).
+		step = time.Now()
 		tracks, err := s.trackRepo.GetByPathPrefix(ctx, folder.Path)
+		s.logger.Debug("RemoveWatchedFolder: GetByPathPrefix done", "path", folder.Path, "count", len(tracks), "took", time.Since(step), "error", err)
 		if err == nil {
-			for _, track := range tracks {
-				if err := s.searchService.DeleteFromIndex(ctx, track.ID); err != nil {
-					s.logger.Warn("Failed to delete track from search index", "id", track.ID, "error", err)
-				}
+			ids := make([]string, len(tracks))
+			for i, track := range tracks {
+				ids[i] = track.ID
 			}
+
+			step = time.Now()
+			s.notifyTracksDeleted(ids)
+			s.logger.Debug("RemoveWatchedFolder: notifyTracksDeleted done", "count", len(ids), "took", time.Since(step))
+
+			// Batched: one (or a few, at batchCommitSize) commits instead of
+			// two fsync-ing commits per track — the per-track loop this
+			// replaced is what made removing a large folder slow.
+			step = time.Now()
+			if err := s.searchService.DeleteTracksFromIndex(ctx, ids); err != nil {
+				s.logger.Warn("Failed to delete tracks from search index", "count", len(ids), "error", err)
+			}
+			s.logger.Debug("RemoveWatchedFolder: DeleteTracksFromIndex done", "count", len(ids), "took", time.Since(step))
 		}
 
 		// 3. Delete tracks from DB
+		step = time.Now()
 		if err := s.trackRepo.DeleteByPathPrefix(ctx, folder.Path); err != nil {
 			return fmt.Errorf("failed to delete tracks from DB: %w", err)
 		}
+		s.logger.Debug("RemoveWatchedFolder: DeleteByPathPrefix done", "path", folder.Path, "took", time.Since(step))
 
 		// 4. Cleanup orphaned entities
+		step = time.Now()
 		s.cleanupOrphanedEntities(ctx)
+		s.logger.Debug("RemoveWatchedFolder: cleanupOrphanedEntities done", "took", time.Since(step))
 
 		// 5. Cleanup orphaned artworks
+		step = time.Now()
 		if err := s.CleanupOrphanedArtworks(ctx); err != nil {
 			s.logger.Warn("Failed to cleanup orphaned artworks", "error", err)
 		}
+		s.logger.Debug("RemoveWatchedFolder: CleanupOrphanedArtworks done", "took", time.Since(step))
 	}
 
 	// 6. Delete watched folder record
+	step = time.Now()
 	if err := s.watchedFolderRepo.Delete(ctx, id); err != nil {
 		return fmt.Errorf("failed to delete watched folder record: %w", err)
 	}
+	s.logger.Debug("RemoveWatchedFolder: folder record deleted", "took", time.Since(step))
 
 	// 7. Notify frontend
 	if app := application.Get(); app != nil && app.Event != nil {
 		app.Event.Emit("library:updated", nil)
 	}
+
+	s.logger.Info("Removed watched folder", "path", folder.Path, "totalTook", time.Since(start))
 
 	return nil
 }
@@ -639,6 +711,21 @@ func (s *LibraryService) SyncFolder(ctx context.Context, root string) error {
 	// image lookup — the batch pass below handles it far more cheaply.
 	s.syncing.Add(1)
 	defer s.syncing.Add(-1)
+
+	// Cache resolved artist/album/genre/composer IDs for the duration of this
+	// run so repeated entities (e.g. one artist across 200 tracks) don't hit
+	// GetByNormalizationKey again. Only the consumer loop below touches it, so
+	// no locking is needed. nil outside a sync run (see resolveEntities).
+	s.syncEntityCache = newSyncEntityCache()
+	defer func() { s.syncEntityCache = nil }()
+
+	// Batch search-index writes instead of committing one fsync per document.
+	s.searchService.BeginSyncBatch()
+	defer func() {
+		if err := s.searchService.EndSyncBatch(); err != nil {
+			s.logger.Warn("Failed to flush search index sync batch", "error", err)
+		}
+	}()
 
 	// Was the library empty before this sync? Combined with a missing signature
 	// below, this distinguishes a fresh install (baseline it silently) from an
@@ -825,11 +912,18 @@ func (s *LibraryService) SyncFolder(ctx context.Context, root string) error {
 				continue
 			}
 			deletedIDs = append(deletedIDs, t.ID)
-			if err := s.searchService.DeleteFromIndex(ctx, t.ID); err != nil {
-				s.logger.Warn("Failed to delete missing track from Search", "path", t.Path, "error", err)
-			}
+		}
+		// Batched: one (or a few) commits instead of one fsync-ing commit per
+		// track — same fix as RemoveWatchedFolder. A resync of a folder with
+		// many moved/deleted files was hitting this the same way.
+		if err := s.searchService.DeleteTracksFromIndex(ctx, deletedIDs); err != nil {
+			s.logger.Warn("Failed to delete missing tracks from search index", "count", len(deletedIDs), "error", err)
 		}
 	}
+
+	// Tell the analysis pool to drop these before it wastes cycles/DB writes
+	// analyzing tracks that no longer exist.
+	s.notifyTracksDeleted(deletedIDs)
 
 	// Always clear orphans: a track removed here (or by an earlier run/path) can
 	// leave an album/artist/genre/composer with no tracks.
@@ -950,8 +1044,12 @@ func (s *LibraryService) persistImported(ctx context.Context, job *importJob) er
 	dto := job.dto
 	path := job.path
 
-	// Resolve related entities
-	if err := s.resolveEntities(ctx, dto); err != nil {
+	// Resolve related entities. All of resolveEntities' DB writes for this
+	// file land in a single SQLite transaction/fsync instead of one per
+	// statement — the dominant cost for large folder scans.
+	if err := s.txManager.RunInTx(ctx, func(ctx context.Context) error {
+		return s.resolveEntities(ctx, dto)
+	}); err != nil {
 		return fmt.Errorf("failed to resolve entities for %s: %w", path, err)
 	}
 
@@ -994,8 +1092,9 @@ func (s *LibraryService) resolveEntities(ctx context.Context, dto *domain.TrackD
 	// 1. Resolve Artists
 	var artistIDs []string
 	for _, artist := range dto.Artists {
-		existing, _ := s.artistRepo.GetByNormalizationKey(ctx, artist.NormalizationKey)
-		if existing != nil {
+		if id, ok := s.syncEntityCache.get(entityArtist, artist.NormalizationKey); ok {
+			artist.ID = id
+		} else if existing, _ := s.artistRepo.GetByNormalizationKey(ctx, artist.NormalizationKey); existing != nil {
 			artist.ID = existing.ID
 		} else {
 			artist.ID = s.generateID(artist.NormalizationKey)
@@ -1003,6 +1102,7 @@ func (s *LibraryService) resolveEntities(ctx context.Context, dto *domain.TrackD
 		if err := s.artistRepo.Upsert(ctx, artist); err != nil {
 			return err
 		}
+		s.syncEntityCache.set(entityArtist, artist.NormalizationKey, artist.ID)
 		artistIDs = append(artistIDs, artist.ID)
 
 		// Index artist in search
@@ -1014,8 +1114,9 @@ func (s *LibraryService) resolveEntities(ctx context.Context, dto *domain.TrackD
 	// 2. Resolve Album Artists
 	var albumArtistIDs []string
 	for _, aa := range dto.AlbumArtists {
-		existing, _ := s.artistRepo.GetByNormalizationKey(ctx, aa.NormalizationKey)
-		if existing != nil {
+		if id, ok := s.syncEntityCache.get(entityArtist, aa.NormalizationKey); ok {
+			aa.ID = id
+		} else if existing, _ := s.artistRepo.GetByNormalizationKey(ctx, aa.NormalizationKey); existing != nil {
 			aa.ID = existing.ID
 		} else {
 			aa.ID = s.generateID(aa.NormalizationKey)
@@ -1023,6 +1124,7 @@ func (s *LibraryService) resolveEntities(ctx context.Context, dto *domain.TrackD
 		if err := s.artistRepo.Upsert(ctx, aa); err != nil {
 			return err
 		}
+		s.syncEntityCache.set(entityArtist, aa.NormalizationKey, aa.ID)
 		albumArtistIDs = append(albumArtistIDs, aa.ID)
 
 		// Index album artist in search
@@ -1042,9 +1144,13 @@ func (s *LibraryService) resolveEntities(ctx context.Context, dto *domain.TrackD
 		}
 
 		dto.Album.NormalizationKey = domain.NormalizationKey(dto.Album.Title) + "|" + primaryArtistID
+		// Always read (rather than trusting the cache) since we need the
+		// existing row's artwork key to preserve it below, not just the ID.
 		existing, _ := s.albumRepo.GetByNormalizationKey(ctx, dto.Album.NormalizationKey)
 		if existing != nil {
 			dto.Album.ID = existing.ID
+		} else if id, ok := s.syncEntityCache.get(entityAlbum, dto.Album.NormalizationKey); ok {
+			dto.Album.ID = id
 		} else {
 			dto.Album.ID = s.generateID(dto.Album.NormalizationKey)
 		}
@@ -1058,6 +1164,7 @@ func (s *LibraryService) resolveEntities(ctx context.Context, dto *domain.TrackD
 		if err := s.albumRepo.Upsert(ctx, dto.Album); err != nil {
 			return err
 		}
+		s.syncEntityCache.set(entityAlbum, dto.Album.NormalizationKey, dto.Album.ID)
 
 		// Use album artists if available, otherwise fall back to track artists
 		finalAlbumArtistIDs := albumArtistIDs
@@ -1089,8 +1196,9 @@ func (s *LibraryService) resolveEntities(ctx context.Context, dto *domain.TrackD
 	// 4. Resolve Genres
 	var genreIDs []string
 	for _, g := range dto.Genres {
-		existing, _ := s.genreRepo.GetByNormalizationKey(ctx, g.NormalizationKey)
-		if existing != nil {
+		if id, ok := s.syncEntityCache.get(entityGenre, g.NormalizationKey); ok {
+			g.ID = id
+		} else if existing, _ := s.genreRepo.GetByNormalizationKey(ctx, g.NormalizationKey); existing != nil {
 			g.ID = existing.ID
 		} else {
 			g.ID = s.generateID(g.NormalizationKey)
@@ -1098,14 +1206,16 @@ func (s *LibraryService) resolveEntities(ctx context.Context, dto *domain.TrackD
 		if err := s.genreRepo.Upsert(ctx, g); err != nil {
 			return err
 		}
+		s.syncEntityCache.set(entityGenre, g.NormalizationKey, g.ID)
 		genreIDs = append(genreIDs, g.ID)
 	}
 
 	// 5. Resolve Composers
 	var composerIDs []string
 	for _, c := range dto.Composers {
-		existing, _ := s.composerRepo.GetByNormalizationKey(ctx, c.NormalizationKey)
-		if existing != nil {
+		if id, ok := s.syncEntityCache.get(entityComposer, c.NormalizationKey); ok {
+			c.ID = id
+		} else if existing, _ := s.composerRepo.GetByNormalizationKey(ctx, c.NormalizationKey); existing != nil {
 			c.ID = existing.ID
 		} else {
 			c.ID = s.generateID(c.NormalizationKey)
@@ -1113,6 +1223,7 @@ func (s *LibraryService) resolveEntities(ctx context.Context, dto *domain.TrackD
 		if err := s.composerRepo.Upsert(ctx, c); err != nil {
 			return err
 		}
+		s.syncEntityCache.set(entityComposer, c.NormalizationKey, c.ID)
 		composerIDs = append(composerIDs, c.ID)
 
 		// Index composer in search
@@ -1208,6 +1319,22 @@ func (s *LibraryService) ResplitLibrary(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to load tracks: %w", err)
 	}
+
+	// Same two optimizations SyncFolder uses, missing here previously: an
+	// in-run entity cache (otherwise every artist/album/genre/composer on
+	// every track re-hits GetByNormalizationKey) and batched search-index
+	// commits (otherwise every IndexArtist/IndexAlbum/IndexComposer call
+	// below is its own fsync-ing Bleve commit) — resplitting a large library
+	// touches both once per track and was correspondingly slow without them.
+	s.syncEntityCache = newSyncEntityCache()
+	defer func() { s.syncEntityCache = nil }()
+
+	s.searchService.BeginSyncBatch()
+	defer func() {
+		if err := s.searchService.EndSyncBatch(); err != nil {
+			s.logger.Warn("Failed to flush search index sync batch", "error", err)
+		}
+	}()
 
 	total := len(tracks)
 	if app := application.Get(); app != nil && app.Event != nil {

--- a/internal/app/library/service_test.go
+++ b/internal/app/library/service_test.go
@@ -13,6 +13,12 @@ import (
 	"airmedy/internal/domain"
 )
 
+type mockTxManager struct{}
+
+func (m *mockTxManager) RunInTx(ctx context.Context, fn func(context.Context) error) error {
+	return fn(ctx)
+}
+
 type mockTrackRepo struct {
 	domain.TrackRepository
 	tracks map[string]*domain.Track
@@ -190,10 +196,14 @@ func (m *mockSearchService) IndexComposer(ctx context.Context, composer *domain.
 func (m *mockSearchService) IndexPlaylist(ctx context.Context, playlist *domain.Playlist) error { return nil }
 func (m *mockSearchService) Close() error { return nil }
 func (m *mockSearchService) DeleteFromIndex(ctx context.Context, id string) error { return nil }
+func (m *mockSearchService) DeleteTracksFromIndex(ctx context.Context, ids []string) error { return nil }
+func (m *mockSearchService) BatchDeleteFromIndex(ctx context.Context, docIDs []string) error { return nil }
 func (m *mockSearchService) DeleteAlbumFromIndex(ctx context.Context, albumID string) error { return nil }
 func (m *mockSearchService) DeleteArtistFromIndex(ctx context.Context, artistID string) error { return nil }
 func (m *mockSearchService) DeleteComposerFromIndex(ctx context.Context, composerID string) error { return nil }
 func (m *mockSearchService) DocCount(ctx context.Context) (uint64, error) { return 0, nil }
+func (m *mockSearchService) BeginSyncBatch()                              {}
+func (m *mockSearchService) EndSyncBatch() error                          { return nil }
 
 type mockArtworkCache struct{ domain.ArtworkCache }
 func (m *mockArtworkCache) Save(ctx context.Context, data []byte, mimeType string) (string, error) { return "", nil }
@@ -236,6 +246,7 @@ func TestLibraryService_SyncFolder(t *testing.T) {
 		&mockMetadataWriter{},
 		&mockArtworkCache{},
 		&mockSearchService{},
+		&mockTxManager{},
 		nil,
 		slog.Default(),
 	)
@@ -332,6 +343,7 @@ func TestLibraryService_SyncFolder_SupportedExtensions(t *testing.T) {
 		&mockMetadataWriter{},
 		&mockArtworkCache{},
 		&mockSearchService{},
+		&mockTxManager{},
 		nil,
 		slog.Default(),
 	)
@@ -374,6 +386,7 @@ func TestLibraryService_AddWatchedFolder_CoveringExisting(t *testing.T) {
 		&mockMetadataWriter{},
 		&mockArtworkCache{},
 		&mockSearchService{},
+		&mockTxManager{},
 		nil,
 		slog.Default(),
 	)
@@ -406,5 +419,64 @@ func TestLibraryService_AddWatchedFolder_CoveringExisting(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("Parent folder %s not found in repo after AddWatchedFolder", wantPath)
+	}
+}
+
+// TestLibraryService_RemoveWatchedFolder_NotifiesTrackDeletedListeners covers
+// the fix for tracks/folders getting deleted while the background analysis
+// pool still has them queued: RemoveWatchedFolder must tell listeners
+// (wired to AnalysisService.Dequeue in production) which track IDs are gone
+// before it starts deleting, so a running analysis pass drops them instead
+// of continuing to race the deletion for the same DB writer.
+func TestLibraryService_RemoveWatchedFolder_NotifiesTrackDeletedListeners(t *testing.T) {
+	trackRepo := &mockTrackRepo{tracks: map[string]*domain.Track{
+		"/Music/A/one.mp3": {ID: "track-1", Path: "/Music/A/one.mp3"},
+		"/Music/A/two.mp3": {ID: "track-2", Path: "/Music/A/two.mp3"},
+	}}
+	folderRepo := &mockFolderRepo{
+		folders: []*domain.WatchedFolder{{ID: "folder-id", Path: "/Music/A"}},
+	}
+
+	s, err := NewLibraryService(
+		trackRepo,
+		&mockAlbumRepo{},
+		&mockArtistRepo{},
+		&mockGenreRepo{},
+		&mockComposerRepo{},
+		&mockPlaylistRepo{},
+		folderRepo,
+		&mockSettingsRepo{},
+		&mockSyncStateRepo{},
+		&mockMetadataExtractor{},
+		&mockMetadataWriter{},
+		&mockArtworkCache{},
+		&mockSearchService{},
+		&mockTxManager{},
+		nil,
+		slog.Default(),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create library service: %v", err)
+	}
+	defer func() { _ = s.Stop(context.Background()) }()
+
+	var notified []string
+	s.AddTrackDeletedListener(func(ids []string) {
+		notified = append(notified, ids...)
+	})
+
+	if err := s.RemoveWatchedFolder(context.Background(), "folder-id", false); err != nil {
+		t.Fatalf("RemoveWatchedFolder failed: %v", err)
+	}
+
+	if len(notified) != 2 {
+		t.Fatalf("expected 2 deleted track IDs notified, got %v", notified)
+	}
+	seen := map[string]bool{}
+	for _, id := range notified {
+		seen[id] = true
+	}
+	if !seen["track-1"] || !seen["track-2"] {
+		t.Fatalf("expected track-1 and track-2 notified, got %v", notified)
 	}
 }

--- a/internal/app/library/sync_entity_cache.go
+++ b/internal/app/library/sync_entity_cache.go
@@ -1,0 +1,63 @@
+package library
+
+// entityKind identifies which cache map syncEntityCache.get/set operates on.
+type entityKind int
+
+const (
+	entityArtist entityKind = iota
+	entityAlbum
+	entityGenre
+	entityComposer
+)
+
+// syncEntityCache caches normalization-key -> resolved-ID lookups for the
+// duration of one SyncFolder run, so repeated entities (e.g. one artist
+// across hundreds of tracks) don't re-hit GetByNormalizationKey for every
+// file. Only the sync consumer goroutine touches it, so no locking is
+// needed. A nil *syncEntityCache (outside a sync run) makes get/set safe
+// no-ops, falling back to the always-hit-DB behavior.
+type syncEntityCache struct {
+	artists   map[string]string
+	albums    map[string]string
+	genres    map[string]string
+	composers map[string]string
+}
+
+func newSyncEntityCache() *syncEntityCache {
+	return &syncEntityCache{
+		artists:   make(map[string]string),
+		albums:    make(map[string]string),
+		genres:    make(map[string]string),
+		composers: make(map[string]string),
+	}
+}
+
+func (c *syncEntityCache) mapFor(kind entityKind) map[string]string {
+	switch kind {
+	case entityArtist:
+		return c.artists
+	case entityAlbum:
+		return c.albums
+	case entityGenre:
+		return c.genres
+	case entityComposer:
+		return c.composers
+	default:
+		return nil
+	}
+}
+
+func (c *syncEntityCache) get(kind entityKind, key string) (string, bool) {
+	if c == nil {
+		return "", false
+	}
+	id, ok := c.mapFor(kind)[key]
+	return id, ok
+}
+
+func (c *syncEntityCache) set(kind entityKind, key, id string) {
+	if c == nil {
+		return
+	}
+	c.mapFor(kind)[key] = id
+}

--- a/internal/app/module.go
+++ b/internal/app/module.go
@@ -110,6 +110,9 @@ var Module = fx.Module("app",
 				lib.AddAnalysisListener(func(trackID string) {
 					analysisSvc.Enqueue(trackID, false)
 				})
+				lib.AddTrackDeletedListener(func(trackIDs []string) {
+					analysisSvc.Dequeue(trackIDs)
+				})
 				playerSvc.AddStatusListener(func(status domain.PlayerStatus) {
 					analysisSvc.SetThrottled(status.PlaybackState == domain.PlaybackStatePlaying)
 				})

--- a/internal/domain/search.go
+++ b/internal/domain/search.go
@@ -27,8 +27,26 @@ type SearchService interface {
 	// (one fsync per chunk, not per document). onProgress, if non-nil, is
 	// called once per item with a human-readable label.
 	BatchReindex(ctx context.Context, data *ReindexData, onProgress func(path string)) error
+	// BeginSyncBatch switches IndexTrack/IndexAlbum/IndexArtist/IndexComposer
+	// into batch-accumulating mode (one fsync per chunk instead of per call)
+	// for the duration of a bulk folder sync. Must be paired with EndSyncBatch.
+	BeginSyncBatch()
+	// EndSyncBatch flushes any documents accumulated since BeginSyncBatch and
+	// returns to per-call indexing. Safe to call via defer on every return path.
+	EndSyncBatch() error
 	Search(ctx context.Context, query string) ([]SearchResult, error)
 	DeleteFromIndex(ctx context.Context, id string) error
+	// DeleteTracksFromIndex removes many track documents in batched commits
+	// (not one fsync-ing commit per document). Use for folder/bulk removal —
+	// looping DeleteFromIndex is what made RemoveWatchedFolder slow on large
+	// folders.
+	DeleteTracksFromIndex(ctx context.Context, ids []string) error
+	// BatchDeleteFromIndex removes arbitrary, already-prefixed index document
+	// IDs (e.g. "album:x", "artist:y", "composer:z") in batched commits.
+	// Same one-fsync-per-document problem as DeleteFromIndex/DeleteAlbum-
+	// FromIndex/etc looped one at a time — used by orphan cleanup, which can
+	// delete many albums/artists/composers at once after a bulk track removal.
+	BatchDeleteFromIndex(ctx context.Context, docIDs []string) error
 	// DeleteAlbumFromIndex removes an album document (keyed by the "album:" prefix)
 	// from the search index.
 	DeleteAlbumFromIndex(ctx context.Context, albumID string) error

--- a/internal/domain/tx.go
+++ b/internal/domain/tx.go
@@ -1,0 +1,11 @@
+package domain
+
+import "context"
+
+// TxManager runs fn within a database transaction. Repository calls made
+// with the ctx passed to fn transparently participate in that transaction.
+// Reentrant: an outer RunInTx call wrapping an inner one does not open a
+// second transaction.
+type TxManager interface {
+	RunInTx(ctx context.Context, fn func(ctx context.Context) error) error
+}

--- a/internal/infra/bleve/bleve.go
+++ b/internal/infra/bleve/bleve.go
@@ -20,6 +20,13 @@ import (
 type bleveSearchService struct {
 	indexPath string
 	index     bleve.Index
+
+	// syncBatch, when non-nil, accumulates documents from IndexTrack/Album/
+	// Artist/Composer instead of committing each one individually. Only
+	// touched from LibraryService's single sync-consumer goroutine (see
+	// BeginSyncBatch/EndSyncBatch), so no locking is needed.
+	syncBatch        *bleve.Batch
+	syncBatchPending int
 }
 
 func NewBleveSearchService(indexPath string) (domain.SearchService, error) {
@@ -170,15 +177,18 @@ func composerDoc(composer *domain.Composer) (string, map[string]interface{}) {
 }
 
 func (s *bleveSearchService) IndexTrack(ctx context.Context, track *domain.TrackDTO) error {
-	return s.index.Index(trackDoc(track))
+	id, doc := trackDoc(track)
+	return s.indexOrBatch(id, doc)
 }
 
 func (s *bleveSearchService) IndexAlbum(ctx context.Context, album *domain.AlbumDTO) error {
-	return s.index.Index(albumDoc(album))
+	id, doc := albumDoc(album)
+	return s.indexOrBatch(id, doc)
 }
 
 func (s *bleveSearchService) IndexArtist(ctx context.Context, artist *domain.Artist) error {
-	return s.index.Index(artistDoc(artist))
+	id, doc := artistDoc(artist)
+	return s.indexOrBatch(id, doc)
 }
 
 func (s *bleveSearchService) IndexPlaylist(ctx context.Context, playlist *domain.Playlist) error {
@@ -186,7 +196,54 @@ func (s *bleveSearchService) IndexPlaylist(ctx context.Context, playlist *domain
 }
 
 func (s *bleveSearchService) IndexComposer(ctx context.Context, composer *domain.Composer) error {
-	return s.index.Index(composerDoc(composer))
+	id, doc := composerDoc(composer)
+	return s.indexOrBatch(id, doc)
+}
+
+// indexOrBatch appends to the active sync batch if one is open (see
+// BeginSyncBatch), auto-flushing at batchCommitSize; otherwise it commits
+// the document immediately, same as before.
+func (s *bleveSearchService) indexOrBatch(id string, doc map[string]interface{}) error {
+	if s.syncBatch == nil {
+		return s.index.Index(id, doc)
+	}
+	if err := s.syncBatch.Index(id, doc); err != nil {
+		return fmt.Errorf("failed to add %q to sync batch: %w", id, err)
+	}
+	s.syncBatchPending++
+	if s.syncBatchPending >= batchCommitSize {
+		return s.flushSyncBatch()
+	}
+	return nil
+}
+
+func (s *bleveSearchService) flushSyncBatch() error {
+	if s.syncBatchPending == 0 {
+		return nil
+	}
+	if err := s.index.Batch(s.syncBatch); err != nil {
+		return fmt.Errorf("failed to commit sync batch: %w", err)
+	}
+	s.syncBatch = s.index.NewBatch()
+	s.syncBatchPending = 0
+	return nil
+}
+
+// BeginSyncBatch switches IndexTrack/IndexAlbum/IndexArtist/IndexComposer
+// into batch-accumulating mode for the duration of a bulk SyncFolder run.
+func (s *bleveSearchService) BeginSyncBatch() {
+	s.syncBatch = s.index.NewBatch()
+	s.syncBatchPending = 0
+}
+
+// EndSyncBatch flushes any remaining batched documents and returns to
+// per-document indexing. Must be called (e.g. via defer) after
+// BeginSyncBatch, on every return path including errors/cancellation.
+func (s *bleveSearchService) EndSyncBatch() error {
+	err := s.flushSyncBatch()
+	s.syncBatch = nil
+	s.syncBatchPending = 0
+	return err
 }
 
 // batchCommitSize bounds how many documents accumulate before a single
@@ -340,6 +397,77 @@ func (s *bleveSearchService) Search(ctx context.Context, queryStr string) ([]dom
 func (s *bleveSearchService) DeleteFromIndex(ctx context.Context, id string) error {
 	_ = s.index.Delete(id)
 	return s.index.Delete("track:" + id)
+}
+
+// DeleteTracksFromIndex removes many track documents in batched commits
+// instead of one fsync-ing commit per document — looping DeleteFromIndex for
+// a large folder is the same "hang on Windows" cost BatchReindex/
+// BeginSyncBatch already avoid for imports (batchCommitSize), so bulk
+// removal gets the same treatment.
+func (s *bleveSearchService) DeleteTracksFromIndex(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	batch := s.index.NewBatch()
+	pending := 0
+	flush := func() error {
+		if pending == 0 {
+			return nil
+		}
+		if err := s.index.Batch(batch); err != nil {
+			return fmt.Errorf("failed to commit delete batch: %w", err)
+		}
+		batch = s.index.NewBatch()
+		pending = 0
+		return nil
+	}
+
+	for _, id := range ids {
+		batch.Delete(id)
+		batch.Delete("track:" + id)
+		pending++
+		if pending >= batchCommitSize {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+	}
+	return flush()
+}
+
+// BatchDeleteFromIndex removes arbitrary already-prefixed doc IDs in batched
+// commits — same fsync-per-doc cost as DeleteTracksFromIndex avoids, but for
+// callers (orphan cleanup) that delete a mix of album/artist/composer docs.
+func (s *bleveSearchService) BatchDeleteFromIndex(ctx context.Context, docIDs []string) error {
+	if len(docIDs) == 0 {
+		return nil
+	}
+
+	batch := s.index.NewBatch()
+	pending := 0
+	flush := func() error {
+		if pending == 0 {
+			return nil
+		}
+		if err := s.index.Batch(batch); err != nil {
+			return fmt.Errorf("failed to commit delete batch: %w", err)
+		}
+		batch = s.index.NewBatch()
+		pending = 0
+		return nil
+	}
+
+	for _, id := range docIDs {
+		batch.Delete(id)
+		pending++
+		if pending >= batchCommitSize {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+	}
+	return flush()
 }
 
 func (s *bleveSearchService) DeleteAlbumFromIndex(ctx context.Context, albumID string) error {

--- a/internal/infra/sqlite/album_repository.go
+++ b/internal/infra/sqlite/album_repository.go
@@ -21,7 +21,7 @@ func NewAlbumRepository(db *DB) domain.AlbumRepository {
 func (r *albumRepository) GetByID(ctx context.Context, id string) (*domain.AlbumDTO, error) {
 	query := fmt.Sprintf(`SELECT %s FROM albums a WHERE a.id = ?`, albumSelectFields)
 	var album domain.Album
-	err := r.db.GetContext(ctx, &album, query, id)
+	err := r.db.Ext(ctx).GetContext(ctx, &album, query, id)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -39,7 +39,7 @@ func (r *albumRepository) GetByID(ctx context.Context, id string) (*domain.Album
 		WHERE aa.album_id = ?
 		ORDER BY aa.position
 	`
-	err = r.db.SelectContext(ctx, &artists, artistQuery, id)
+	err = r.db.Ext(ctx).SelectContext(ctx, &artists, artistQuery, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get album artists: %w", err)
 	}
@@ -50,7 +50,7 @@ func (r *albumRepository) GetByID(ctx context.Context, id string) (*domain.Album
 
 func (r *albumRepository) GetByNormalizationKey(ctx context.Context, key string) (*domain.Album, error) {
 	var album domain.Album
-	err := r.db.GetContext(ctx, &album, "SELECT * FROM albums WHERE normalization_key = ?", key)
+	err := r.db.Ext(ctx).GetContext(ctx, &album, "SELECT * FROM albums WHERE normalization_key = ?", key)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -90,7 +90,7 @@ func (r *albumRepository) GetByArtistID(ctx context.Context, artistID string) ([
 		ORDER BY a.year DESC, a.sort_title
 	`, albumSelectFields)
 	var rows []albumRow
-	err := r.db.SelectContext(ctx, &rows, query, artistID, artistID, artistID)
+	err := r.db.Ext(ctx).SelectContext(ctx, &rows, query, artistID, artistID, artistID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get albums by artist id: %w", err)
 	}
@@ -119,7 +119,7 @@ func (r *albumRepository) GetRecentlyAdded(ctx context.Context, limit int) ([]*d
 		LIMIT ?
 	`, albumSelectFields)
 	var rows []albumRow
-	err := r.db.SelectContext(ctx, &rows, query, limit)
+	err := r.db.Ext(ctx).SelectContext(ctx, &rows, query, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get recently added albums: %w", err)
 	}
@@ -169,7 +169,7 @@ func (r *albumRepository) GetAll(ctx context.Context) ([]*domain.AlbumDTO, error
 		ORDER BY a.sort_title
 	`, albumSelectFields)
 	var rows []albumRow
-	err := r.db.SelectContext(ctx, &rows, query)
+	err := r.db.Ext(ctx).SelectContext(ctx, &rows, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get all albums: %w", err)
 	}
@@ -190,7 +190,7 @@ func (r *albumRepository) Save(ctx context.Context, album *domain.Album) error {
 			:id, :title, :sort_title, :normalization_key, :year, :copyright, :artwork_key, :created_at, :updated_at
 		)`
 
-	_, err := r.db.NamedExecContext(ctx, query, album)
+	_, err := r.db.Ext(ctx).NamedExecContext(ctx, query, album)
 	if err != nil {
 		return fmt.Errorf("failed to save album: %w", err)
 	}
@@ -219,7 +219,7 @@ func (r *albumRepository) Upsert(ctx context.Context, album *domain.Album) error
 			updated_at = excluded.updated_at
 	`
 
-	_, err := r.db.NamedExecContext(ctx, query, album)
+	_, err := r.db.Ext(ctx).NamedExecContext(ctx, query, album)
 	if err != nil {
 		return fmt.Errorf("failed to upsert album: %w", err)
 	}
@@ -227,34 +227,32 @@ func (r *albumRepository) Upsert(ctx context.Context, album *domain.Album) error
 }
 
 func (r *albumRepository) SetArtists(ctx context.Context, albumID string, artistIDs []string) error {
-	tx, err := r.db.BeginTxx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = tx.Rollback() }()
+	return r.db.RunTx(ctx, func(ctx context.Context) error {
+		ex := r.db.Ext(ctx)
 
-	_, err = tx.ExecContext(ctx, "DELETE FROM album_artists WHERE album_id = ?", albumID)
-	if err != nil {
-		return err
-	}
-
-	for i, artistID := range artistIDs {
-		_, err = tx.ExecContext(ctx, "INSERT INTO album_artists (album_id, artist_id, position) VALUES (?, ?, ?)", albumID, artistID, i)
+		_, err := ex.ExecContext(ctx, "DELETE FROM album_artists WHERE album_id = ?", albumID)
 		if err != nil {
 			return err
 		}
-	}
 
-	return tx.Commit()
+		for i, artistID := range artistIDs {
+			_, err = ex.ExecContext(ctx, "INSERT INTO album_artists (album_id, artist_id, position) VALUES (?, ?, ?)", albumID, artistID, i)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
 }
 
 func (r *albumRepository) DeleteOrphaned(ctx context.Context) ([]string, error) {
 	const cond = `id NOT IN (SELECT DISTINCT album_id FROM tracks WHERE album_id IS NOT NULL)`
 	var ids []string
-	if err := r.db.SelectContext(ctx, &ids, `SELECT id FROM albums WHERE `+cond); err != nil {
+	if err := r.db.Ext(ctx).SelectContext(ctx, &ids, `SELECT id FROM albums WHERE `+cond); err != nil {
 		return nil, fmt.Errorf("failed to select orphaned albums: %w", err)
 	}
-	if _, err := r.db.ExecContext(ctx, `DELETE FROM albums WHERE `+cond); err != nil {
+	if _, err := r.db.Ext(ctx).ExecContext(ctx, `DELETE FROM albums WHERE `+cond); err != nil {
 		return nil, fmt.Errorf("failed to delete orphaned albums: %w", err)
 	}
 	return ids, nil

--- a/internal/infra/sqlite/analysis_repository.go
+++ b/internal/infra/sqlite/analysis_repository.go
@@ -18,56 +18,54 @@ func NewAnalysisRepository(db *DB) domain.AnalysisRepository {
 }
 
 func (r *analysisRepository) UpsertFeatures(ctx context.Context, f *domain.TrackFeatures) error {
-	tx, err := r.db.BeginTxx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	return r.db.RunTx(ctx, func(ctx context.Context) error {
+		ex := r.db.Ext(ctx)
 
-	// Phase-2 columns (loudness/dynamics/spectral) plus tempo (BPM, via aubio).
-	// The remaining reserved Phase-6 mood columns are left untouched on conflict.
-	_, err = tx.ExecContext(ctx,
-		`INSERT INTO track_features (
-		   track_id, analyzer_version, analyzed_at,
-		   loudness_lufs, loudness_range, true_peak, rms, crest,
-		   spectral_centroid, spectral_rolloff, spectral_flatness, spectral_flux, zcr,
-		   tempo)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		 ON CONFLICT(track_id) DO UPDATE SET
-		   analyzer_version = excluded.analyzer_version,
-		   analyzed_at = excluded.analyzed_at,
-		   loudness_lufs = excluded.loudness_lufs,
-		   loudness_range = excluded.loudness_range,
-		   true_peak = excluded.true_peak,
-		   rms = excluded.rms,
-		   crest = excluded.crest,
-		   spectral_centroid = excluded.spectral_centroid,
-		   spectral_rolloff = excluded.spectral_rolloff,
-		   spectral_flatness = excluded.spectral_flatness,
-		   spectral_flux = excluded.spectral_flux,
-		   zcr = excluded.zcr,
-		   tempo = excluded.tempo`,
-		f.TrackID, f.AnalyzerVersion, f.AnalyzedAt,
-		f.LoudnessLUFS, f.LoudnessRange, f.TruePeak, f.RMS, f.Crest,
-		f.SpectralCentroid, f.SpectralRolloff, f.SpectralFlatness, f.SpectralFlux, f.ZCR,
-		f.Tempo,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to upsert track features: %w", err)
-	}
+		// Phase-2 columns (loudness/dynamics/spectral) plus tempo (BPM, via aubio).
+		// The remaining reserved Phase-6 mood columns are left untouched on conflict.
+		_, err := ex.ExecContext(ctx,
+			`INSERT INTO track_features (
+			   track_id, analyzer_version, analyzed_at,
+			   loudness_lufs, loudness_range, true_peak, rms, crest,
+			   spectral_centroid, spectral_rolloff, spectral_flatness, spectral_flux, zcr,
+			   tempo)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			 ON CONFLICT(track_id) DO UPDATE SET
+			   analyzer_version = excluded.analyzer_version,
+			   analyzed_at = excluded.analyzed_at,
+			   loudness_lufs = excluded.loudness_lufs,
+			   loudness_range = excluded.loudness_range,
+			   true_peak = excluded.true_peak,
+			   rms = excluded.rms,
+			   crest = excluded.crest,
+			   spectral_centroid = excluded.spectral_centroid,
+			   spectral_rolloff = excluded.spectral_rolloff,
+			   spectral_flatness = excluded.spectral_flatness,
+			   spectral_flux = excluded.spectral_flux,
+			   zcr = excluded.zcr,
+			   tempo = excluded.tempo`,
+			f.TrackID, f.AnalyzerVersion, f.AnalyzedAt,
+			f.LoudnessLUFS, f.LoudnessRange, f.TruePeak, f.RMS, f.Crest,
+			f.SpectralCentroid, f.SpectralRolloff, f.SpectralFlatness, f.SpectralFlux, f.ZCR,
+			f.Tempo,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to upsert track features: %w", err)
+		}
 
-	if _, err = tx.ExecContext(ctx,
-		`UPDATE tracks SET analyzed_version = ? WHERE id = ?`,
-		f.AnalyzerVersion, f.TrackID,
-	); err != nil {
-		return fmt.Errorf("failed to bump analyzed_version: %w", err)
-	}
+		if _, err = ex.ExecContext(ctx,
+			`UPDATE tracks SET analyzed_version = ? WHERE id = ?`,
+			f.AnalyzerVersion, f.TrackID,
+		); err != nil {
+			return fmt.Errorf("failed to bump analyzed_version: %w", err)
+		}
 
-	return tx.Commit()
+		return nil
+	})
 }
 
 func (r *analysisRepository) MarkFailed(ctx context.Context, trackID string, currentVersion int) error {
-	if _, err := r.db.ExecContext(ctx,
+	if _, err := r.db.Ext(ctx).ExecContext(ctx,
 		`UPDATE tracks SET analyzed_version = ? WHERE id = ?`,
 		currentVersion, trackID,
 	); err != nil {
@@ -98,7 +96,7 @@ func (r *analysisRepository) GetFeatures(ctx context.Context, trackID string) (*
 		Energy           float64      `db:"energy"`
 		Danceability     float64      `db:"danceability"`
 	}
-	err := r.db.GetContext(ctx, &row,
+	err := r.db.Ext(ctx).GetContext(ctx, &row,
 		`SELECT
 		   track_id, analyzer_version, analyzed_at,
 		   COALESCE(loudness_lufs, 0) AS loudness_lufs,
@@ -156,7 +154,7 @@ func (r *analysisRepository) GetFeatures(ctx context.Context, trackID string) (*
 
 func (r *analysisRepository) CountPending(ctx context.Context, currentVersion int) (int, error) {
 	var n int
-	if err := r.db.GetContext(ctx, &n,
+	if err := r.db.Ext(ctx).GetContext(ctx, &n,
 		`SELECT COUNT(*) FROM tracks WHERE analyzed_version < ?`, currentVersion,
 	); err != nil {
 		return 0, fmt.Errorf("failed to count pending analysis: %w", err)
@@ -166,7 +164,7 @@ func (r *analysisRepository) CountPending(ctx context.Context, currentVersion in
 
 func (r *analysisRepository) ListPending(ctx context.Context, currentVersion, limit int) ([]string, error) {
 	var ids []string
-	if err := r.db.SelectContext(ctx, &ids,
+	if err := r.db.Ext(ctx).SelectContext(ctx, &ids,
 		`SELECT id FROM tracks WHERE analyzed_version < ? ORDER BY rowid ASC LIMIT ?`,
 		currentVersion, limit,
 	); err != nil {

--- a/internal/infra/sqlite/artist_repository.go
+++ b/internal/infra/sqlite/artist_repository.go
@@ -19,7 +19,7 @@ func NewArtistRepository(db *DB) domain.ArtistRepository {
 
 func (r *artistRepository) GetByID(ctx context.Context, id string) (*domain.Artist, error) {
 	var artist domain.Artist
-	err := r.db.GetContext(ctx, &artist, "SELECT * FROM artists WHERE id = ?", id)
+	err := r.db.Ext(ctx).GetContext(ctx, &artist, "SELECT * FROM artists WHERE id = ?", id)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -31,7 +31,7 @@ func (r *artistRepository) GetByID(ctx context.Context, id string) (*domain.Arti
 
 func (r *artistRepository) GetByNormalizationKey(ctx context.Context, key string) (*domain.Artist, error) {
 	var artist domain.Artist
-	err := r.db.GetContext(ctx, &artist, "SELECT * FROM artists WHERE normalization_key = ?", key)
+	err := r.db.Ext(ctx).GetContext(ctx, &artist, "SELECT * FROM artists WHERE normalization_key = ?", key)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -43,7 +43,7 @@ func (r *artistRepository) GetByNormalizationKey(ctx context.Context, key string
 
 func (r *artistRepository) GetAll(ctx context.Context) ([]*domain.Artist, error) {
 	var artists []*domain.Artist
-	err := r.db.SelectContext(ctx, &artists, "SELECT * FROM artists ORDER BY sort_name")
+	err := r.db.Ext(ctx).SelectContext(ctx, &artists, "SELECT * FROM artists ORDER BY sort_name")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get all artists: %w", err)
 	}
@@ -64,7 +64,7 @@ func (r *artistRepository) Save(ctx context.Context, artist *domain.Artist) erro
 			:id, :name, :sort_name, :normalization_key, :created_at, :updated_at
 		)`
 
-	_, err := r.db.NamedExecContext(ctx, query, artist)
+	_, err := r.db.Ext(ctx).NamedExecContext(ctx, query, artist)
 	if err != nil {
 		return fmt.Errorf("failed to save artist: %w", err)
 	}
@@ -92,7 +92,7 @@ func (r *artistRepository) Upsert(ctx context.Context, artist *domain.Artist) er
 			updated_at = excluded.updated_at
 	`
 
-	_, err := r.db.NamedExecContext(ctx, query, artist)
+	_, err := r.db.Ext(ctx).NamedExecContext(ctx, query, artist)
 	if err != nil {
 		return fmt.Errorf("failed to upsert artist: %w", err)
 	}
@@ -119,7 +119,7 @@ func (r *artistRepository) SetArtworkSource(ctx context.Context, id string, sour
 		return fmt.Errorf("unknown artwork source: %q", source)
 	}
 	query := fmt.Sprintf("UPDATE artists SET %s = ?, updated_at = ? WHERE id = ?", col)
-	if _, err := r.db.ExecContext(ctx, query, key, time.Now(), id); err != nil {
+	if _, err := r.db.Ext(ctx).ExecContext(ctx, query, key, time.Now(), id); err != nil {
 		return fmt.Errorf("failed to set artist artwork (%s): %w", source, err)
 	}
 	return nil
@@ -127,7 +127,7 @@ func (r *artistRepository) SetArtworkSource(ctx context.Context, id string, sour
 
 func (r *artistRepository) GetAllArtworkKeys(ctx context.Context) ([]string, error) {
 	var keys []string
-	err := r.db.SelectContext(ctx, &keys, `
+	err := r.db.Ext(ctx).SelectContext(ctx, &keys, `
 		SELECT artwork_key_manual FROM artists WHERE artwork_key_manual IS NOT NULL AND artwork_key_manual != ''
 		UNION
 		SELECT artwork_key_local FROM artists WHERE artwork_key_local IS NOT NULL AND artwork_key_local != ''
@@ -141,7 +141,7 @@ func (r *artistRepository) GetAllArtworkKeys(ctx context.Context) ([]string, err
 }
 
 func (r *artistRepository) SetArtwork(ctx context.Context, id string, key *string, source string) error {
-	_, err := r.db.ExecContext(ctx,
+	_, err := r.db.Ext(ctx).ExecContext(ctx,
 		"UPDATE artists SET artwork_key = ?, artwork_source = ?, updated_at = ? WHERE id = ?",
 		key, source, time.Now(), id,
 	)
@@ -153,18 +153,18 @@ func (r *artistRepository) SetArtwork(ctx context.Context, id string, key *strin
 
 func (r *artistRepository) DeleteOrphaned(ctx context.Context) ([]string, error) {
 	// Clean up orphaned junction rows that might exist from before foreign keys were enabled
-	_, _ = r.db.ExecContext(ctx, "DELETE FROM track_artists WHERE track_id NOT IN (SELECT id FROM tracks)")
-	_, _ = r.db.ExecContext(ctx, "DELETE FROM track_album_artists WHERE track_id NOT IN (SELECT id FROM tracks)")
-	_, _ = r.db.ExecContext(ctx, "DELETE FROM album_artists WHERE album_id NOT IN (SELECT id FROM albums)")
+	_, _ = r.db.Ext(ctx).ExecContext(ctx, "DELETE FROM track_artists WHERE track_id NOT IN (SELECT id FROM tracks)")
+	_, _ = r.db.Ext(ctx).ExecContext(ctx, "DELETE FROM track_album_artists WHERE track_id NOT IN (SELECT id FROM tracks)")
+	_, _ = r.db.Ext(ctx).ExecContext(ctx, "DELETE FROM album_artists WHERE album_id NOT IN (SELECT id FROM albums)")
 
 	const cond = `id NOT IN (SELECT artist_id FROM track_artists)
 		  AND id NOT IN (SELECT artist_id FROM track_album_artists)
 		  AND id NOT IN (SELECT artist_id FROM album_artists)`
 	var ids []string
-	if err := r.db.SelectContext(ctx, &ids, `SELECT id FROM artists WHERE `+cond); err != nil {
+	if err := r.db.Ext(ctx).SelectContext(ctx, &ids, `SELECT id FROM artists WHERE `+cond); err != nil {
 		return nil, fmt.Errorf("failed to select orphaned artists: %w", err)
 	}
-	if _, err := r.db.ExecContext(ctx, `DELETE FROM artists WHERE `+cond); err != nil {
+	if _, err := r.db.Ext(ctx).ExecContext(ctx, `DELETE FROM artists WHERE `+cond); err != nil {
 		return nil, fmt.Errorf("failed to delete orphaned artists: %w", err)
 	}
 	return ids, nil

--- a/internal/infra/sqlite/composer_repository.go
+++ b/internal/infra/sqlite/composer_repository.go
@@ -18,7 +18,7 @@ func NewComposerRepository(db *DB) domain.ComposerRepository {
 
 func (r *composerRepository) GetByID(ctx context.Context, id string) (*domain.Composer, error) {
 	var c domain.Composer
-	err := r.db.GetContext(ctx, &c, "SELECT * FROM composers WHERE id = ?", id)
+	err := r.db.Ext(ctx).GetContext(ctx, &c, "SELECT * FROM composers WHERE id = ?", id)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -30,7 +30,7 @@ func (r *composerRepository) GetByID(ctx context.Context, id string) (*domain.Co
 
 func (r *composerRepository) GetByName(ctx context.Context, name string) (*domain.Composer, error) {
 	var c domain.Composer
-	err := r.db.GetContext(ctx, &c, "SELECT * FROM composers WHERE name = ?", name)
+	err := r.db.Ext(ctx).GetContext(ctx, &c, "SELECT * FROM composers WHERE name = ?", name)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -42,7 +42,7 @@ func (r *composerRepository) GetByName(ctx context.Context, name string) (*domai
 
 func (r *composerRepository) GetByNormalizationKey(ctx context.Context, key string) (*domain.Composer, error) {
 	var c domain.Composer
-	err := r.db.GetContext(ctx, &c, "SELECT * FROM composers WHERE normalization_key = ?", key)
+	err := r.db.Ext(ctx).GetContext(ctx, &c, "SELECT * FROM composers WHERE normalization_key = ?", key)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -54,7 +54,7 @@ func (r *composerRepository) GetByNormalizationKey(ctx context.Context, key stri
 
 func (r *composerRepository) GetAll(ctx context.Context) ([]*domain.Composer, error) {
 	var composers []*domain.Composer
-	err := r.db.SelectContext(ctx, &composers, "SELECT * FROM composers ORDER BY name")
+	err := r.db.Ext(ctx).SelectContext(ctx, &composers, "SELECT * FROM composers ORDER BY name")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get all composers: %w", err)
 	}
@@ -62,7 +62,7 @@ func (r *composerRepository) GetAll(ctx context.Context) ([]*domain.Composer, er
 }
 
 func (r *composerRepository) Save(ctx context.Context, c *domain.Composer) error {
-	_, err := r.db.NamedExecContext(ctx, "INSERT INTO composers (id, name, normalization_key) VALUES (:id, :name, :normalization_key)", c)
+	_, err := r.db.Ext(ctx).NamedExecContext(ctx, "INSERT INTO composers (id, name, normalization_key) VALUES (:id, :name, :normalization_key)", c)
 	if err != nil {
 		return fmt.Errorf("failed to save composer: %w", err)
 	}
@@ -76,7 +76,7 @@ func (r *composerRepository) Upsert(ctx context.Context, c *domain.Composer) err
 		ON CONFLICT(id) DO UPDATE SET 
 			normalization_key = excluded.normalization_key
 	`
-	_, err := r.db.NamedExecContext(ctx, query, c)
+	_, err := r.db.Ext(ctx).NamedExecContext(ctx, query, c)
 	if err != nil {
 		return fmt.Errorf("failed to upsert composer: %w", err)
 	}
@@ -85,14 +85,14 @@ func (r *composerRepository) Upsert(ctx context.Context, c *domain.Composer) err
 
 func (r *composerRepository) DeleteOrphaned(ctx context.Context) ([]string, error) {
 	// Clean up orphaned junction rows that might exist from before foreign keys were enabled
-	_, _ = r.db.ExecContext(ctx, "DELETE FROM track_composers WHERE track_id NOT IN (SELECT id FROM tracks)")
+	_, _ = r.db.Ext(ctx).ExecContext(ctx, "DELETE FROM track_composers WHERE track_id NOT IN (SELECT id FROM tracks)")
 
 	const cond = `id NOT IN (SELECT composer_id FROM track_composers)`
 	var ids []string
-	if err := r.db.SelectContext(ctx, &ids, `SELECT id FROM composers WHERE `+cond); err != nil {
+	if err := r.db.Ext(ctx).SelectContext(ctx, &ids, `SELECT id FROM composers WHERE `+cond); err != nil {
 		return nil, fmt.Errorf("failed to select orphaned composers: %w", err)
 	}
-	if _, err := r.db.ExecContext(ctx, `DELETE FROM composers WHERE `+cond); err != nil {
+	if _, err := r.db.Ext(ctx).ExecContext(ctx, `DELETE FROM composers WHERE `+cond); err != nil {
 		return nil, fmt.Errorf("failed to delete orphaned composers: %w", err)
 	}
 	return ids, nil

--- a/internal/infra/sqlite/genre_repository.go
+++ b/internal/infra/sqlite/genre_repository.go
@@ -18,7 +18,7 @@ func NewGenreRepository(db *DB) domain.GenreRepository {
 
 func (r *genreRepository) GetByID(ctx context.Context, id string) (*domain.Genre, error) {
 	var g domain.Genre
-	err := r.db.GetContext(ctx, &g, "SELECT * FROM genres WHERE id = ?", id)
+	err := r.db.Ext(ctx).GetContext(ctx, &g, "SELECT * FROM genres WHERE id = ?", id)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -30,7 +30,7 @@ func (r *genreRepository) GetByID(ctx context.Context, id string) (*domain.Genre
 
 func (r *genreRepository) GetByName(ctx context.Context, name string) (*domain.Genre, error) {
 	var g domain.Genre
-	err := r.db.GetContext(ctx, &g, "SELECT * FROM genres WHERE name = ?", name)
+	err := r.db.Ext(ctx).GetContext(ctx, &g, "SELECT * FROM genres WHERE name = ?", name)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -42,7 +42,7 @@ func (r *genreRepository) GetByName(ctx context.Context, name string) (*domain.G
 
 func (r *genreRepository) GetByNormalizationKey(ctx context.Context, key string) (*domain.Genre, error) {
 	var g domain.Genre
-	err := r.db.GetContext(ctx, &g, "SELECT * FROM genres WHERE normalization_key = ?", key)
+	err := r.db.Ext(ctx).GetContext(ctx, &g, "SELECT * FROM genres WHERE normalization_key = ?", key)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -54,7 +54,7 @@ func (r *genreRepository) GetByNormalizationKey(ctx context.Context, key string)
 
 func (r *genreRepository) GetAll(ctx context.Context) ([]*domain.Genre, error) {
 	var genres []*domain.Genre
-	err := r.db.SelectContext(ctx, &genres, "SELECT * FROM genres ORDER BY name")
+	err := r.db.Ext(ctx).SelectContext(ctx, &genres, "SELECT * FROM genres ORDER BY name")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get all genres: %w", err)
 	}
@@ -62,7 +62,7 @@ func (r *genreRepository) GetAll(ctx context.Context) ([]*domain.Genre, error) {
 }
 
 func (r *genreRepository) Save(ctx context.Context, g *domain.Genre) error {
-	_, err := r.db.NamedExecContext(ctx, "INSERT INTO genres (id, name, normalization_key) VALUES (:id, :name, :normalization_key)", g)
+	_, err := r.db.Ext(ctx).NamedExecContext(ctx, "INSERT INTO genres (id, name, normalization_key) VALUES (:id, :name, :normalization_key)", g)
 	if err != nil {
 		return fmt.Errorf("failed to save genre: %w", err)
 	}
@@ -76,7 +76,7 @@ func (r *genreRepository) Upsert(ctx context.Context, g *domain.Genre) error {
 		ON CONFLICT(id) DO UPDATE SET 
 			normalization_key = excluded.normalization_key
 	`
-	_, err := r.db.NamedExecContext(ctx, query, g)
+	_, err := r.db.Ext(ctx).NamedExecContext(ctx, query, g)
 	if err != nil {
 		return fmt.Errorf("failed to upsert genre: %w", err)
 	}
@@ -85,14 +85,14 @@ func (r *genreRepository) Upsert(ctx context.Context, g *domain.Genre) error {
 
 func (r *genreRepository) DeleteOrphaned(ctx context.Context) ([]string, error) {
 	// Clean up orphaned junction rows that might exist from before foreign keys were enabled
-	_, _ = r.db.ExecContext(ctx, "DELETE FROM track_genres WHERE track_id NOT IN (SELECT id FROM tracks)")
+	_, _ = r.db.Ext(ctx).ExecContext(ctx, "DELETE FROM track_genres WHERE track_id NOT IN (SELECT id FROM tracks)")
 
 	const cond = `id NOT IN (SELECT genre_id FROM track_genres)`
 	var ids []string
-	if err := r.db.SelectContext(ctx, &ids, `SELECT id FROM genres WHERE `+cond); err != nil {
+	if err := r.db.Ext(ctx).SelectContext(ctx, &ids, `SELECT id FROM genres WHERE `+cond); err != nil {
 		return nil, fmt.Errorf("failed to select orphaned genres: %w", err)
 	}
-	if _, err := r.db.ExecContext(ctx, `DELETE FROM genres WHERE `+cond); err != nil {
+	if _, err := r.db.Ext(ctx).ExecContext(ctx, `DELETE FROM genres WHERE `+cond); err != nil {
 		return nil, fmt.Errorf("failed to delete orphaned genres: %w", err)
 	}
 	return ids, nil

--- a/internal/infra/sqlite/migrations/000035_junction_reverse_indexes.down.sql
+++ b/internal/infra/sqlite/migrations/000035_junction_reverse_indexes.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_track_artists_artist_id;
+DROP INDEX IF EXISTS idx_track_album_artists_artist_id;
+DROP INDEX IF EXISTS idx_track_genres_genre_id;
+DROP INDEX IF EXISTS idx_track_composers_composer_id;
+DROP INDEX IF EXISTS idx_album_artists_artist_id;

--- a/internal/infra/sqlite/migrations/000035_junction_reverse_indexes.up.sql
+++ b/internal/infra/sqlite/migrations/000035_junction_reverse_indexes.up.sql
@@ -1,0 +1,13 @@
+-- Reverse-lookup columns on junction tables had no index — only the
+-- composite PRIMARY KEY (track_id, artist_id/genre_id/composer_id), which is
+-- useless for queries filtering by the second column alone. That made
+-- DeleteOrphaned's "id NOT IN (SELECT artist_id FROM track_artists)" style
+-- anti-join queries (run after every deletion, e.g. RemoveWatchedFolder) do a
+-- full scan of the junction table per candidate row instead of an index
+-- lookup — tens of seconds on a library of any real size. Also speeds up
+-- GetByArtistID/GetByGenreID/GetByComposerID/GetAlbumsByArtistID.
+CREATE INDEX IF NOT EXISTS idx_track_artists_artist_id ON track_artists(artist_id);
+CREATE INDEX IF NOT EXISTS idx_track_album_artists_artist_id ON track_album_artists(artist_id);
+CREATE INDEX IF NOT EXISTS idx_track_genres_genre_id ON track_genres(genre_id);
+CREATE INDEX IF NOT EXISTS idx_track_composers_composer_id ON track_composers(composer_id);
+CREATE INDEX IF NOT EXISTS idx_album_artists_artist_id ON album_artists(artist_id);

--- a/internal/infra/sqlite/module.go
+++ b/internal/infra/sqlite/module.go
@@ -22,5 +22,6 @@ var Module = fx.Module("sqlite",
 		func(db *DB) domain.AnalysisRepository { return NewAnalysisRepository(db) },
 		func(db *DB) domain.MiniPlayerStateRepository { return NewMiniPlayerStateRepository(db) },
 		func(db *DB) domain.LibrarySyncStateRepository { return NewLibrarySyncStateRepository(db) },
+		func(db *DB) domain.TxManager { return NewTxManager(db) },
 	),
 )

--- a/internal/infra/sqlite/playlist_repository.go
+++ b/internal/infra/sqlite/playlist_repository.go
@@ -23,7 +23,7 @@ func NewPlaylistRepository(db *DB) domain.PlaylistRepository {
 func (r *playlistRepository) GetByID(ctx context.Context, id string) (*domain.Playlist, error) {
 	var p domain.Playlist
 	query := fmt.Sprintf("SELECT %s FROM playlists WHERE id = ?", playlistSelectFields)
-	err := r.db.GetContext(ctx, &p, query, id)
+	err := r.db.Ext(ctx).GetContext(ctx, &p, query, id)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -36,7 +36,7 @@ func (r *playlistRepository) GetByID(ctx context.Context, id string) (*domain.Pl
 func (r *playlistRepository) GetAll(ctx context.Context) ([]*domain.Playlist, error) {
 	var playlists []*domain.Playlist
 	query := fmt.Sprintf("SELECT %s FROM playlists ORDER BY name", playlistSelectFields)
-	err := r.db.SelectContext(ctx, &playlists, query)
+	err := r.db.Ext(ctx).SelectContext(ctx, &playlists, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get all playlists: %w", err)
 	}
@@ -48,7 +48,7 @@ func (r *playlistRepository) Save(ctx context.Context, p *domain.Playlist) error
 	p.CreatedAt = now
 	p.UpdatedAt = now
 
-	_, err := r.db.NamedExecContext(ctx, "INSERT INTO playlists (id, name, description, artwork_key, created_at, updated_at) VALUES (:id, :name, :description, :artwork_key, :created_at, :updated_at)", p)
+	_, err := r.db.Ext(ctx).NamedExecContext(ctx, "INSERT INTO playlists (id, name, description, artwork_key, created_at, updated_at) VALUES (:id, :name, :description, :artwork_key, :created_at, :updated_at)", p)
 	if err != nil {
 		return fmt.Errorf("failed to save playlist: %w", err)
 	}
@@ -57,7 +57,7 @@ func (r *playlistRepository) Save(ctx context.Context, p *domain.Playlist) error
 
 func (r *playlistRepository) Update(ctx context.Context, p *domain.Playlist) error {
 	p.UpdatedAt = time.Now()
-	_, err := r.db.ExecContext(ctx,
+	_, err := r.db.Ext(ctx).ExecContext(ctx,
 		"UPDATE playlists SET name = ?, description = ?, artwork_key = ?, updated_at = ? WHERE id = ?",
 		p.Name, p.Description, p.ArtworkKey, p.UpdatedAt, p.ID,
 	)
@@ -69,7 +69,7 @@ func (r *playlistRepository) Update(ctx context.Context, p *domain.Playlist) err
 
 func (r *playlistRepository) CountTracks(ctx context.Context, playlistID string) (int, error) {
 	var count int
-	err := r.db.GetContext(ctx, &count, "SELECT COUNT(*) FROM playlist_tracks WHERE playlist_id = ?", playlistID)
+	err := r.db.Ext(ctx).GetContext(ctx, &count, "SELECT COUNT(*) FROM playlist_tracks WHERE playlist_id = ?", playlistID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count playlist tracks: %w", err)
 	}
@@ -77,7 +77,7 @@ func (r *playlistRepository) CountTracks(ctx context.Context, playlistID string)
 }
 
 func (r *playlistRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.ExecContext(ctx, "DELETE FROM playlists WHERE id = ?", id)
+	_, err := r.db.Ext(ctx).ExecContext(ctx, "DELETE FROM playlists WHERE id = ?", id)
 	if err != nil {
 		return fmt.Errorf("failed to delete playlist: %w", err)
 	}
@@ -85,7 +85,7 @@ func (r *playlistRepository) Delete(ctx context.Context, id string) error {
 }
 
 func (r *playlistRepository) AddTrack(ctx context.Context, playlistID, trackID string, position string) error {
-	_, err := r.db.ExecContext(ctx, "INSERT OR IGNORE INTO playlist_tracks (playlist_id, track_id, position) VALUES (?, ?, ?)", playlistID, trackID, position)
+	_, err := r.db.Ext(ctx).ExecContext(ctx, "INSERT OR IGNORE INTO playlist_tracks (playlist_id, track_id, position) VALUES (?, ?, ?)", playlistID, trackID, position)
 	if err != nil {
 		return fmt.Errorf("failed to add track to playlist: %w", err)
 	}
@@ -97,44 +97,42 @@ func (r *playlistRepository) AddTracks(ctx context.Context, playlistID string, t
 		return nil
 	}
 
-	tx, err := r.db.BeginTxx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = tx.Rollback() }()
+	return r.db.RunTx(ctx, func(ctx context.Context) error {
+		ex := r.db.Ext(ctx)
 
-	var maxRankStr string
-	_ = tx.GetContext(ctx, &maxRankStr, "SELECT COALESCE(MAX(position), '') FROM playlist_tracks WHERE playlist_id = ?", playlistID)
+		var maxRankStr string
+		_ = ex.GetContext(ctx, &maxRankStr, "SELECT COALESCE(MAX(position), '') FROM playlist_tracks WHERE playlist_id = ?", playlistID)
 
-	var currentRank lexorank.Rank
-	if maxRankStr == "" {
-		currentRank = lexorank.Middle()
-	} else {
-		maxRank, err := lexorank.ParseRank(maxRankStr)
-		if err != nil {
-			return fmt.Errorf("failed to parse max rank: %w", err)
+		var currentRank lexorank.Rank
+		if maxRankStr == "" {
+			currentRank = lexorank.Middle()
+		} else {
+			maxRank, err := lexorank.ParseRank(maxRankStr)
+			if err != nil {
+				return fmt.Errorf("failed to parse max rank: %w", err)
+			}
+			currentRank = maxRank.GenNext()
 		}
-		currentRank = maxRank.GenNext()
-	}
 
-	placeholders := make([]string, len(trackIDs))
-	args := make([]any, 0, len(trackIDs)*3)
-	for i, trackID := range trackIDs {
-		placeholders[i] = "(?, ?, ?)"
-		args = append(args, playlistID, trackID, currentRank.String())
-		currentRank = currentRank.GenNext()
-	}
+		placeholders := make([]string, len(trackIDs))
+		args := make([]any, 0, len(trackIDs)*3)
+		for i, trackID := range trackIDs {
+			placeholders[i] = "(?, ?, ?)"
+			args = append(args, playlistID, trackID, currentRank.String())
+			currentRank = currentRank.GenNext()
+		}
 
-	query := "INSERT OR IGNORE INTO playlist_tracks (playlist_id, track_id, position) VALUES " + strings.Join(placeholders, ", ")
-	if _, err = tx.ExecContext(ctx, query, args...); err != nil {
-		return fmt.Errorf("failed to add tracks to playlist: %w", err)
-	}
+		query := "INSERT OR IGNORE INTO playlist_tracks (playlist_id, track_id, position) VALUES " + strings.Join(placeholders, ", ")
+		if _, err := ex.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("failed to add tracks to playlist: %w", err)
+		}
 
-	return tx.Commit()
+		return nil
+	})
 }
 
 func (r *playlistRepository) RemoveTrack(ctx context.Context, playlistID, trackID string) error {
-	_, err := r.db.ExecContext(ctx, "DELETE FROM playlist_tracks WHERE playlist_id = ? AND track_id = ?", playlistID, trackID)
+	_, err := r.db.Ext(ctx).ExecContext(ctx, "DELETE FROM playlist_tracks WHERE playlist_id = ? AND track_id = ?", playlistID, trackID)
 	if err != nil {
 		return fmt.Errorf("failed to remove track from playlist: %w", err)
 	}
@@ -142,7 +140,7 @@ func (r *playlistRepository) RemoveTrack(ctx context.Context, playlistID, trackI
 }
 
 func (r *playlistRepository) UpdateTrackPosition(ctx context.Context, playlistID, trackID, position string) error {
-	_, err := r.db.ExecContext(ctx, "UPDATE playlist_tracks SET position = ? WHERE playlist_id = ? AND track_id = ?", position, playlistID, trackID)
+	_, err := r.db.Ext(ctx).ExecContext(ctx, "UPDATE playlist_tracks SET position = ? WHERE playlist_id = ? AND track_id = ?", position, playlistID, trackID)
 	if err != nil {
 		return fmt.Errorf("failed to update track position: %w", err)
 	}
@@ -150,25 +148,20 @@ func (r *playlistRepository) UpdateTrackPosition(ctx context.Context, playlistID
 }
 
 func (r *playlistRepository) UpdateTracksPositions(ctx context.Context, playlistID string, updates map[string]string) error {
-	tx, err := r.db.BeginTxx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	for trackID, position := range updates {
-		_, err = tx.ExecContext(ctx, "UPDATE playlist_tracks SET position = ? WHERE playlist_id = ? AND track_id = ?", position, playlistID, trackID)
-		if err != nil {
-			return err
+	return r.db.RunTx(ctx, func(ctx context.Context) error {
+		ex := r.db.Ext(ctx)
+		for trackID, position := range updates {
+			if _, err := ex.ExecContext(ctx, "UPDATE playlist_tracks SET position = ? WHERE playlist_id = ? AND track_id = ?", position, playlistID, trackID); err != nil {
+				return err
+			}
 		}
-	}
-
-	return tx.Commit()
+		return nil
+	})
 }
 
 func (r *playlistRepository) GetTrackPosition(ctx context.Context, playlistID, trackID string) (string, error) {
 	var position string
-	err := r.db.GetContext(ctx, &position, "SELECT position FROM playlist_tracks WHERE playlist_id = ? AND track_id = ?", playlistID, trackID)
+	err := r.db.Ext(ctx).GetContext(ctx, &position, "SELECT position FROM playlist_tracks WHERE playlist_id = ? AND track_id = ?", playlistID, trackID)
 	if err != nil {
 		return "", err
 	}
@@ -177,7 +170,7 @@ func (r *playlistRepository) GetTrackPosition(ctx context.Context, playlistID, t
 
 func (r *playlistRepository) GetMaxPosition(ctx context.Context, playlistID string) (string, error) {
 	var position string
-	err := r.db.GetContext(ctx, &position, "SELECT COALESCE(MAX(position), '') FROM playlist_tracks WHERE playlist_id = ?", playlistID)
+	err := r.db.Ext(ctx).GetContext(ctx, &position, "SELECT COALESCE(MAX(position), '') FROM playlist_tracks WHERE playlist_id = ?", playlistID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return "", nil
@@ -202,7 +195,7 @@ func (r *playlistRepository) GetTracks(ctx context.Context, playlistID string) (
 		ORDER BY pt.position, pt.track_id`, trackSelectFields)
 	
 	var rows []trackRow
-	err := r.db.SelectContext(ctx, &rows, query, playlistID)
+	err := r.db.Ext(ctx).SelectContext(ctx, &rows, query, playlistID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get playlist tracks: %w", err)
 	}
@@ -214,7 +207,7 @@ func (r *playlistRepository) GetTracks(ctx context.Context, playlistID string) (
 func (r *playlistRepository) GetPlaylistsForTrack(ctx context.Context, trackID string) ([]string, error) {
 	var ids []string
 	query := "SELECT playlist_id FROM playlist_tracks WHERE track_id = ?"
-	err := r.db.SelectContext(ctx, &ids, query, trackID)
+	err := r.db.Ext(ctx).SelectContext(ctx, &ids, query, trackID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get playlists for track: %w", err)
 	}

--- a/internal/infra/sqlite/sqlite.go
+++ b/internal/infra/sqlite/sqlite.go
@@ -32,6 +32,18 @@ func NewDB(dbPath string, logger *slog.Logger) (*DB, error) {
 		return nil, fmt.Errorf("failed to enable foreign keys: %w", err)
 	}
 
+	// WAL + synchronous=NORMAL drastically cuts fsync cost for bulk writes
+	// (e.g. library folder scans) while remaining crash-safe.
+	if _, err := db.Exec("PRAGMA journal_mode = WAL;"); err != nil {
+		return nil, fmt.Errorf("failed to enable WAL journal mode: %w", err)
+	}
+	if _, err := db.Exec("PRAGMA synchronous = NORMAL;"); err != nil {
+		return nil, fmt.Errorf("failed to set synchronous mode: %w", err)
+	}
+	if _, err := db.Exec("PRAGMA busy_timeout = 5000;"); err != nil {
+		return nil, fmt.Errorf("failed to set busy timeout: %w", err)
+	}
+
 	if err := runMigrations(db, logger); err != nil {
 		return nil, fmt.Errorf("failed to run migrations: %w", err)
 	}

--- a/internal/infra/sqlite/track_repository.go
+++ b/internal/infra/sqlite/track_repository.go
@@ -21,7 +21,7 @@ func NewTrackRepository(db *DB) domain.TrackRepository {
 func (r *trackRepository) GetByID(ctx context.Context, id string) (*domain.TrackDTO, error) {
 	query := fmt.Sprintf(`SELECT %s FROM tracks t WHERE t.id = ?`, trackSelectFields)
 	var track domain.Track
-	err := r.db.GetContext(ctx, &track, query, id)
+	err := r.db.Ext(ctx).GetContext(ctx, &track, query, id)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -41,7 +41,7 @@ func (r *trackRepository) populateRelationships(ctx context.Context, dto *domain
 	// Album
 	if dto.AlbumID != "" {
 		var album domain.Album
-		err := r.db.GetContext(ctx, &album, "SELECT * FROM albums WHERE id = ?", dto.AlbumID)
+		err := r.db.Ext(ctx).GetContext(ctx, &album, "SELECT * FROM albums WHERE id = ?", dto.AlbumID)
 		if err == nil {
 			dto.Album = &album
 		}
@@ -49,7 +49,7 @@ func (r *trackRepository) populateRelationships(ctx context.Context, dto *domain
 
 	// Artists
 	var artists []*domain.Artist
-	err := r.db.SelectContext(ctx, &artists, `
+	err := r.db.Ext(ctx).SelectContext(ctx, &artists, `
 		SELECT art.* FROM artists art
 		JOIN track_artists ta ON art.id = ta.artist_id
 		WHERE ta.track_id = ?
@@ -61,7 +61,7 @@ func (r *trackRepository) populateRelationships(ctx context.Context, dto *domain
 
 	// Album Artists
 	var albumArtists []*domain.Artist
-	err = r.db.SelectContext(ctx, &albumArtists, `
+	err = r.db.Ext(ctx).SelectContext(ctx, &albumArtists, `
 		SELECT art.* FROM artists art
 		JOIN track_album_artists taa ON art.id = taa.artist_id
 		WHERE taa.track_id = ?
@@ -73,7 +73,7 @@ func (r *trackRepository) populateRelationships(ctx context.Context, dto *domain
 
 	// Genres
 	var genres []*domain.Genre
-	err = r.db.SelectContext(ctx, &genres, `
+	err = r.db.Ext(ctx).SelectContext(ctx, &genres, `
 		SELECT g.* FROM genres g
 		JOIN track_genres tg ON g.id = tg.genre_id
 		WHERE tg.track_id = ?
@@ -85,7 +85,7 @@ func (r *trackRepository) populateRelationships(ctx context.Context, dto *domain
 
 	// Composers
 	var composers []*domain.Composer
-	err = r.db.SelectContext(ctx, &composers, `
+	err = r.db.Ext(ctx).SelectContext(ctx, &composers, `
 		SELECT c.* FROM composers c
 		JOIN track_composers tc ON c.id = tc.composer_id
 		WHERE tc.track_id = ?
@@ -101,7 +101,7 @@ func (r *trackRepository) populateRelationships(ctx context.Context, dto *domain
 func (r *trackRepository) GetByPath(ctx context.Context, path string) (*domain.TrackDTO, error) {
 	query := fmt.Sprintf(`SELECT %s FROM tracks t WHERE t.path = ?`, trackSelectFields)
 	var track domain.Track
-	err := r.db.GetContext(ctx, &track, query, path)
+	err := r.db.Ext(ctx).GetContext(ctx, &track, query, path)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -140,7 +140,7 @@ func (r *trackRepository) GetByAlbumID(ctx context.Context, albumID string) ([]*
 		ORDER BY t.disc_number, t.track_number, t.sort_title
 	`, trackSelectFields)
 	var rows []trackRow
-	err := r.db.SelectContext(ctx, &rows, query, albumID)
+	err := r.db.Ext(ctx).SelectContext(ctx, &rows, query, albumID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tracks by album id: %w", err)
 	}
@@ -163,7 +163,7 @@ func (r *trackRepository) GetByArtistID(ctx context.Context, artistID string) ([
 		ORDER BY t.year DESC, a.title, t.disc_number, t.track_number, t.sort_title
 	`, trackSelectFields)
 	var rows []trackRow
-	err := r.db.SelectContext(ctx, &rows, query, artistID, artistID, artistID)
+	err := r.db.Ext(ctx).SelectContext(ctx, &rows, query, artistID, artistID, artistID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tracks by artist id: %w", err)
 	}
@@ -184,7 +184,7 @@ func (r *trackRepository) GetByGenreID(ctx context.Context, genreID string) ([]*
 		ORDER BY t.year DESC, a.title, t.disc_number, t.track_number, t.sort_title
 		`, trackSelectFields)
 		var rows []trackRow
-		err := r.db.SelectContext(ctx, &rows, query, genreID)
+		err := r.db.Ext(ctx).SelectContext(ctx, &rows, query, genreID)
 		if err != nil {
 		return nil, fmt.Errorf("failed to get tracks by genre id: %w", err)
 		}
@@ -206,7 +206,7 @@ func (r *trackRepository) GetByGenreID(ctx context.Context, genreID string) ([]*
 		`, trackSelectFields)
 
 	var rows []trackRow
-	err := r.db.SelectContext(ctx, &rows, query, composerID)
+	err := r.db.Ext(ctx).SelectContext(ctx, &rows, query, composerID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tracks by composer id: %w", err)
 	}
@@ -254,7 +254,7 @@ func (r *trackRepository) GetByPathPrefix(ctx context.Context, prefix string) ([
 		ORDER BY t.sort_title
 	`, trackSelectFields)
 	var rows []trackRow
-	err := r.db.SelectContext(ctx, &rows, query, prefix)
+	err := r.db.Ext(ctx).SelectContext(ctx, &rows, query, prefix)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tracks by path prefix: %w", err)
 	}
@@ -263,7 +263,7 @@ func (r *trackRepository) GetByPathPrefix(ctx context.Context, prefix string) ([
 
 func (r *trackRepository) AlbumArtistIDsByPathPrefix(ctx context.Context, prefix string) ([]string, error) {
 	var ids []string
-	err := r.db.SelectContext(ctx, &ids, `
+	err := r.db.Ext(ctx).SelectContext(ctx, &ids, `
 		SELECT DISTINCT taa.artist_id
 		FROM tracks t
 		JOIN track_album_artists taa ON t.id = taa.track_id
@@ -277,7 +277,7 @@ func (r *trackRepository) AlbumArtistIDsByPathPrefix(ctx context.Context, prefix
 
 func (r *trackRepository) Count(ctx context.Context) (int, error) {
 	var count int
-	err := r.db.GetContext(ctx, &count, "SELECT COUNT(*) FROM tracks")
+	err := r.db.Ext(ctx).GetContext(ctx, &count, "SELECT COUNT(*) FROM tracks")
 	if err != nil {
 		return 0, fmt.Errorf("failed to count tracks: %w", err)
 	}
@@ -298,7 +298,7 @@ func (r *trackRepository) GetPaginated(ctx context.Context, offset, limit int) (
 		LIMIT ? OFFSET ?
 	`, trackSelectFields)
 	var rows []trackRow
-	err := r.db.SelectContext(ctx, &rows, query, limit, offset)
+	err := r.db.Ext(ctx).SelectContext(ctx, &rows, query, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get paginated tracks: %w", err)
 	}
@@ -327,7 +327,7 @@ func (r *trackRepository) GetByIDs(ctx context.Context, ids []string) ([]*domain
 		GROUP BY t.id
 	`, trackSelectFields, placeholders)
 	var rows []trackRow
-	if err := r.db.SelectContext(ctx, &rows, q, args...); err != nil {
+	if err := r.db.Ext(ctx).SelectContext(ctx, &rows, q, args...); err != nil {
 		return nil, fmt.Errorf("failed to get tracks by ids: %w", err)
 	}
 	// Reorder to match input order (IN clause doesn't preserve order)
@@ -358,7 +358,7 @@ func (r *trackRepository) GetAll(ctx context.Context) ([]*domain.TrackDTO, error
 		ORDER BY t.sort_title
 	`, trackSelectFields)
 	var rows []trackRow
-	err := r.db.SelectContext(ctx, &rows, query)
+	err := r.db.Ext(ctx).SelectContext(ctx, &rows, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get all tracks: %w", err)
 	}
@@ -379,7 +379,7 @@ func (r *trackRepository) GetFavorites(ctx context.Context) ([]*domain.TrackDTO,
 		ORDER BY t.sort_title
 	`, trackSelectFields)
 	var rows []trackRow
-	err := r.db.SelectContext(ctx, &rows, query)
+	err := r.db.Ext(ctx).SelectContext(ctx, &rows, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get favorite tracks: %w", err)
 	}
@@ -387,7 +387,7 @@ func (r *trackRepository) GetFavorites(ctx context.Context) ([]*domain.TrackDTO,
 }
 
 func (r *trackRepository) ToggleFavorite(ctx context.Context, id string) (bool, error) {
-	_, err := r.db.ExecContext(ctx,
+	_, err := r.db.Ext(ctx).ExecContext(ctx,
 		"UPDATE tracks SET is_favorite = NOT is_favorite, updated_at = ? WHERE id = ?",
 		time.Now(), id,
 	)
@@ -395,7 +395,7 @@ func (r *trackRepository) ToggleFavorite(ctx context.Context, id string) (bool, 
 		return false, fmt.Errorf("failed to toggle favorite: %w", err)
 	}
 	var val bool
-	err = r.db.GetContext(ctx, &val, "SELECT is_favorite FROM tracks WHERE id = ?", id)
+	err = r.db.Ext(ctx).GetContext(ctx, &val, "SELECT is_favorite FROM tracks WHERE id = ?", id)
 	if err != nil {
 		return false, fmt.Errorf("failed to read favorite state: %w", err)
 	}
@@ -403,7 +403,7 @@ func (r *trackRepository) ToggleFavorite(ctx context.Context, id string) (bool, 
 }
 
 func (r *trackRepository) IncrementPlayCount(ctx context.Context, id string) error {
-	_, err := r.db.ExecContext(ctx,
+	_, err := r.db.Ext(ctx).ExecContext(ctx,
 		"UPDATE tracks SET play_count = play_count + 1, updated_at = ? WHERE id = ?",
 		time.Now(), id,
 	)
@@ -428,7 +428,7 @@ func (r *trackRepository) GetMostListened(ctx context.Context, limit int) ([]*do
 		LIMIT ?
 	`, trackSelectFields)
 	var rows []trackRow
-	err := r.db.SelectContext(ctx, &rows, query, limit)
+	err := r.db.Ext(ctx).SelectContext(ctx, &rows, query, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get most listened tracks: %w", err)
 	}
@@ -449,7 +449,7 @@ func (r *trackRepository) GetLeastListened(ctx context.Context, limit int) ([]*d
 		LIMIT ?
 	`, trackSelectFields)
 	var rows []trackRow
-	err := r.db.SelectContext(ctx, &rows, query, limit)
+	err := r.db.Ext(ctx).SelectContext(ctx, &rows, query, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get least listened tracks: %w", err)
 	}
@@ -471,7 +471,7 @@ func (r *trackRepository) GetRecentlyPlayed(ctx context.Context, limit int) ([]*
 		LIMIT ?
 	`, trackSelectFields)
 	var rows []trackRow
-	err := r.db.SelectContext(ctx, &rows, query, limit)
+	err := r.db.Ext(ctx).SelectContext(ctx, &rows, query, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get recently played tracks: %w", err)
 	}
@@ -492,7 +492,7 @@ func (r *trackRepository) GetRecentlyAdded(ctx context.Context, limit int) ([]*d
 		LIMIT ?
 	`, trackSelectFields)
 	var rows []trackRow
-	err := r.db.SelectContext(ctx, &rows, query, limit)
+	err := r.db.Ext(ctx).SelectContext(ctx, &rows, query, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get recently added tracks: %w", err)
 	}
@@ -531,7 +531,7 @@ func (r *trackRepository) Save(ctx context.Context, track *domain.Track) error {
 			:copyright, :bpm, :label, :isrc, :play_count, :other_metadata, :file_size, :is_favorite, :mtime, :created_at, :updated_at
 		)`
 
-	_, err := r.db.NamedExecContext(ctx, query, dbTrack)
+	_, err := r.db.Ext(ctx).NamedExecContext(ctx, query, dbTrack)
 	if err != nil {
 		return fmt.Errorf("failed to save track: %w", err)
 	}
@@ -591,7 +591,7 @@ func (r *trackRepository) Upsert(ctx context.Context, track *domain.Track) error
 			updated_at = excluded.updated_at
 	`
 
-	_, err := r.db.NamedExecContext(ctx, query, dbTrack)
+	_, err := r.db.Ext(ctx).NamedExecContext(ctx, query, dbTrack)
 	if err != nil {
 		return fmt.Errorf("failed to upsert track: %w", err)
 	}
@@ -615,25 +615,23 @@ func (r *trackRepository) SetComposers(ctx context.Context, trackID string, comp
 }
 
 func (r *trackRepository) setJunction(ctx context.Context, table, idCol, valCol, id string, vals []string) error {
-	tx, err := r.db.BeginTxx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = tx.Rollback() }()
+	return r.db.RunTx(ctx, func(ctx context.Context) error {
+		ex := r.db.Ext(ctx)
 
-	_, err = tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE %s = ?", table, idCol), id)
-	if err != nil {
-		return err
-	}
-
-	for i, val := range vals {
-		_, err = tx.ExecContext(ctx, fmt.Sprintf("INSERT INTO %s (%s, %s, position) VALUES (?, ?, ?)", table, idCol, valCol), id, val, i)
+		_, err := ex.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE %s = ?", table, idCol), id)
 		if err != nil {
 			return err
 		}
-	}
 
-	return tx.Commit()
+		for i, val := range vals {
+			_, err = ex.ExecContext(ctx, fmt.Sprintf("INSERT INTO %s (%s, %s, position) VALUES (?, ?, ?)", table, idCol, valCol), id, val, i)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
 }
 
 func toNullString(s string) sql.NullString {
@@ -644,7 +642,7 @@ func toNullString(s string) sql.NullString {
 }
 
 func (r *trackRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.ExecContext(ctx, "DELETE FROM tracks WHERE id = ?", id)
+	_, err := r.db.Ext(ctx).ExecContext(ctx, "DELETE FROM tracks WHERE id = ?", id)
 	if err != nil {
 		return fmt.Errorf("failed to delete track: %w", err)
 	}
@@ -652,7 +650,7 @@ func (r *trackRepository) Delete(ctx context.Context, id string) error {
 }
 
 func (r *trackRepository) DeleteByPathPrefix(ctx context.Context, prefix string) error {
-	_, err := r.db.ExecContext(ctx, "DELETE FROM tracks WHERE path LIKE ? || '%'", prefix)
+	_, err := r.db.Ext(ctx).ExecContext(ctx, "DELETE FROM tracks WHERE path LIKE ? || '%'", prefix)
 	if err != nil {
 		return fmt.Errorf("failed to delete tracks by path prefix: %w", err)
 	}
@@ -667,7 +665,7 @@ func (r *trackRepository) GetAllArtworkKeys(ctx context.Context) ([]string, erro
 		SELECT DISTINCT artwork_key FROM albums WHERE artwork_key IS NOT NULL AND artwork_key != ''
 	`
 	var keys []string
-	err := r.db.SelectContext(ctx, &keys, query)
+	err := r.db.Ext(ctx).SelectContext(ctx, &keys, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get all artwork keys: %w", err)
 	}

--- a/internal/infra/sqlite/tx.go
+++ b/internal/infra/sqlite/tx.go
@@ -1,0 +1,76 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+
+	"airmedy/internal/domain"
+
+	"github.com/jmoiron/sqlx"
+)
+
+type txCtxKey struct{}
+
+func withTx(ctx context.Context, tx *sqlx.Tx) context.Context {
+	return context.WithValue(ctx, txCtxKey{}, tx)
+}
+
+func txFromContext(ctx context.Context) (*sqlx.Tx, bool) {
+	tx, ok := ctx.Value(txCtxKey{}).(*sqlx.Tx)
+	return tx, ok
+}
+
+// sqlExecutor is the subset of *sqlx.DB / *sqlx.Tx methods repositories
+// need. Both types implement it identically, so Ext can hand out either
+// transparently.
+type sqlExecutor interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	GetContext(ctx context.Context, dest any, query string, args ...any) error
+	SelectContext(ctx context.Context, dest any, query string, args ...any) error
+	NamedExecContext(ctx context.Context, query string, arg any) (sql.Result, error)
+}
+
+// Ext returns the ambient transaction carried on ctx if present, otherwise
+// the plain db handle, so repository code can use this as a drop-in
+// executor that transparently joins an outer RunTx when there is one.
+func (db *DB) Ext(ctx context.Context) sqlExecutor {
+	if tx, ok := txFromContext(ctx); ok {
+		return tx
+	}
+	return db.DB
+}
+
+// RunTx runs fn inside a transaction, committing on success and rolling
+// back on error. It is reentrant: if ctx already carries a transaction
+// (e.g. an outer RunTx call), fn is invoked inline without opening a new
+// one, since SQLite/database-sql has no nested transaction support on a
+// single connection.
+func (db *DB) RunTx(ctx context.Context, fn func(ctx context.Context) error) error {
+	if _, ok := txFromContext(ctx); ok {
+		return fn(ctx)
+	}
+
+	tx, err := db.BeginTxx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := fn(withTx(ctx, tx)); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// txManager adapts DB.RunTx to the domain.TxManager interface.
+type txManager struct {
+	db *DB
+}
+
+func NewTxManager(db *DB) domain.TxManager {
+	return &txManager{db: db}
+}
+
+func (m *txManager) RunInTx(ctx context.Context, fn func(ctx context.Context) error) error {
+	return m.db.RunTx(ctx, fn)
+}

--- a/internal/infra/sqlite/tx_test.go
+++ b/internal/infra/sqlite/tx_test.go
@@ -1,0 +1,133 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+)
+
+func newTxTestDB(t *testing.T) *DB {
+	t.Helper()
+	dbPath := t.Name() + ".db"
+	t.Cleanup(func() { _ = os.Remove(dbPath) })
+
+	db, err := NewDB(dbPath, slog.Default())
+	if err != nil {
+		t.Fatalf("Failed to create test db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestRunTxCommitsOnSuccess(t *testing.T) {
+	db := newTxTestDB(t)
+	ctx := context.Background()
+	repo := NewTrackRepository(db)
+
+	err := db.RunTx(ctx, func(ctx context.Context) error {
+		_, execErr := db.Ext(ctx).ExecContext(ctx,
+			"INSERT INTO tracks (id, path, title, sort_title, mtime) VALUES (?, ?, ?, ?, ?)",
+			"tx-commit", "/tx/commit.mp3", "Commit", "Commit", time.Now())
+		return execErr
+	})
+	if err != nil {
+		t.Fatalf("RunTx returned error: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, "tx-commit")
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected committed row to be visible after RunTx")
+	}
+}
+
+func TestRunTxRollsBackOnError(t *testing.T) {
+	db := newTxTestDB(t)
+	ctx := context.Background()
+	repo := NewTrackRepository(db)
+
+	sentinel := errors.New("boom")
+	err := db.RunTx(ctx, func(ctx context.Context) error {
+		_, execErr := db.Ext(ctx).ExecContext(ctx,
+			"INSERT INTO tracks (id, path, title, sort_title, mtime) VALUES (?, ?, ?, ?, ?)",
+			"tx-rollback", "/tx/rollback.mp3", "Rollback", "Rollback", time.Now())
+		if execErr != nil {
+			return execErr
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, "tx-rollback")
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if got != nil {
+		t.Fatal("expected rolled-back row to be absent")
+	}
+}
+
+func TestRunTxReentrantDoesNotNest(t *testing.T) {
+	db := newTxTestDB(t)
+	ctx := context.Background()
+	repo := NewTrackRepository(db)
+
+	err := db.RunTx(ctx, func(ctx context.Context) error {
+		outerTx, ok := txFromContext(ctx)
+		if !ok {
+			t.Fatal("expected outer RunTx to stash a tx in ctx")
+		}
+
+		return db.RunTx(ctx, func(ctx context.Context) error {
+			innerTx, ok := txFromContext(ctx)
+			if !ok {
+				t.Fatal("expected inner RunTx to see a tx in ctx")
+			}
+			if innerTx != outerTx {
+				t.Fatal("expected reentrant RunTx to reuse the outer transaction, not nest a new one")
+			}
+			_, execErr := db.Ext(ctx).ExecContext(ctx,
+				"INSERT INTO tracks (id, path, title, sort_title, mtime) VALUES (?, ?, ?, ?, ?)",
+				"tx-reentrant", "/tx/reentrant.mp3", "Reentrant", "Reentrant", time.Now())
+			return execErr
+		})
+	})
+	if err != nil {
+		t.Fatalf("RunTx returned error: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, "tx-reentrant")
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected reentrant-committed row to be visible")
+	}
+}
+
+func TestExtReturnsTxOrDB(t *testing.T) {
+	db := newTxTestDB(t)
+	ctx := context.Background()
+
+	if db.Ext(ctx) != sqlExecutor(db.DB) {
+		t.Fatal("expected plain ctx to yield the db handle")
+	}
+
+	_ = db.RunTx(ctx, func(ctx context.Context) error {
+		tx, ok := txFromContext(ctx)
+		if !ok {
+			t.Fatal("expected RunTx to stash a tx in ctx")
+		}
+		if db.Ext(ctx) != sqlExecutor(tx) {
+			t.Fatal("expected Ext(ctx) to return the ambient tx")
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
## Summary
- Removing a watched folder while background analysis was running/backfilling could hang or take tens of seconds (up to 40s+ on a real library). Root causes:
  - `AnalysisService` had no coupling to deletion — added `Dequeue()`, wired from `RemoveWatchedFolder`, fsnotify remove/rename, and `SyncFolder`'s missing-file cleanup.
  - `RemoveWatchedFolder`, `cleanupOrphanedEntities`, `SyncFolder`'s missing-file cleanup, and the fsnotify directory-removal handler all looped per-item search-index deletes, each its own fsync-ing Bleve commit. Added `DeleteTracksFromIndex`/`BatchDeleteFromIndex` to batch these (same pattern `BatchReindex`/`BeginSyncBatch` already use for imports).
  - `ResplitLibrary` (delimiter-change resync) was missing the `syncEntityCache` + `BeginSyncBatch`/`EndSyncBatch` optimizations `SyncFolder` already had.
  - Junction tables (`track_artists`, `track_album_artists`, `track_genres`, `track_composers`, `album_artists`) had no index on the reverse-lookup column, so `DeleteOrphaned`'s anti-join queries full-scanned per candidate row — migration `000035` adds them.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/...`
- [x] Verified via `EXPLAIN QUERY PLAN` that the new indexes are used for the orphan anti-join queries
- [x] Live-tested remove-watched-folder + delimiter resync against a real library with debug timing logs; both went from tens of seconds to milliseconds