### PR TITLE
fix(albums): remove double padding wrapper on album list view

### DIFF
--- a/catalog/database/README.md
+++ b/catalog/database/README.md
@@ -63,6 +63,8 @@ SQLite database managed via `golang-migrate` for schema versioning and `sqlx` fo
 | 000036 | `onset_variance.up.sql`              | `ALTER TABLE track_features ADD COLUMN onset_variance REAL` (danceability input; down keeps column — SQLite `DROP COLUMN` unsafe across versions) |
 | 000037 | `corpus_feature_stats.up.sql`        | Add `feature_percentiles` table (per-feature `p1/p5/p50/p95/p99` + `sample_count`/`computed_at`, corpus normalization stats for mood derivation); add `app_settings.mood_derivation_version INTEGER NOT NULL DEFAULT 0` |
 | 000038 | `track_mood_version.up.sql`          | `ALTER TABLE tracks ADD COLUMN mood_derived_version INTEGER NOT NULL DEFAULT 0` + `idx_tracks_mood_derived_version` — marks a track's mood stale vs `app_settings.mood_derivation_version` for re-derivation |
+| 000039 | `track_bitdepth_codec.up.sql`        | `ALTER TABLE tracks ADD COLUMN bit_depth INTEGER NOT NULL DEFAULT 0`, `ADD COLUMN codec TEXT NOT NULL DEFAULT ''` — bits-per-sample and inner codec (e.g. m4a `aac`/`alac`) from the `go-taglib` fork, used to classify Lossy/Lossless/Hi-Res/DSD |
+| 000040 | `metadata_schema_version.up.sql`     | `ALTER TABLE library_sync_state ADD COLUMN metadata_schema_version INTEGER NOT NULL DEFAULT 0` — tracks which extractor field-set a library's data reflects, so a sync can force one full re-parse when it's behind (see `catalog/library`) |
 
 ## Full Schema
 
@@ -120,6 +122,8 @@ tracks (
     bitrate INTEGER,
     sample_rate INTEGER,
     format TEXT,
+    bit_depth INTEGER NOT NULL DEFAULT 0,  -- 0 = unknown/legacy row, not yet re-synced (000039)
+    codec TEXT NOT NULL DEFAULT '',        -- inner codec for container formats, e.g. m4a aac/alac (000039)
     artwork_key TEXT,
     raw_artist_names TEXT,
     raw_album_artist_names TEXT,
@@ -249,6 +253,7 @@ app_settings (
 library_sync_state (
     id INTEGER PRIMARY KEY CHECK(id = 1),
     delimiters_signature TEXT NOT NULL DEFAULT '',  -- JSON of the 4 applied delimiter lists; compared on sync to decide re-split
+    metadata_schema_version INTEGER NOT NULL DEFAULT 0,  -- current extractor field-set version; behind → next SyncFolder force-reparses all files once (000040)
     updated_at DATETIME
 )
 

--- a/catalog/library/README.md
+++ b/catalog/library/README.md
@@ -83,6 +83,21 @@ The signature lives in DB, so "delimiters changed but not yet synced" survives a
 show a persistent "Sync Library to apply" hint and to clear it after sync (re-queried on every
 `library:sync-finished`).
 
+## Unchanged-File Skip & Forced Metadata Re-parse
+
+`SyncFolder` preloads existing tracks' `(size, mtime)` under the walked root into an in-memory
+map and skips re-extracting any file whose stamp still matches — this keeps repeat syncs of a
+large, mostly-unchanged library fast.
+
+That optimization is bypassed once, library-wide, whenever `currentMetadataSchemaVersion`
+(`library/service.go`) is ahead of `library_sync_state.metadata_schema_version`: every file gets
+re-parsed regardless of its stamp, so newly-added `TrackDTO` fields (e.g. `bit_depth`/`codec`,
+added in migration 000039) get backfilled onto already-imported rows without a full reimport.
+`SyncLibrary` persists the bumped version only after every watched folder has been synced, so a
+library with multiple folders doesn't have one folder's completion silently skip the backfill for
+the next. Bump `currentMetadataSchemaVersion` whenever the extractor (`taglib.go`) gains a field
+that existing unchanged files need re-read to populate.
+
 ## Wails-Exposed Methods
 
 ```typescript

--- a/catalog/metadata/README.md
+++ b/catalog/metadata/README.md
@@ -38,7 +38,7 @@ type MetadataExtractor interface {
 }
 ```
 
-**Library:** `go.senan.xyz/taglib` — Go bindings to the TagLib C++ library.
+**Library:** `github.com/misa198/go-taglib` — fork of `go.senan.xyz/taglib` (Go bindings to the TagLib C++ library), extended to expose `BitDepth` (bits per sample) and `InnerCodec` (codec inside a container format, e.g. m4a `aac`/`alac`), which upstream doesn't surface. Feeds `Track.BitDepth`/`Track.Codec`, used by the frontend to classify Lossy/Lossless/Hi-Res/DSD (see `catalog/library` for the audio-quality tiering and the re-sync backfill mechanism).
 
 ## Tag Mapping Strategy
 

--- a/frontend/src/views/AlbumsView.vue
+++ b/frontend/src/views/AlbumsView.vue
@@ -111,7 +111,7 @@ onMounted(loadAlbums)
       </template>
     </ViewHeader>
 
-    <div class="flex-1 overflow-hidden" :class="viewMode === 'list' ? 'px-6 py-8' : ''">
+    <div class="flex-1 overflow-hidden">
       <div v-if="isLoading" class="h-full flex items-center justify-center">
         <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
       </div>


### PR DESCRIPTION
## Summary
- Album list view had duplicate padding: `px-6 py-8` wrapper in AlbumsView.vue stacked on top of AlbumListView/VirtualizedGrid's own internal padding.
- Removed wrapper class, list view now relies on component's own padding only.

## Test plan
- [ ] Toggle Albums view to list mode, verify padding on all 4 edges looks correct (no double spacing)
- [ ] Toggle back to grid mode, verify unaffected