### PR TITLE
fix: batch remaining unbatched writes, bound analysis hangs

### DIFF
--- a/internal/app/analysis/analysis_service.go
+++ b/internal/app/analysis/analysis_service.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"runtime"
 	"sync"
+	"time"
 
 	"airmedy/internal/domain"
 
@@ -15,6 +16,19 @@ import (
 // result; tracks with tracks.analyzed_version < this are pending. Must be
 // kept in sync with audio.AnalyzerVersion (internal/infra/audio/analyzer.go).
 const analyzerVersion = 1
+
+// analyzeTimeout bounds a single track's decode/analysis pass. The cgo
+// analyzer only polls its cancel flag once per outer decode iteration, so a
+// stalled read (network mount, truncated/corrupt stream) can otherwise wedge
+// a worker — and therefore stopPool's wg.Wait() — forever.
+const analyzeTimeout = 3 * time.Minute
+
+// stopPoolWaitTimeout bounds how long stopPool waits for in-flight workers
+// before giving up and returning anyway, so a single wedged analysis (see
+// analyzeTimeout) can't hang app shutdown or a disable/re-enable toggle
+// indefinitely. The abandoned worker goroutine keeps running in the
+// background and will exit on its own once analyzeTimeout elapses.
+const stopPoolWaitTimeout = analyzeTimeout + 30*time.Second
 
 // AnalysisService runs the background audio-analysis pipeline: a resumable,
 // priority-aware worker pool that turns pending tracks into stored
@@ -168,7 +182,16 @@ func (s *AnalysisService) stopPool() {
 	s.cond.Broadcast()
 	s.mu.Unlock()
 
-	s.wg.Wait()
+	waitDone := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+	case <-time.After(stopPoolWaitTimeout):
+		s.logger.Warn("analysis: stopPool gave up waiting for in-flight workers, abandoning them", "timeout", stopPoolWaitTimeout)
+	}
 
 	s.mu.Lock()
 	s.boostQueue = nil
@@ -362,13 +385,17 @@ func (s *AnalysisService) analyzeOne(ctx context.Context, trackID string) {
 
 	// The on-play boost hook enqueues every track it loads, whether or not it's
 	// already analyzed (Enqueue only dedups in-flight/queued, not analyzed
-	// state). Skip the expensive ffmpeg pass if a prior analyzeOne already
-	// wrote up-to-date features for this track.
-	if existing, err := s.analysisRepo.GetFeatures(ctx, trackID); err == nil && existing != nil && existing.AnalyzerVersion >= analyzerVersion {
+	// state). Skip the expensive ffmpeg pass if this track already has an
+	// up-to-date analyzed_version — checking that (rather than GetFeatures)
+	// also covers tracks MarkFailed as permanently unanalyzable, which have no
+	// features row and would otherwise be re-run on every play.
+	if done, err := s.analysisRepo.IsAnalyzed(ctx, trackID, analyzerVersion); err == nil && done {
 		return
 	}
 
-	feat, err := s.analyzer.Analyze(ctx, track.Path)
+	analyzeCtx, cancel := context.WithTimeout(ctx, analyzeTimeout)
+	defer cancel()
+	feat, err := s.analyzer.Analyze(analyzeCtx, track.Path)
 	if err != nil {
 		if ctx.Err() != nil {
 			return // shutting down

--- a/internal/app/analysis/analysis_service_test.go
+++ b/internal/app/analysis/analysis_service_test.go
@@ -53,6 +53,12 @@ func (m *mockAnalysisRepo) GetFeatures(ctx context.Context, trackID string) (*do
 	return nil, nil
 }
 
+func (m *mockAnalysisRepo) IsAnalyzed(ctx context.Context, trackID string, currentVersion int) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.versions[trackID] >= currentVersion, nil
+}
+
 func (m *mockAnalysisRepo) MarkFailed(ctx context.Context, trackID string, currentVersion int) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/app/library/service.go
+++ b/internal/app/library/service.go
@@ -391,17 +391,17 @@ func (s *LibraryService) handleEvent(event fsnotify.Event) {
 			tracks, err := s.trackRepo.GetByPathPrefix(ctx, prefix)
 			if err == nil && len(tracks) > 0 {
 				s.logger.Info("Directory removed, deleting tracks inside", "count", len(tracks), "prefix", prefix)
-				var dirDeletedIDs []string
-				for _, t := range tracks {
-					if err := s.trackRepo.Delete(ctx, t.ID); err != nil {
-						s.logger.Warn("Failed to delete track from DB", "id", t.ID, "error", err)
-						continue
-					}
-					dirDeletedIDs = append(dirDeletedIDs, t.ID)
+				dirDeletedIDs := make([]string, len(tracks))
+				for i, t := range tracks {
+					dirDeletedIDs[i] = t.ID
 				}
-				deletedIDs = append(deletedIDs, dirDeletedIDs...)
-				// Batched: one (or a few) commits instead of one fsync-ing
-				// commit per track — same fix as RemoveWatchedFolder.
+				// Batched: one statement instead of one fsync-ing commit per
+				// track — same fix as RemoveWatchedFolder.
+				if err := s.trackRepo.DeleteByPathPrefix(ctx, prefix); err != nil {
+					s.logger.Warn("Failed to delete tracks from DB", "count", len(dirDeletedIDs), "error", err)
+				} else {
+					deletedIDs = append(deletedIDs, dirDeletedIDs...)
+				}
 				if err := s.searchService.DeleteTracksFromIndex(ctx, dirDeletedIDs); err != nil {
 					s.logger.Warn("Failed to delete tracks from search index", "count", len(dirDeletedIDs), "error", err)
 				}
@@ -902,20 +902,26 @@ func (s *LibraryService) SyncFolder(ctx context.Context, root string) error {
 	var deletedIDs []string
 	existingTracks, err := s.trackRepo.GetByPathPrefix(ctx, root)
 	if err == nil {
-		for _, t := range existingTracks {
-			if foundPaths[filepath.Clean(t.Path)] {
-				continue
+		// Batched: all deletes share one transaction/fsync instead of one
+		// commit per track — same fix as RemoveWatchedFolder. A resync of a
+		// folder with many moved/deleted files was hitting this the same way.
+		txErr := s.txManager.RunInTx(ctx, func(ctx context.Context) error {
+			for _, t := range existingTracks {
+				if foundPaths[filepath.Clean(t.Path)] {
+					continue
+				}
+				s.logger.Info("Removing missing track", "path", t.Path)
+				if err := s.trackRepo.Delete(ctx, t.ID); err != nil {
+					s.logger.Warn("Failed to delete missing track from DB", "path", t.Path, "error", err)
+					continue
+				}
+				deletedIDs = append(deletedIDs, t.ID)
 			}
-			s.logger.Info("Removing missing track", "path", t.Path)
-			if err := s.trackRepo.Delete(ctx, t.ID); err != nil {
-				s.logger.Warn("Failed to delete missing track from DB", "path", t.Path, "error", err)
-				continue
-			}
-			deletedIDs = append(deletedIDs, t.ID)
+			return nil
+		})
+		if txErr != nil {
+			s.logger.Warn("Failed to delete missing tracks from DB", "error", txErr)
 		}
-		// Batched: one (or a few) commits instead of one fsync-ing commit per
-		// track — same fix as RemoveWatchedFolder. A resync of a folder with
-		// many moved/deleted files was hitting this the same way.
 		if err := s.searchService.DeleteTracksFromIndex(ctx, deletedIDs); err != nil {
 			s.logger.Warn("Failed to delete missing tracks from search index", "count", len(deletedIDs), "error", err)
 		}
@@ -1346,7 +1352,9 @@ func (s *LibraryService) ResplitLibrary(ctx context.Context) error {
 
 	for i, dto := range tracks {
 		s.buildEntitiesFromRaw(dto, settings)
-		if err := s.resolveEntities(ctx, dto); err != nil {
+		if err := s.txManager.RunInTx(ctx, func(ctx context.Context) error {
+			return s.resolveEntities(ctx, dto)
+		}); err != nil {
 			s.logger.Error("Failed to re-split track", "path", dto.Path, "error", err)
 		}
 		if app := application.Get(); app != nil && app.Event != nil {

--- a/internal/domain/repositories.go
+++ b/internal/domain/repositories.go
@@ -181,6 +181,11 @@ type AnalysisRepository interface {
 	// Normalization correctly treats it as unanalyzed (gain 0) rather than
 	// inventing fake loudness data.
 	MarkFailed(ctx context.Context, trackID string, currentVersion int) error
+	// IsAnalyzed reports whether tracks.analyzed_version >= currentVersion for
+	// the given track. True for both successfully analyzed and permanently
+	// failed tracks (MarkFailed also bumps analyzed_version), so callers can
+	// skip re-running the analyzer on a track that already failed once.
+	IsAnalyzed(ctx context.Context, trackID string, currentVersion int) (bool, error)
 }
 
 type MiniPlayerStateRepository interface {

--- a/internal/infra/sqlite/analysis_repository.go
+++ b/internal/infra/sqlite/analysis_repository.go
@@ -152,6 +152,20 @@ func (r *analysisRepository) GetFeatures(ctx context.Context, trackID string) (*
 	}, nil
 }
 
+func (r *analysisRepository) IsAnalyzed(ctx context.Context, trackID string, currentVersion int) (bool, error) {
+	var version int
+	err := r.db.Ext(ctx).GetContext(ctx, &version,
+		`SELECT analyzed_version FROM tracks WHERE id = ?`, trackID,
+	)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to get track analyzed_version: %w", err)
+	}
+	return version >= currentVersion, nil
+}
+
 func (r *analysisRepository) CountPending(ctx context.Context, currentVersion int) (int, error) {
 	var n int
 	if err := r.db.Ext(ctx).GetContext(ctx, &n,


### PR DESCRIPTION
## Summary
- `ResplitLibrary` now wraps `resolveEntities` in `txManager.RunInTx`, same as `persistImported` — was committing one fsync per track.
- Directory-removal (`handleEvent`) and `SyncFolder`'s missing-file cleanup now batch their deletes (`DeleteByPathPrefix` / single `RunInTx`) instead of one commit per track — same fix already applied to `RemoveWatchedFolder`.
- Bound `AnalysisService`: added a per-track `analyzeTimeout` (3m) and a `stopPoolWaitTimeout` so a stalled decode (corrupt file, network mount) can no longer hang `stopPool`'s wait forever on shutdown/toggle.
- Added `AnalysisRepository.IsAnalyzed` so tracks already marked failed (`MarkFailed`, no features row) aren't re-run on every play — `analyzeOne` now checks `analyzed_version` instead of `GetFeatures`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/app/library/... ./internal/app/analysis/... ./internal/infra/sqlite/... ./internal/domain/...`