### PR TITLE
fix: prevent duplicate sync runs and show button busy during background sync

### DIFF
--- a/frontend/src/components/settings/LibrarySettings.vue
+++ b/frontend/src/components/settings/LibrarySettings.vue
@@ -49,6 +49,9 @@ const syncType = ref<'sync' | 'optimize' | null>(null)
 const isLoading = ref(true)
 const syncProgress = ref<SyncProgress | null>(null)
 const syncComplete = ref(false)
+// True while an automatic background sync is running: the button still shows
+// busy, but the overlay stays hidden (see showSyncDialog below).
+const backgroundSyncActive = ref(false)
 const folderToDelete = ref<string | null>(null)
 const removingFolderIds = ref<string[]>([])
 
@@ -121,6 +124,11 @@ const optimizeSearch = async () => {
 const handleSyncStarted = (ev: Events.WailsEvent) => {
   const data = ev.data as any
   isSyncing.value = true
+  if (data.background) {
+    backgroundSyncActive.value = true
+    return
+  }
+  backgroundSyncActive.value = false
   syncComplete.value = false
   syncProgress.value = {
     current: 0,
@@ -132,6 +140,7 @@ const handleSyncStarted = (ev: Events.WailsEvent) => {
 const handleSyncProgress = (ev: Events.WailsEvent) => {
   const progress = ev.data as SyncProgress
   isSyncing.value = true
+  backgroundSyncActive.value = false
   syncProgress.value = progress
 }
 
@@ -143,9 +152,13 @@ const refreshDelimitersPending = async () => {
   }
 }
 
-const handleSyncFinished = () => {
+const handleSyncFinished = (ev: Events.WailsEvent) => {
+  const data = ev.data as any
   isSyncing.value = false
-  syncComplete.value = true
+  if (!data?.background) {
+    syncComplete.value = true
+  }
+  backgroundSyncActive.value = false
   // Re-query the backend so the banner reflects the actual applied state. Always
   // (not gated on syncType): a Sync Library run emits several sync-finished
   // events — folder sync, re-split, then re-index — and only the last one lands
@@ -153,8 +166,13 @@ const handleSyncFinished = () => {
   refreshDelimitersPending()
 }
 
+// Background syncs keep the button spinning (isSyncing) but never show the
+// overlay — only a foreground (user-triggered) sync does.
 const showSyncDialog = computed(
-  () => isSyncing.value || removingFolderIds.value.length > 0 || syncComplete.value
+  () =>
+    (isSyncing.value && !backgroundSyncActive.value) ||
+    removingFolderIds.value.length > 0 ||
+    syncComplete.value
 )
 
 watch(syncComplete, (val) => {

--- a/internal/app/library/service.go
+++ b/internal/app/library/service.go
@@ -87,6 +87,7 @@ type LibraryService struct {
 	pendingArtistArtworkMu  sync.Mutex
 	artistArtworkLocks      sync.Map         // artistID -> *sync.Mutex; serializes artwork writes
 	bulkSyncMu              sync.Mutex       // serializes SyncFolder/ResplitLibrary/ReindexAll: all three read/write the shared syncEntityCache and search index sync-batch below, which are not safe for concurrent use
+	syncRunning             atomic.Bool      // true while a top-level SyncFolder/SyncLibrary call is running; gates re-entrant calls so a queued caller skips instead of redoing the same work
 	syncing                 atomic.Int32     // >0 while a bulk SyncFolder runs (gates per-track work)
 	syncEntityCache         *syncEntityCache // non-nil only during a SyncFolder/ResplitLibrary run; caches resolved entity IDs
 	syncReschedule          chan struct{}    // signals the periodic-sync scheduler to re-read the interval setting
@@ -594,6 +595,12 @@ func (s *LibraryService) CleanupOrphanedArtworks(ctx context.Context) error {
 // hold the lock for their whole run and calling this would self-deadlock; call
 // syncFolderLocked directly instead.
 func (s *LibraryService) SyncFolder(ctx context.Context, root string) error {
+	if !s.syncRunning.CompareAndSwap(false, true) {
+		s.logger.Info("sync already in progress, skipping", "root", root)
+		return nil
+	}
+	defer s.syncRunning.Store(false)
+
 	s.bulkSyncMu.Lock()
 	defer s.bulkSyncMu.Unlock()
 	return s.syncFolderLocked(ctx, root)
@@ -646,10 +653,14 @@ func (s *LibraryService) syncFolderLocked(ctx context.Context, root string) erro
 		return nil
 	})
 
-	if app := application.Get(); app != nil && app.Event != nil && !isBackgroundSync(ctx) {
+	// Always emit sync-started (even for background syncs) so the UI can show the
+	// button as busy; only the progress/dialog emits below stay gated on
+	// isBackgroundSync so the overlay itself does not appear for background runs.
+	if app := application.Get(); app != nil && app.Event != nil {
 		app.Event.Emit("library:sync-started", map[string]interface{}{
-			"path":  root,
-			"total": total,
+			"path":       root,
+			"total":      total,
+			"background": isBackgroundSync(ctx),
 		})
 	}
 
@@ -859,9 +870,10 @@ func (s *LibraryService) syncFolderLocked(ctx context.Context, root string) erro
 		for _, id := range deletedIDs {
 			app.Event.Emit("library:track-deleted", id)
 		}
-		if !isBackgroundSync(ctx) {
-			app.Event.Emit("library:sync-finished", root)
-		}
+		app.Event.Emit("library:sync-finished", map[string]interface{}{
+			"path":       root,
+			"background": isBackgroundSync(ctx),
+		})
 	}
 	s.notifySyncFinished()
 	return nil
@@ -1224,6 +1236,12 @@ func (s *LibraryService) buildEntitiesFromRaw(dto *domain.TrackDTO, settings *do
 // lock comment: do not call this from inside SyncLibrary, which already holds
 // the lock — call resplitLibraryLocked directly instead.
 func (s *LibraryService) ResplitLibrary(ctx context.Context) error {
+	if !s.syncRunning.CompareAndSwap(false, true) {
+		s.logger.Info("sync already in progress, skipping resplit")
+		return nil
+	}
+	defer s.syncRunning.Store(false)
+
 	s.bulkSyncMu.Lock()
 	defer s.bulkSyncMu.Unlock()
 	return s.resplitLibraryLocked(ctx)
@@ -1260,10 +1278,11 @@ func (s *LibraryService) resplitLibraryLocked(ctx context.Context) error {
 
 	total := len(tracks)
 	emitProgress := !isBackgroundSync(ctx) // background syncs run without the dialog
-	if app := application.Get(); emitProgress && app != nil && app.Event != nil {
+	if app := application.Get(); app != nil && app.Event != nil {
 		app.Event.Emit("library:sync-started", map[string]interface{}{
-			"path":  "",
-			"total": total,
+			"path":       "",
+			"total":      total,
+			"background": isBackgroundSync(ctx),
 		})
 	}
 
@@ -1290,8 +1309,11 @@ func (s *LibraryService) resplitLibraryLocked(ctx context.Context) error {
 	}
 
 	s.logger.Info("Finished library re-split")
-	if app := application.Get(); emitProgress && app != nil && app.Event != nil {
-		app.Event.Emit("library:sync-finished", "")
+	if app := application.Get(); app != nil && app.Event != nil {
+		app.Event.Emit("library:sync-finished", map[string]interface{}{
+			"path":       "",
+			"background": isBackgroundSync(ctx),
+		})
 	}
 	return nil
 }
@@ -1347,6 +1369,15 @@ func (s *LibraryService) DelimitersPendingResync(ctx context.Context) (bool, err
 // additionally re-splits the whole library and rebuilds the search index. The
 // applied-delimiters signature is persisted so the decision survives restarts.
 func (s *LibraryService) SyncLibrary(ctx context.Context) error {
+	// Skip instead of queuing behind an in-flight run: a queued caller would
+	// otherwise redo the same full folder scan right after this one finishes
+	// (e.g. a manual "Sync Library" click landing during the startup auto-scan).
+	if !s.syncRunning.CompareAndSwap(false, true) {
+		s.logger.Info("sync already in progress, skipping")
+		return nil
+	}
+	defer s.syncRunning.Store(false)
+
 	// Hold the lock for this whole run (folder loop + resplit + reindex), not just
 	// per sub-step — otherwise a second SyncLibrary/SyncFolder call queued on the
 	// same mutex can slip in during the gap between two sub-steps and interleave
@@ -1565,6 +1596,12 @@ func (s *LibraryService) GetAlbumColors(ctx context.Context, id string) (*domain
 // comment: do not call this from inside SyncLibrary, which already holds the
 // lock — call reindexAllLocked directly instead.
 func (s *LibraryService) ReindexAll(ctx context.Context) error {
+	if !s.syncRunning.CompareAndSwap(false, true) {
+		s.logger.Info("sync already in progress, skipping reindex")
+		return nil
+	}
+	defer s.syncRunning.Store(false)
+
 	s.bulkSyncMu.Lock()
 	defer s.bulkSyncMu.Unlock()
 	return s.reindexAllLocked(ctx)
@@ -1601,10 +1638,11 @@ func (s *LibraryService) reindexAllLocked(ctx context.Context) error {
 		}
 	}
 
-	if app := application.Get(); showDialog && app != nil && app.Event != nil {
+	if app := application.Get(); app != nil && app.Event != nil {
 		app.Event.Emit("library:sync-started", map[string]interface{}{
-			"path":  "Re-indexing Search",
-			"total": total,
+			"path":       "Re-indexing Search",
+			"total":      total,
+			"background": isBackgroundSync(ctx),
 		})
 	}
 
@@ -1632,8 +1670,11 @@ func (s *LibraryService) reindexAllLocked(ctx context.Context) error {
 	}
 
 	s.logger.Info("Finished full library re-indexing")
-	if app := application.Get(); showDialog && app != nil && app.Event != nil {
-		app.Event.Emit("library:sync-finished", "Search Index")
+	if app := application.Get(); app != nil && app.Event != nil {
+		app.Event.Emit("library:sync-finished", map[string]interface{}{
+			"path":       "Search Index",
+			"background": isBackgroundSync(ctx),
+		})
 	}
 	return err
 }


### PR DESCRIPTION
## Problem

When upgrading from old DB (no delimiter tags) to new code, the automatic startup sync triggers a full rescan with schema re-parse and delimiter resplit. If user clicks "Sync Library" button while this is running, the button blocks on bulkSyncMu, then reruns the entire sync again after the first one finishes — duplicate work, redundant parsing/DB writes.

## Solution

**Backend (internal/app/library/service.go):**
- Add `syncRunning atomic.Bool` flag to gate concurrent top-level sync calls
- SyncFolder, SyncLibrary, ResplitLibrary, ReindexAll check the flag and skip (return nil) if already running instead of blocking then re-running
- Emit library:sync-started/sync-finished even for background syncs (with "background": true flag), but keep progress events gated on isBackgroundSync so the overlay never appears for automatic runs

**Frontend (frontend/src/components/settings/LibrarySettings.vue):**
- Add `backgroundSyncActive` ref to track whether the current sync is automatic or user-triggered
- `isSyncing` now covers both: button spinner shows for any active sync
- `showSyncDialog` computed = `(isSyncing && !backgroundSyncActive) || ...`: overlay only for foreground syncs, automatic syncs stay silent

## Testing

- Manual click "Sync Library" → overlay appears, button busy
- Automatic periodic sync → button shows busy, overlay stays hidden
- Click button during automatic sync → skipped, no re-queue or double-work