### PR TITLE
fix(audio): serialize ffmpeg probe/open across analyzer and player

### DIFF
--- a/internal/infra/audio/ffmpeg_analyzer.h
+++ b/internal/infra/audio/ffmpeg_analyzer.h
@@ -32,6 +32,8 @@
 #include <aubio/aubio.h>
 #include <pthread.h>
 
+#include "ffmpeg_shared_mu.h"
+
 /* aubio tempo runs on a fixed mono rate so BPM math is rate-independent. */
 #define FFA_TEMPO_RATE 44100
 #define FFA_TEMPO_BUF  1024
@@ -57,8 +59,12 @@ static pthread_mutex_t ffa_aubio_mu = PTHREAD_MUTEX_INITIALIZER;
  * has corrupted the heap (SIGABRT via malloc). The actual decode/filter loop
  * below is safely reentrant per AVFormatContext/AVCodecContext, so only the
  * open+probe phase is serialized here.
+ *
+ * This must also be serialized against ffmpeg_decoder.h's playback opens
+ * (analysis and playback run concurrently), so the lock lives in
+ * ffmpeg_shared_mu.h/.c with external linkage rather than as a `static`
+ * mutex local to this translation unit.
  */
-static pthread_mutex_t ffa_probe_mu = PTHREAD_MUTEX_INITIALIZER;
 
 /* Numeric features, all as doubles for a simple cgo bridge. */
 typedef struct {
@@ -174,7 +180,7 @@ static int ffmpeg_analyze(const char *path, FFAnalysisResult *out, volatile int 
     AVFrame         *frame = NULL, *filt = NULL;
     int rc = FFA_ERR_PROCESS;
     int stream_idx = -1;
-    int probe_locked = 0; /* guards ffa_probe_mu; see comment at its declaration */
+    int probe_locked = 0; /* guards ffmpeg_probe_mu; see comment at its declaration */
 
     /* tempo (BPM) detection via aubio, fed mono float PCM resampled by swr */
     SwrContext   *tempo_swr = NULL;
@@ -206,7 +212,7 @@ static int ffmpeg_analyze(const char *path, FFAnalysisResult *out, volatile int 
     double peak_db = 0;    /* astats sample peak (dBFS), running max, fallback   */
     int    have_peak_db = 0;
 
-    pthread_mutex_lock(&ffa_probe_mu);
+    pthread_mutex_lock(&ffmpeg_probe_mu);
     probe_locked = 1;
 
     AVDictionary *format_opts = NULL;
@@ -237,7 +243,7 @@ static int ffmpeg_analyze(const char *path, FFAnalysisResult *out, volatile int 
     if (avcodec_open2(codec_ctx, codec, NULL) < 0) { rc = FFA_ERR_DECODER; goto done; }
     avcodec_flush_buffers(codec_ctx);
 
-    pthread_mutex_unlock(&ffa_probe_mu);
+    pthread_mutex_unlock(&ffmpeg_probe_mu);
     probe_locked = 0;
 
     if (codec_ctx->sample_rate == 0) { rc = FFA_ERR_DECODER; goto done; }
@@ -484,7 +490,7 @@ static int ffmpeg_analyze(const char *path, FFAnalysisResult *out, volatile int 
     }
 
 done:
-    if (probe_locked) pthread_mutex_unlock(&ffa_probe_mu);
+    if (probe_locked) pthread_mutex_unlock(&ffmpeg_probe_mu);
     pthread_mutex_lock(&ffa_aubio_mu);
     if (onset) del_aubio_onset(onset);
     if (onset_out) del_fvec(onset_out);

--- a/internal/infra/audio/ffmpeg_decoder.h
+++ b/internal/infra/audio/ffmpeg_decoder.h
@@ -18,6 +18,8 @@
 #include <libavutil/channel_layout.h>
 #include <libswresample/swresample.h>
 
+#include "ffmpeg_shared_mu.h"
+
 typedef unsigned int           ma_uint32;
 typedef unsigned long long     ma_uint64;
 
@@ -63,18 +65,28 @@ static FFmpegHandle* ffmpeg_open(const char* path, ma_uint32 target_rate) {
     if (!h) return NULL;
     h->target_rate = target_rate;
 
+    /*
+     * avformat_open_input .. avcodec_open2 shares ffmpeg_probe_mu with
+     * ffmpeg_analyzer.h: probing an embedded MJPEG cover-art stream can
+     * trigger a decoder's one-time lazy static-table init, which corrupts
+     * the heap if playback opens a file at the same moment an analysis
+     * worker is probing another one. See ffmpeg_shared_mu.h.
+     */
+    pthread_mutex_lock(&ffmpeg_probe_mu);
+
     AVDictionary* format_opts = NULL;
     av_dict_set(&format_opts, "probesize", "32000000", 0);      /* 32MB */
     av_dict_set(&format_opts, "analyzeduration", "10000000", 0); /* 10s */
 
     if (avformat_open_input(&h->fmt_ctx, path, NULL, &format_opts) < 0) {
         av_dict_free(&format_opts);
+        pthread_mutex_unlock(&ffmpeg_probe_mu);
         free(h);
         return NULL;
     }
     av_dict_free(&format_opts);
 
-    /* 
+    /*
      * avformat_find_stream_info can return errors for files with "broken" metadata streams
      * (like timescale errors in M4A), but the audio stream might be perfectly fine.
      * We proceed even on error and let av_find_best_stream be the final arbiter.
@@ -91,22 +103,27 @@ static FFmpegHandle* ffmpeg_open(const char* path, ma_uint32 target_rate) {
     const AVCodec* codec = NULL;
     h->stream_idx = av_find_best_stream(h->fmt_ctx, AVMEDIA_TYPE_AUDIO, -1, -1, &codec, 0);
     if (h->stream_idx < 0 || !codec) {
+        pthread_mutex_unlock(&ffmpeg_probe_mu);
         ffmpeg_close(h);
         return NULL;
     }
 
     h->codec_ctx = avcodec_alloc_context3(codec);
     if (!h->codec_ctx) {
+        pthread_mutex_unlock(&ffmpeg_probe_mu);
         ffmpeg_close(h);
         return NULL;
     }
 
     avcodec_parameters_to_context(h->codec_ctx, h->fmt_ctx->streams[h->stream_idx]->codecpar);
     if (avcodec_open2(h->codec_ctx, codec, NULL) < 0) {
+        pthread_mutex_unlock(&ffmpeg_probe_mu);
         ffmpeg_close(h);
         return NULL;
     }
     avcodec_flush_buffers(h->codec_ctx);
+
+    pthread_mutex_unlock(&ffmpeg_probe_mu);
 
     ma_uint32 in_ch;
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(59, 37, 100)

--- a/internal/infra/audio/ffmpeg_shared_mu.c
+++ b/internal/infra/audio/ffmpeg_shared_mu.c
@@ -1,0 +1,3 @@
+#include "ffmpeg_shared_mu.h"
+
+pthread_mutex_t ffmpeg_probe_mu = PTHREAD_MUTEX_INITIALIZER;

--- a/internal/infra/audio/ffmpeg_shared_mu.h
+++ b/internal/infra/audio/ffmpeg_shared_mu.h
@@ -1,0 +1,22 @@
+/*
+ * ffmpeg_shared_mu.h — mutex shared across every cgo translation unit that
+ * opens/probes files through the vendored ffmpeg build.
+ *
+ * ffmpeg_analyzer.h and ffmpeg_decoder.h are each pulled into a *different*
+ * cgo preamble (analyzer.go vs player_miniaudio.go), so a `static` mutex
+ * declared inside either header would give each translation unit its own
+ * independent lock — useless for cross-file serialization. This header
+ * declares one mutex with external linkage, defined once in
+ * ffmpeg_shared_mu.c, so the analysis worker pool and the playback decoder
+ * actually contend on the same lock during avformat_open_input .. avcodec_open2
+ * (the phase that can trigger a decoder's lazy static-table init and corrupt
+ * the heap under concurrent first-touch).
+ */
+#ifndef FFMPEG_SHARED_MU_H
+#define FFMPEG_SHARED_MU_H
+
+#include <pthread.h>
+
+extern pthread_mutex_t ffmpeg_probe_mu;
+
+#endif /* FFMPEG_SHARED_MU_H */


### PR DESCRIPTION
## Summary
- Analysis worker pool and playback decoder each open/probe files via the same vendored ffmpeg build, concurrently. Probing an embedded MJPEG cover-art stream can trigger a decoder's one-time lazy static-table init, corrupting the heap under concurrent first-touch (`malloc: *** error ... pointer being freed was not allocated` -> SIGABRT).
- The analyzer already serialized its own probe phase with a mutex, but it was `static` — scoped to its own cgo translation unit, so it never contended with the player's `ffmpeg_open` (no lock at all).
- Moved the mutex into `ffmpeg_shared_mu.h`/`.c` with external linkage so both `ffmpeg_analyzer.h` and `ffmpeg_decoder.h` serialize on the same lock. Only `avformat_open_input..avcodec_open2` is covered — the decode loop stays fully concurrent, no parallelism lost.

## Test plan
- [x] `go build ./...` passes clean
- [ ] Repro original crash scenario (run library analysis while playing a track) and confirm no SIGABRT