### PR TITLE
Add sort by date added and configurable columns for albums/tracks

### DIFF
--- a/frontend/src/components/AlbumListView.vue
+++ b/frontend/src/components/AlbumListView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { Disc, Play, MoreVertical } from '@lucide/vue'
 import type { AlbumDTO, Artist } from '../../bindings/airmedy/internal/domain/models'
 import { buildArtworkUrl } from '@airmedy/utils'
@@ -8,13 +8,27 @@ import { useRowBackground } from '@/composables/useRowBackground'
 import { useContextMenu } from '@/composables/useContextMenu'
 import SortableHeaderCell from './SortableHeaderCell.vue'
 import { useAlbumContextMenu } from '@/composables/useAlbumContextMenu'
+import { useAlbumListSettings } from '@/composables/useAlbumListSettings'
 import ContextMenu from './ContextMenu.vue'
 import VirtualList from 'vue-virtual-sortable'
 
-const GRID = '40px 1fr 1fr 80px 40px'
 const ROW_HEIGHT = 56
 
-type SortCol = 'title' | 'artist' | 'year'
+const { visibleColumns } = useAlbumListSettings()
+const showArtist = computed(() => visibleColumns.value.includes('artist'))
+const showYear = computed(() => visibleColumns.value.includes('year'))
+const showDateAdded = computed(() => visibleColumns.value.includes('dateAdded'))
+
+const GRID = computed(() => [
+  '40px',
+  '1fr',
+  showArtist.value ? '1fr' : null,
+  showYear.value ? '80px' : null,
+  showDateAdded.value ? '110px' : null,
+  '40px',
+].filter(Boolean).join(' '))
+
+type SortCol = 'title' | 'artist' | 'year' | 'dateAdded'
 type SortDir = 'asc' | 'desc'
 
 const props = defineProps<{
@@ -81,14 +95,20 @@ const { rowBg } = useRowBackground()
                 <div class="w-px h-full bg-foreground/[0.12]" />
               </div>
             </SortableHeaderCell>
-            <SortableHeaderCell :active="sortColumn === 'artist'" :dir="sortDir" @click="cycleSort('artist')">
+            <SortableHeaderCell v-if="showArtist" :active="sortColumn === 'artist'" :dir="sortDir" @click="cycleSort('artist')">
               <span class="truncate min-w-0 pointer-events-none">{{ $t('library.artist') }}</span>
               <div class="absolute top-1/2 -translate-y-1/2 -right-2 h-4/5 w-4 z-20 flex items-center justify-center pointer-events-none">
                 <div class="w-px h-full bg-foreground/[0.12]" />
               </div>
             </SortableHeaderCell>
-            <SortableHeaderCell :active="sortColumn === 'year'" :dir="sortDir" @click="cycleSort('year')">
+            <SortableHeaderCell v-if="showYear" :active="sortColumn === 'year'" :dir="sortDir" @click="cycleSort('year')">
               <span class="truncate min-w-0 pointer-events-none">{{ $t('library.year') }}</span>
+              <div class="absolute top-1/2 -translate-y-1/2 -right-2 h-4/5 w-4 z-20 flex items-center justify-center pointer-events-none">
+                <div class="w-px h-full bg-foreground/[0.12]" />
+              </div>
+            </SortableHeaderCell>
+            <SortableHeaderCell v-if="showDateAdded" :active="sortColumn === 'dateAdded'" :dir="sortDir" @click="cycleSort('dateAdded')">
+              <span class="truncate min-w-0 pointer-events-none">{{ $t('library.date_added') }}</span>
               <div class="absolute top-1/2 -translate-y-1/2 -right-2 h-4/5 w-4 z-20 flex items-center justify-center pointer-events-none">
                 <div class="w-px h-full bg-foreground/[0.12]" />
               </div>
@@ -145,7 +165,7 @@ const { rowBg } = useRowBackground()
                 </div>
 
                 <!-- Artist -->
-                <div class="px-2 text-foreground opacity-80 truncate flex items-center min-w-0">
+                <div v-if="showArtist" class="px-2 text-foreground opacity-80 truncate flex items-center min-w-0">
                   <div class="truncate">
                     <template v-if="album.artists && album.artists.length > 0">
                       <span v-for="(artist, i) in (album.artists.filter(a => !!a) as Artist[])" :key="artist.id || i">
@@ -161,8 +181,13 @@ const { rowBg } = useRowBackground()
                 </div>
 
                 <!-- Year -->
-                <div class="text-center text-foreground opacity-80 text-xs px-2">
+                <div v-if="showYear" class="text-center text-foreground opacity-80 text-xs px-2">
                   {{ album.year || '' }}
+                </div>
+
+                <!-- Date added -->
+                <div v-if="showDateAdded" class="text-foreground opacity-80 text-xs px-2 truncate">
+                  {{ album.created_at ? new Date(album.created_at).toLocaleDateString() : '' }}
                 </div>
 
                 <!-- Context menu -->

--- a/frontend/src/components/AlbumViewFilter.vue
+++ b/frontend/src/components/AlbumViewFilter.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { LayoutGrid, List, ArrowUp, ArrowDown, ListFilter } from '@lucide/vue'
-import { IconButton } from '@airmedy/ui'
+import { Checkbox, IconButton } from '@airmedy/ui'
 import FilterDropdown from './FilterDropdown.vue'
+import FilterSubmenu from './FilterSubmenu.vue'
+import { ALBUM_COLUMNS, useAlbumListSettings } from '@/composables/useAlbumListSettings'
+import { useHoverSubmenuGroup } from '@/composables/useHoverSubmenuGroup'
 
-type SortCol = 'title' | 'artist' | 'year' | null
+type SortCol = 'title' | 'artist' | 'year' | 'dateAdded' | null
 type SortDir = 'asc' | 'desc'
 
 const props = defineProps<{
@@ -26,6 +29,9 @@ function selectSortCol(col: NonNullable<SortCol>) {
     emit('update:sortDir', 'asc')
   }
 }
+
+const { visibleColumns, toggleColumn } = useAlbumListSettings()
+const submenuGroup = useHoverSubmenuGroup()
 </script>
 
 <template>
@@ -63,12 +69,9 @@ function selectSortCol(col: NonNullable<SortCol>) {
 
     <!-- Sort -->
     <div class="mt-2 pt-2 border-t border-foreground/10">
-      <p class="text-[10px] font-semibold text-foreground opacity-60 uppercase tracking-widest px-1 mb-2">
-        {{ $t('library.sort_by') }}
-      </p>
-      <div class="flex flex-col gap-0.5">
+      <FilterSubmenu :label="$t('library.sort_by')" :group="submenuGroup">
         <div
-          v-for="col in (['title', 'artist', 'year'] as const)"
+          v-for="col in (['title', 'artist', 'year', 'dateAdded'] as const)"
           :key="col"
           class="flex items-center gap-2.5 px-1.5 py-1.5 rounded-lg hover:bg-foreground/[0.06] cursor-pointer transition-colors"
           :class="{ 'bg-foreground/[0.08]': sortColumn === col }"
@@ -78,11 +81,30 @@ function selectSortCol(col: NonNullable<SortCol>) {
           <ArrowDown v-else-if="sortColumn === col && sortDir === 'desc'" class="w-4 h-4 text-foreground/70" />
           <span v-else class="w-4 h-4 inline-block" />
           <span class="text-sm text-foreground opacity-90">
-            {{ $t(`library.${col}`) }}
+            {{ col === 'dateAdded' ? $t('library.date_added') : $t(`library.${col}`) }}
           </span>
           <div v-if="sortColumn === col" class="ml-auto w-1.5 h-1.5 rounded-full bg-primary" />
         </div>
-      </div>
+      </FilterSubmenu>
+    </div>
+
+    <!-- Columns (list view only) -->
+    <div class="mt-2 pt-2 border-t border-foreground/10">
+      <FilterSubmenu :label="$t('library.columns')" :group="submenuGroup" :disabled="viewMode === 'grid'">
+        <div
+          v-for="col in ALBUM_COLUMNS"
+          :key="col.key"
+          class="flex items-center gap-2.5 px-1.5 py-1.5 rounded-lg hover:bg-foreground/[0.06] cursor-pointer transition-colors"
+          @click="toggleColumn(col.key)"
+        >
+          <Checkbox
+            :checked="visibleColumns.includes(col.key)"
+            variant="contained"
+            @update:checked="toggleColumn(col.key)"
+          />
+          <span class="text-sm text-foreground opacity-90">{{ $t(col.labelKey) }}</span>
+        </div>
+      </FilterSubmenu>
     </div>
   </FilterDropdown>
 </template>

--- a/frontend/src/components/FilterSubmenu.vue
+++ b/frontend/src/components/FilterSubmenu.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { ChevronRight } from '@lucide/vue'
+import type { useHoverSubmenuGroup } from '@/composables/useHoverSubmenuGroup'
+
+const props = withDefaults(defineProps<{
+  label: string
+  group: ReturnType<typeof useHoverSubmenuGroup>
+  disabled?: boolean
+  panelWidth?: number
+}>(), { disabled: false, panelWidth: 160 })
+
+const key = Symbol()
+const open = computed(() => props.group.activeKey.value === key)
+
+function onEnter() {
+  if (!props.disabled) props.group.enter(key)
+}
+
+function onLeave() {
+  props.group.leave(key)
+}
+</script>
+
+<template>
+  <div
+    class="relative"
+    @mouseenter="onEnter"
+    @mouseleave="onLeave"
+  >
+    <div
+      class="flex items-center gap-2.5 px-1.5 py-1.5 rounded-lg transition-colors"
+      :class="disabled ? 'opacity-40 cursor-not-allowed' : 'hover:bg-foreground/[0.06] cursor-pointer'"
+    >
+      <span class="text-sm text-foreground opacity-90">{{ label }}</span>
+      <ChevronRight class="w-3.5 h-3.5 text-foreground/50 ml-auto" />
+    </div>
+
+    <!-- Zero-width bridge: keeps the hover region contiguous across the gap -->
+    <div v-if="open" class="absolute left-full top-0 bottom-0 w-2" />
+
+    <div
+      v-if="open"
+      class="flex flex-col gap-0.5 absolute left-full top-0 -mt-[1px] ml-2 max-h-72 overflow-y-auto rounded-2xl bg-glass-elevated backdrop-blur-xl ring-1 ring-border-glass shadow-2xl p-1.5"
+      :style="{ minWidth: panelWidth + 'px' }"
+    >
+      <slot />
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/FindLyricsDialog.vue
+++ b/frontend/src/components/FindLyricsDialog.vue
@@ -78,7 +78,8 @@ async function save() {
 <template>
   <Modal
     :open="isVisible"
-    width-class="max-w-4xl w-full h-[82vh] !p-0 flex flex-col overflow-hidden"
+    bare
+    width-class="max-w-4xl w-full h-[82vh] flex flex-col overflow-hidden"
     @close="close"
   >
     <!-- Header -->

--- a/frontend/src/components/LyricsDrawer.vue
+++ b/frontend/src/components/LyricsDrawer.vue
@@ -44,7 +44,7 @@ watch(activeIndex, (newIndex) => {
 <template>
   <div class="h-full w-full bg-background flex flex-col">
     <!-- Header -->
-    <div class="flex items-center justify-between px-4 py-3 border-b border-foreground/[0.06] gap-2 h-[63px]">
+    <div class="flex items-center justify-between px-4 py-3 border-b border-foreground/[0.06] select-none">
       <div class="flex items-center gap-2 font-semibold flex-shrink-0">
         <Mic2 class="w-4 h-4 text-primary" />
         <div class="max-w-[100px] truncate">{{ t('player.lyrics') }}</div>

--- a/frontend/src/components/QueueDrawer.vue
+++ b/frontend/src/components/QueueDrawer.vue
@@ -47,7 +47,7 @@ onUnmounted(() => {
 <template>
   <div class="h-full w-full bg-background flex flex-col">
     <!-- Header -->
-    <div class="flex items-center justify-between px-4 py-3 border-b border-foreground/[0.06] h-[63px]">
+    <div class="flex items-center justify-between px-4 py-3 border-b border-foreground/[0.06] select-none">
       <div class="flex items-center gap-2 font-semibold">
         <ListMusic class="w-4 h-4 text-primary" />
         <span>{{ t('player.queue') }}</span>

--- a/frontend/src/components/TrackTable.vue
+++ b/frontend/src/components/TrackTable.vue
@@ -311,7 +311,7 @@ function handlePlayTrack(track: TrackDTO, index: number) {
   emit('play-track', track, index, displayTracks.value)
 }
 
-defineExpose({ scrollToCurrentTrack, optionalColumns })
+defineExpose({ scrollToCurrentTrack, optionalColumns, sortColumn, sortDir, cycleSort })
 </script>
 
 <template>

--- a/frontend/src/components/TrackTableFilter.vue
+++ b/frontend/src/components/TrackTableFilter.vue
@@ -1,15 +1,25 @@
 <script setup lang="ts">
-import { ListFilter } from '@lucide/vue'
+import { ListFilter, ArrowUp, ArrowDown } from '@lucide/vue'
 import { Checkbox, IconButton } from '@airmedy/ui'
-import { type ColumnDef, useTrackTableSettings } from '@/composables/useTrackTableSettings'
+import { COLUMNS, type ColumnDef, type ColumnKey, useTrackTableSettings } from '@/composables/useTrackTableSettings'
 import FilterDropdown from './FilterDropdown.vue'
+import FilterSubmenu from './FilterSubmenu.vue'
+import { useHoverSubmenuGroup } from '@/composables/useHoverSubmenuGroup'
 
 const props = defineProps<{
   simpleMode?: boolean
   optionalColumns: ColumnDef[]
+  sortColumn?: ColumnKey | null
+  sortDir?: 'asc' | 'desc' | null
+}>()
+
+const emit = defineEmits<{
+  'select-sort': [ColumnKey]
 }>()
 
 const settings = useTrackTableSettings()
+const sortableColumns = COLUMNS.filter((c) => c.sortable)
+const submenuGroup = useHoverSubmenuGroup()
 </script>
 
 <template>
@@ -21,23 +31,38 @@ const settings = useTrackTableSettings()
         </IconButton>
       </template>
 
-      <p class="text-[10px] font-semibold text-foreground opacity-60 uppercase tracking-widest px-1 mb-2">
-        {{ $t('library.columns') }}
-      </p>
-      <div class="flex flex-col">
+      <FilterSubmenu :label="$t('library.sort_by')" :group="submenuGroup">
         <div
-          v-for="col in optionalColumns"
+          v-for="col in sortableColumns"
           :key="col.key"
           class="flex items-center gap-2.5 px-1.5 py-1.5 rounded-lg hover:bg-foreground/[0.06] cursor-pointer transition-colors"
-          @click="settings.toggleColumn(col.key)"
+          :class="{ 'bg-foreground/[0.08]': sortColumn === col.key }"
+          @click="emit('select-sort', col.key)"
         >
-          <Checkbox
-            :checked="settings.visibleColumns.value.includes(col.key)"
-            variant="contained"
-            @update:checked="settings.toggleColumn(col.key)"
-          />
+          <ArrowUp v-if="sortColumn === col.key && sortDir === 'asc'" class="w-4 h-4 text-foreground/70" />
+          <ArrowDown v-else-if="sortColumn === col.key && sortDir === 'desc'" class="w-4 h-4 text-foreground/70" />
+          <span v-else class="w-4 h-4 inline-block" />
           <span class="text-sm text-foreground opacity-90">{{ $t(col.labelKey) }}</span>
+          <div v-if="sortColumn === col.key" class="ml-auto w-1.5 h-1.5 rounded-full bg-primary" />
         </div>
+      </FilterSubmenu>
+
+      <div class="mt-1">
+        <FilterSubmenu :label="$t('library.columns')" :group="submenuGroup" :panel-width="180">
+          <div
+            v-for="col in optionalColumns"
+            :key="col.key"
+            class="flex items-center gap-2.5 px-1.5 py-1.5 rounded-lg hover:bg-foreground/[0.06] cursor-pointer transition-colors"
+            @click="settings.toggleColumn(col.key)"
+          >
+            <Checkbox
+              :checked="settings.visibleColumns.value.includes(col.key)"
+              variant="contained"
+              @update:checked="settings.toggleColumn(col.key)"
+            />
+            <span class="text-sm text-foreground opacity-90">{{ $t(col.labelKey) }}</span>
+          </div>
+        </FilterSubmenu>
       </div>
 
       <div class="mt-2 pt-2 border-t border-foreground/10">

--- a/frontend/src/components/TrackTableRow.vue
+++ b/frontend/src/components/TrackTableRow.vue
@@ -221,6 +221,14 @@ const isCurrentTrack = (trackId: string) => playerStore.currentTrack?.id === tra
         </div>
       </div>
 
+      <!-- Date added cell -->
+      <div
+        v-else-if="col.key === 'date_added'"
+        class="text-foreground opacity-80 truncate text-xs px-2"
+      >
+        {{ track.created_at ? new Date(track.created_at).toLocaleDateString() : '' }}
+      </div>
+
       <!-- Context menu cell -->
       <div
         v-else-if="col.key === 'context_menu'"

--- a/frontend/src/composables/useAlbumListSettings.ts
+++ b/frontend/src/composables/useAlbumListSettings.ts
@@ -1,0 +1,46 @@
+import { ref, watch } from 'vue'
+
+export type AlbumColumnKey = 'artist' | 'year' | 'dateAdded'
+
+export interface AlbumColumnDef {
+  key: AlbumColumnKey
+  labelKey: string
+}
+
+export const ALBUM_COLUMNS: AlbumColumnDef[] = [
+  { key: 'artist', labelKey: 'library.artist' },
+  { key: 'year', labelKey: 'library.year' },
+  { key: 'dateAdded', labelKey: 'library.date_added' },
+]
+
+const DEFAULT_VISIBLE: AlbumColumnKey[] = ['artist', 'year']
+const STORAGE_VISIBLE = 'airmedy:albums-visible-columns'
+
+function loadJson<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key)
+    if (raw) return JSON.parse(raw) as T
+  } catch {}
+  return fallback
+}
+
+const visibleColumns = ref<AlbumColumnKey[]>(loadJson(STORAGE_VISIBLE, DEFAULT_VISIBLE))
+
+watch(
+  visibleColumns,
+  (v) => localStorage.setItem(STORAGE_VISIBLE, JSON.stringify(v)),
+  { deep: true },
+)
+
+export function useAlbumListSettings() {
+  function toggleColumn(key: AlbumColumnKey) {
+    const idx = visibleColumns.value.indexOf(key)
+    if (idx === -1) {
+      visibleColumns.value = [...visibleColumns.value, key]
+    } else {
+      visibleColumns.value = visibleColumns.value.filter((k) => k !== key)
+    }
+  }
+
+  return { visibleColumns, toggleColumn }
+}

--- a/frontend/src/composables/useHoverSubmenuGroup.ts
+++ b/frontend/src/composables/useHoverSubmenuGroup.ts
@@ -1,0 +1,28 @@
+import { ref } from 'vue'
+
+/**
+ * Coordinates multiple FilterSubmenu siblings so only one is open at a time.
+ * Switching between sibling rows is instant (no delay); the close delay only
+ * applies when the pointer actually leaves the whole group (e.g. the diagonal
+ * path from a row to its own flyout, or leaving the dropdown entirely).
+ */
+export function useHoverSubmenuGroup(closeDelayMs = 120) {
+  const activeKey = ref<symbol | null>(null)
+  let closeTimer: ReturnType<typeof setTimeout> | null = null
+
+  function enter(key: symbol) {
+    if (closeTimer) {
+      clearTimeout(closeTimer)
+      closeTimer = null
+    }
+    activeKey.value = key
+  }
+
+  function leave(key: symbol) {
+    closeTimer = setTimeout(() => {
+      if (activeKey.value === key) activeKey.value = null
+    }, closeDelayMs)
+  }
+
+  return { activeKey, enter, leave }
+}

--- a/frontend/src/composables/useTrackTableSettings.ts
+++ b/frontend/src/composables/useTrackTableSettings.ts
@@ -16,6 +16,7 @@ export type ColumnKey =
   | 'disc_number'
   | 'track_number'
   | 'album_artist'
+  | 'date_added'
   | 'context_menu'
 
 export interface ColumnDef {
@@ -160,6 +161,16 @@ export const COLUMNS: ColumnDef[] = [
     alwaysVisible: false,
     sortable: true,
     sortFn: (a, b) => strCmp(a.raw_album_artist_names || '', b.raw_album_artist_names || ''),
+    draggable: true,
+  },
+  {
+    key: 'date_added',
+    labelKey: 'library.date_added',
+    gridWidth: 'minmax(100px,120px)',
+    minWidthPx: 100,
+    alwaysVisible: false,
+    sortable: true,
+    sortFn: (a, b) => numCmp(new Date(a.created_at).getTime(), new Date(b.created_at).getTime()),
     draggable: true,
   },
   {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -375,6 +375,7 @@
     "layout": "Layout",
     "grid_view": "Raster",
     "list_view": "Liste",
+    "date_added": "Hinzugefügt am",
     "sort_by": "Sortieren nach",
     "no_sort": "Keine",
     "context_menu": "",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -377,6 +377,7 @@
     "layout": "Layout",
     "grid_view": "Grid",
     "list_view": "List",
+    "date_added": "Date Added",
     "sort_by": "Sort By",
     "no_sort": "None",
     "context_menu": ""

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -375,6 +375,7 @@
     "layout": "Disposición",
     "grid_view": "Cuadrícula",
     "list_view": "Lista",
+    "date_added": "Fecha de adición",
     "sort_by": "Ordenar por",
     "no_sort": "Ninguno",
     "context_menu": "",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -375,6 +375,7 @@
     "layout": "Disposition",
     "grid_view": "Grille",
     "list_view": "Liste",
+    "date_added": "Date d'ajout",
     "sort_by": "Trier par",
     "no_sort": "Aucun",
     "context_menu": "",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -375,6 +375,7 @@
     "layout": "Layout",
     "grid_view": "Griglia",
     "list_view": "Lista",
+    "date_added": "Data di aggiunta",
     "sort_by": "Ordina per",
     "no_sort": "Nessuno",
     "context_menu": "",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -375,6 +375,7 @@
     "layout": "レイアウト",
     "grid_view": "グリッド",
     "list_view": "リスト",
+    "date_added": "追加日",
     "sort_by": "並び替え",
     "no_sort": "なし",
     "context_menu": "",

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -375,6 +375,7 @@
     "layout": "레이아웃",
     "grid_view": "그리드",
     "list_view": "목록",
+    "date_added": "추가된 날짜",
     "sort_by": "정렬 기준",
     "no_sort": "없음",
     "context_menu": "",

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -375,6 +375,7 @@
     "layout": "Layout",
     "grid_view": "Grade",
     "list_view": "Lista",
+    "date_added": "Data de adição",
     "sort_by": "Ordenar por",
     "no_sort": "Nenhum",
     "context_menu": "",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -375,6 +375,7 @@
     "layout": "Вид",
     "grid_view": "Сетка",
     "list_view": "Список",
+    "date_added": "Дата добавления",
     "sort_by": "Сортировать по",
     "no_sort": "Нет",
     "context_menu": "",

--- a/frontend/src/locales/th.json
+++ b/frontend/src/locales/th.json
@@ -375,6 +375,7 @@
     "layout": "เลย์เอาต์",
     "grid_view": "ตาราง",
     "list_view": "รายการ",
+    "date_added": "วันที่เพิ่ม",
     "sort_by": "เรียงตาม",
     "no_sort": "ไม่มี",
     "context_menu": "",

--- a/frontend/src/locales/vi.json
+++ b/frontend/src/locales/vi.json
@@ -375,6 +375,7 @@
     "layout": "Bố cục",
     "grid_view": "Lưới",
     "list_view": "Danh sách",
+    "date_added": "Ngày thêm vào",
     "sort_by": "Sắp xếp theo",
     "no_sort": "Không",
     "context_menu": "",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -375,6 +375,7 @@
     "layout": "布局",
     "grid_view": "网格",
     "list_view": "列表",
+    "date_added": "添加日期",
     "sort_by": "排序方式",
     "no_sort": "无",
     "context_menu": "",

--- a/frontend/src/views/AlbumsView.vue
+++ b/frontend/src/views/AlbumsView.vue
@@ -12,7 +12,7 @@ import { foldUnicode } from '@airmedy/utils'
 import { useRouter } from 'vue-router'
 import { usePlayerStore } from '@/stores/player'
 
-type SortCol = 'title' | 'artist' | 'year' | null
+type SortCol = 'title' | 'artist' | 'year' | 'dateAdded' | null
 type SortDir = 'asc' | 'desc'
 
 const albums = shallowRef<AlbumDTO[]>([])
@@ -71,6 +71,10 @@ const processedAlbums = computed(() => {
     result = [...result].sort((a, b) => {
       if (col === 'year') {
         const diff = (a.year ?? 0) - (b.year ?? 0)
+        return dir === 'asc' ? diff : -diff
+      }
+      if (col === 'dateAdded') {
+        const diff = new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
         return dir === 'asc' ? diff : -diff
       }
       const aVal = col === 'title' ? (a.title || '') : (a.artists?.[0]?.name || '')

--- a/frontend/src/views/TracksView.vue
+++ b/frontend/src/views/TracksView.vue
@@ -77,7 +77,12 @@ onMounted(loadTracks)
     >
       <template #actions>
         <div class="relative z-[99]">
-          <TrackTableFilter :optional-columns="trackTableRef?.optionalColumns ?? []" />
+          <TrackTableFilter
+            :optional-columns="trackTableRef?.optionalColumns ?? []"
+            :sort-column="trackTableRef?.sortColumn ?? null"
+            :sort-dir="trackTableRef?.sortDir ?? null"
+            @select-sort="key => trackTableRef?.cycleSort(key)"
+          />
         </div>
       </template>
     </ViewHeader>

--- a/packages/ui/src/Modal.vue
+++ b/packages/ui/src/Modal.vue
@@ -5,6 +5,7 @@ defineProps<{
   open: boolean
   title?: string
   widthClass?: string
+  bare?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -38,7 +39,8 @@ function onClickClose() {
           class="modal-content relative z-10 rounded-3xl bg-glass-modal backdrop-blur-3xl ring-1 ring-border-glass shadow-2xl transform-gpu isolate max-h-[85vh] overflow-hidden"
           :class="widthClass || 'w-72'"
           @keydown.esc="emit('close')">
-          <div class="flex flex-col max-h-[85vh]">
+          <slot v-if="bare" />
+          <div v-else class="flex flex-col max-h-[85vh]">
             <div class="min-h-0 flex-1 overflow-y-auto p-5">
               <h3 v-if="title" class="text-base font-semibold text-foreground mb-4">{{ title }}</h3>
               <slot />


### PR DESCRIPTION
## Summary
- Add "Date Added" sort option to Albums and Tracks views
- Add configurable column visibility for Albums list view (#, Title always shown; Artist, Year, Date Added optional)
- Convert Tracks filter's column list into a hover submenu, add matching Sort By submenu
- Extract shared FilterSubmenu component + useHoverSubmenuGroup composable so only one submenu is open at a time, with instant switching between sibling menu rows

## Test plan
- [x] Albums view: toggle grid/list, verify Sort By > Date Added reorders albums
- [x] Albums list view: toggle Columns (Artist/Year/Date Added), verify grid layout adjusts; verify Columns menu is disabled in grid view
- [x] Tracks view: verify Sort By submenu sorts by each column, Columns submenu toggles visibility
- [x] Verify hovering between Sort By and Columns rows switches instantly, no flicker