### PR TITLE
perf: virtualize grouped album list + fix stale/smart-playlist bugs

### DIFF
--- a/frontend/src/assets/index.css
+++ b/frontend/src/assets/index.css
@@ -90,6 +90,11 @@
   optgroup {
     font-family: inherit;
   }
+
+  /* WKWebView (Wails on macOS) defaults placeholder text to italic; normalize it */
+  ::placeholder {
+    font-style: normal;
+  }
 }
 
 /* Fix WebKit rendering issues with semi-transparent backgrounds, blurs, and opacity */

--- a/frontend/src/components/GroupedAlbumList.vue
+++ b/frontend/src/components/GroupedAlbumList.vue
@@ -99,15 +99,17 @@ function tableHeight(trackCount: number): string {
           <!-- Album Header -->
           <div class="flex items-end gap-6 pr-2" @contextmenu.prevent="e => group.album && onContextMenu(e, group.album, group.tracks)">
             <div
-              class="w-32 h-32 md:w-40 md:h-40 rounded-xl shadow-xl overflow-hidden ring-1 ring-foreground/8 bg-foreground/5 flex-shrink-0 group relative cursor-pointer"
+              class="w-32 h-32 md:w-40 md:h-40 rounded-xl shadow-xl ring-1 ring-foreground/8 bg-foreground/5 flex-shrink-0 group relative cursor-pointer"
               @click="group.album && router.push(`/albums/${group.album.id}`)">
-              <LazyImg v-if="group.album?.artwork_key" :src="buildArtworkUrl(group.album.artwork_key, 'md')"
-                class="w-full h-full object-cover" />
-              <div v-else class="w-full h-full flex items-center justify-center text-foreground opacity-30">
-                <Disc class="w-16 h-16" />
+              <div class="w-full h-full rounded-xl overflow-hidden">
+                <LazyImg v-if="group.album?.artwork_key" :src="buildArtworkUrl(group.album.artwork_key, 'md')"
+                  class="w-full h-full object-cover" />
+                <div v-else class="w-full h-full flex items-center justify-center text-foreground opacity-30">
+                  <Disc class="w-16 h-16" />
+                </div>
               </div>
               <div v-if="group.album"
-                class="absolute inset-0 bg-background/30 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                class="absolute inset-0 bg-background/30 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center rounded-xl">
                 <button
                   class="w-12 h-12 bg-foreground text-background rounded-full shadow-xl flex items-center justify-center transform scale-90 group-hover:scale-100 transition-all duration-300"
                   @click.stop="playerStore.playTracks(group.tracks, 0)">
@@ -130,16 +132,18 @@ function tableHeight(trackCount: number): string {
           </div>
 
           <!-- Virtualized Track Table -->
-          <div class="rounded-xl overflow-hidden ring-1 ring-foreground/[0.06]"
+          <div class="rounded-xl ring-1 ring-foreground/[0.06]"
             :style="{ height: tableHeight(group.tracks.length) }">
-            <TrackTable
-              :tracks="group.tracks"
-              :simple-mode="true"
-              :virtual-scroll="false"
-              @play-track="(_, index, queue) => playerStore.playTracks(queue, index)"
-              @navigate-album="id => router.push(`/albums/${id}`)"
-              @navigate-artist="id => router.push(`/artists/${id}`)"
-            />
+            <div class="w-full h-full rounded-xl overflow-hidden">
+              <TrackTable
+                :tracks="group.tracks"
+                :simple-mode="true"
+                :virtual-scroll="false"
+                @play-track="(_, index, queue) => playerStore.playTracks(queue, index)"
+                @navigate-album="id => router.push(`/albums/${id}`)"
+                @navigate-artist="id => router.push(`/artists/${id}`)"
+              />
+            </div>
           </div>
         </div>
       </DynamicScrollerItem>
@@ -157,3 +161,11 @@ function tableHeight(trackCount: number): string {
     @close="contextMenu.close()"
   />
 </template>
+
+<style scoped>
+/* vue-virtual-scroller hardcodes overflow:hidden on each item wrapper,
+   which clips album artwork shadow and track table border/ring. */
+:deep(.vue-recycle-scroller__item-wrapper) {
+  overflow: visible;
+}
+</style>

--- a/frontend/src/components/GroupedAlbumList.vue
+++ b/frontend/src/components/GroupedAlbumList.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller'
 import { Play, Disc } from '@lucide/vue'
 import type { TrackDTO, AlbumDTO } from '../../bindings/airmedy/internal/domain/models'
 import { usePlayerStore } from '../stores/player'
@@ -47,7 +48,7 @@ const groupedAlbums = computed(() => {
     groups[albumId].tracks.push(track)
   }
 
-  const result = Object.values(groups).filter(g => g.tracks.length > 0)
+  const result = Object.values(groups).filter(g => g.tracks.length > 0) as { album: AlbumDTO | null, tracks: TrackDTO[], _key: string }[]
 
   result.sort((a, b) => {
     if (a.album?.id === unknownAlbumId) return 1
@@ -65,6 +66,7 @@ const groupedAlbums = computed(() => {
       if (d1 !== d2) return d1 - d2
       return (t1.track_number || 0) - (t2.track_number || 0)
     })
+    group._key = group.album?.id || unknownAlbumId
   }
 
   return result
@@ -77,55 +79,75 @@ function tableHeight(trackCount: number): string {
 </script>
 
 <template>
-  <div class="space-y-12 pb-12">
-    <div v-for="group in groupedAlbums" :key="group.album?.id || 'unknown'" class="space-y-4">
-      <!-- Album Header -->
-      <div class="flex items-end gap-6 pr-2" @contextmenu.prevent="e => group.album && onContextMenu(e, group.album, group.tracks)">
-        <div
-          class="w-32 h-32 md:w-40 md:h-40 rounded-xl shadow-xl overflow-hidden ring-1 ring-foreground/8 bg-foreground/5 flex-shrink-0 group relative cursor-pointer"
-          @click="group.album && router.push(`/albums/${group.album.id}`)">
-          <LazyImg v-if="group.album?.artwork_key" :src="buildArtworkUrl(group.album.artwork_key, 'md')"
-            class="w-full h-full object-cover" />
-          <div v-else class="w-full h-full flex items-center justify-center text-foreground opacity-30">
-            <Disc class="w-16 h-16" />
+  <DynamicScroller
+    :items="groupedAlbums"
+    key-field="_key"
+    :min-item-size="200"
+    class="h-full px-8"
+  >
+    <template #before>
+      <div class="h-8" />
+    </template>
+    <template #default="{ item: group, index, active }">
+      <DynamicScrollerItem
+        :item="group"
+        :active="active"
+        :data-index="index"
+        class="pb-12"
+      >
+        <div class="space-y-4">
+          <!-- Album Header -->
+          <div class="flex items-end gap-6 pr-2" @contextmenu.prevent="e => group.album && onContextMenu(e, group.album, group.tracks)">
+            <div
+              class="w-32 h-32 md:w-40 md:h-40 rounded-xl shadow-xl overflow-hidden ring-1 ring-foreground/8 bg-foreground/5 flex-shrink-0 group relative cursor-pointer"
+              @click="group.album && router.push(`/albums/${group.album.id}`)">
+              <LazyImg v-if="group.album?.artwork_key" :src="buildArtworkUrl(group.album.artwork_key, 'md')"
+                class="w-full h-full object-cover" />
+              <div v-else class="w-full h-full flex items-center justify-center text-foreground opacity-30">
+                <Disc class="w-16 h-16" />
+              </div>
+              <div v-if="group.album"
+                class="absolute inset-0 bg-background/30 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                <button
+                  class="w-12 h-12 bg-foreground text-background rounded-full shadow-xl flex items-center justify-center transform scale-90 group-hover:scale-100 transition-all duration-300"
+                  @click.stop="playerStore.playTracks(group.tracks, 0)">
+                  <Play class="w-6 h-6 fill-current ml-1" />
+                </button>
+              </div>
+            </div>
+
+            <div class="flex-1 pb-2">
+              <h2 class="text-2xl md:text-3xl font-bold tracking-tight mb-1 cursor-pointer hover:text-primary transition-colors inline-block"
+                @click="group.album && router.push(`/albums/${group.album.id}`)">
+                {{ group.album?.title || 'Unknown Album' }}
+              </h2>
+              <div class="flex items-center gap-3 text-sm text-foreground opacity-60">
+                <span v-if="group.album?.year" class="font-medium">{{ group.album.year }}</span>
+                <span v-if="group.album?.year">•</span>
+                <span>{{ group.tracks.length }} tracks</span>
+              </div>
+            </div>
           </div>
-          <div v-if="group.album"
-            class="absolute inset-0 bg-background/30 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
-            <button
-              class="w-12 h-12 bg-foreground text-background rounded-full shadow-xl flex items-center justify-center transform scale-90 group-hover:scale-100 transition-all duration-300"
-              @click.stop="playerStore.playTracks(group.tracks, 0)">
-              <Play class="w-6 h-6 fill-current ml-1" />
-            </button>
+
+          <!-- Virtualized Track Table -->
+          <div class="rounded-xl overflow-hidden ring-1 ring-foreground/[0.06]"
+            :style="{ height: tableHeight(group.tracks.length) }">
+            <TrackTable
+              :tracks="group.tracks"
+              :simple-mode="true"
+              :virtual-scroll="false"
+              @play-track="(_, index, queue) => playerStore.playTracks(queue, index)"
+              @navigate-album="id => router.push(`/albums/${id}`)"
+              @navigate-artist="id => router.push(`/artists/${id}`)"
+            />
           </div>
         </div>
-
-        <div class="flex-1 pb-2">
-          <h2 class="text-2xl md:text-3xl font-bold tracking-tight mb-1 cursor-pointer hover:text-primary transition-colors inline-block"
-            @click="group.album && router.push(`/albums/${group.album.id}`)">
-            {{ group.album?.title || 'Unknown Album' }}
-          </h2>
-          <div class="flex items-center gap-3 text-sm text-foreground opacity-60">
-            <span v-if="group.album?.year" class="font-medium">{{ group.album.year }}</span>
-            <span v-if="group.album?.year">•</span>
-            <span>{{ group.tracks.length }} tracks</span>
-          </div>
-        </div>
-      </div>
-
-      <!-- Virtualized Track Table -->
-      <div class="rounded-xl overflow-hidden ring-1 ring-foreground/[0.06]"
-        :style="{ height: tableHeight(group.tracks.length) }">
-        <TrackTable
-          :tracks="group.tracks"
-          :simple-mode="true"
-          :virtual-scroll="false"
-          @play-track="(_, index, queue) => playerStore.playTracks(queue, index)"
-          @navigate-album="id => router.push(`/albums/${id}`)"
-          @navigate-artist="id => router.push(`/artists/${id}`)"
-        />
-      </div>
-    </div>
-  </div>
+      </DynamicScrollerItem>
+    </template>
+    <template #after>
+      <div class="h-8" />
+    </template>
+  </DynamicScroller>
 
   <ContextMenu
     :visible="contextMenu.visible.value"

--- a/frontend/src/composables/useAlbumContextMenu.ts
+++ b/frontend/src/composables/useAlbumContextMenu.ts
@@ -103,8 +103,8 @@ export function useAlbumContextMenu() {
       {
         label: t('context_menu.add_to_playlist'),
         icon: ListPlus,
-        children: playlistsStore.playlists.length
-          ? playlistsStore.playlists.map(p => ({
+        children: playlistsStore.manualPlaylists.length
+          ? playlistsStore.manualPlaylists.map(p => ({
               label: p.name,
               action: async () => {
                 const tracks = await fetchTracks()

--- a/frontend/src/composables/useDetailRouteLoader.ts
+++ b/frontend/src/composables/useDetailRouteLoader.ts
@@ -1,12 +1,28 @@
-import { onMounted } from 'vue'
+import { onActivated, onMounted } from 'vue'
 import { onBeforeRouteUpdate, useRoute } from 'vue-router'
 
 // Wires the common "load detail page by :id route param" pattern shared by
-// Album/Artist/Genre/Composer/Playlist detail views: fetch on mount, refetch
-// via onBeforeRouteUpdate (scoped to this route so it never fires from an
-// unrelated navigation while KeepAlive keeps the instance around), and expose
-// isStale() so in-flight loads can bail if a newer navigation has since
-// superseded them.
+// Album/Artist/Genre/Composer/Playlist detail views. Three distinct
+// navigation shapes all need to trigger a (re)load:
+//
+// 1. First-ever visit: onMounted.
+// 2. Same route, id changes in place (e.g. album A -> album B directly):
+//    onBeforeRouteUpdate.
+// 3. Navigate away to an unrelated route, then back to this route (possibly
+//    with a different id): MainLayout keeps this component alive via
+//    <KeepAlive>, cached by component *type* — not by route/id. Re-entering
+//    is a fresh "enter" transition (not an "update"), so onBeforeRouteUpdate
+//    never fires, and KeepAlive suppresses onMounted from firing again.
+//    onActivated is the only hook that covers this case (it also fires on
+//    the very first mount when inside a <KeepAlive>, alongside onMounted —
+//    a harmless duplicate fetch, not a correctness issue).
+//
+// Staleness (dropping a response superseded by a newer navigation) is NOT
+// handled here — comparing against the reactive route.params.id is racy: for
+// a fast-resolving load, the fetch can finish before vue-router has finished
+// updating route.params, making a perfectly fresh response look stale. Each
+// view instead tracks its own synchronous "latest requested id" token, set as
+// the first line of its load function, before any await.
 export function useDetailRouteLoader(load: (id: string) => void) {
   const route = useRoute()
 
@@ -15,12 +31,13 @@ export function useDetailRouteLoader(load: (id: string) => void) {
     if (id) load(id)
   })
 
+  onActivated(() => {
+    const id = route.params.id as string
+    if (id) load(id)
+  })
+
   onBeforeRouteUpdate((to) => {
     const id = to.params.id as string
     if (id) load(id)
   })
-
-  const isStale = (id: string) => (route.params.id as string) !== id
-
-  return { isStale }
 }

--- a/frontend/src/composables/useDetailRouteLoader.ts
+++ b/frontend/src/composables/useDetailRouteLoader.ts
@@ -1,0 +1,26 @@
+import { onMounted } from 'vue'
+import { onBeforeRouteUpdate, useRoute } from 'vue-router'
+
+// Wires the common "load detail page by :id route param" pattern shared by
+// Album/Artist/Genre/Composer/Playlist detail views: fetch on mount, refetch
+// via onBeforeRouteUpdate (scoped to this route so it never fires from an
+// unrelated navigation while KeepAlive keeps the instance around), and expose
+// isStale() so in-flight loads can bail if a newer navigation has since
+// superseded them.
+export function useDetailRouteLoader(load: (id: string) => void) {
+  const route = useRoute()
+
+  onMounted(() => {
+    const id = route.params.id as string
+    if (id) load(id)
+  })
+
+  onBeforeRouteUpdate((to) => {
+    const id = to.params.id as string
+    if (id) load(id)
+  })
+
+  const isStale = (id: string) => (route.params.id as string) !== id
+
+  return { isStale }
+}

--- a/frontend/src/composables/useGroupContextMenu.ts
+++ b/frontend/src/composables/useGroupContextMenu.ts
@@ -20,8 +20,8 @@ export function useGroupContextMenu() {
       {
         label: t('context_menu.add_to_playlist'),
         icon: ListPlus,
-        children: playlistsStore.playlists.length
-          ? playlistsStore.playlists.map(p => ({
+        children: playlistsStore.manualPlaylists.length
+          ? playlistsStore.manualPlaylists.map(p => ({
               label: p.name,
               action: async () => {
                 // Add all tracks to playlist

--- a/frontend/src/composables/usePlaylistContextMenu.ts
+++ b/frontend/src/composables/usePlaylistContextMenu.ts
@@ -130,8 +130,8 @@ export function usePlaylistContextMenu() {
           {
             label: t('context_menu.add_to_playlist'),
             icon: ListPlus,
-            disabled: playlistsStore.playlists.length <= 1,
-            children: playlistsStore.playlists
+            disabled: playlistsStore.manualPlaylists.filter(p => p.id !== playlist.id).length === 0,
+            children: playlistsStore.manualPlaylists
               .filter(p => p.id !== playlist.id)
               .map(p => ({
                 label: p.name,

--- a/frontend/src/composables/useTrackContextMenu.ts
+++ b/frontend/src/composables/useTrackContextMenu.ts
@@ -129,8 +129,9 @@ export function useTrackContextMenu(onEditMetadata: (track: TrackDTO) => void) {
     })
 
     if (!options.playlistId) {
-      const playlistChildren: ContextMenuItem[] = playlistsStore.playlists.length
-        ? playlistsStore.playlists.map(p => ({
+      const addablePlaylists = playlistsStore.manualPlaylists
+      const playlistChildren: ContextMenuItem[] = addablePlaylists.length
+        ? addablePlaylists.map(p => ({
           label: p.name,
           action: () => { PlaylistService.AddTrackToPlaylist(p.id, track.id, '') },
         }))
@@ -147,7 +148,7 @@ export function useTrackContextMenu(onEditMetadata: (track: TrackDTO) => void) {
         if (!playlistIds || !playlistIds.length) return
 
         playlistChildren.forEach((child, index) => {
-          const p = playlistsStore.playlists[index]
+          const p = addablePlaylists[index]
           if (p && playlistIds.includes(p.id)) {
             child.iconRight = Check
             child.action = () => { PlaylistService.RemoveTrackFromPlaylist(p.id, track.id, '') }
@@ -275,8 +276,8 @@ export function useTrackContextMenu(onEditMetadata: (track: TrackDTO) => void) {
     })
 
     if (!options.playlistId) {
-      const playlistChildren: ContextMenuItem[] = playlistsStore.playlists.length
-        ? playlistsStore.playlists.map(p => ({
+      const playlistChildren: ContextMenuItem[] = playlistsStore.manualPlaylists.length
+        ? playlistsStore.manualPlaylists.map(p => ({
           label: p.name,
           action: () => {
             PlaylistService.AddTracksToPlaylist(p.id, tracks.map(t => t.id), '')

--- a/frontend/src/composables/useTrackContextMenu.ts
+++ b/frontend/src/composables/useTrackContextMenu.ts
@@ -19,6 +19,7 @@ export interface TrackContextMenuOptions {
   showRemoveFromQueue?: boolean
   excludeAddToQueue?: boolean
   playlistId?: string
+  isSmartPlaylist?: boolean
 }
 
 export function useTrackContextMenu(onEditMetadata: (track: TrackDTO) => void) {
@@ -207,7 +208,7 @@ export function useTrackContextMenu(onEditMetadata: (track: TrackDTO) => void) {
       action: () => { LibraryService.ShowInExplorer(track.id) },
     })
 
-    if (options.playlistId && options.playlistId !== 'favorites') {
+    if (options.playlistId && options.playlistId !== 'favorites' && !options.isSmartPlaylist) {
       items.push({ separator: true })
       items.push({
         label: t('context_menu.remove_from_playlist'),
@@ -292,7 +293,7 @@ export function useTrackContextMenu(onEditMetadata: (track: TrackDTO) => void) {
       })
     }
 
-    if (options.playlistId && options.playlistId !== 'favorites') {
+    if (options.playlistId && options.playlistId !== 'favorites' && !options.isSmartPlaylist) {
       items.push({ separator: true })
       items.push({
         label: t('context_menu.remove_from_playlist'),

--- a/frontend/src/stores/playlists.ts
+++ b/frontend/src/stores/playlists.ts
@@ -146,6 +146,10 @@ export const usePlaylistsStore = defineStore('playlists', () => {
       .sort((a, b) => (a.pinned_at! < b.pinned_at! ? -1 : 1))
   )
 
+  // Smart playlists derive their tracks from rules and reject manual
+  // add/remove server-side — keep them out of "add to playlist" menus.
+  const manualPlaylists = computed(() => playlists.value.filter((p) => !p.is_smart))
+
   return {
     playlists,
     loading,
@@ -159,6 +163,7 @@ export const usePlaylistsStore = defineStore('playlists', () => {
     isPinned,
     togglePinned,
     pinnedPlaylists,
+    manualPlaylists,
     dispose,
   }
 })

--- a/frontend/src/views/AlbumDetailView.vue
+++ b/frontend/src/views/AlbumDetailView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ref, shallowRef, computed, onMounted } from 'vue'
-import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router'
+import { ref, shallowRef, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useDetailRouteLoader } from '@/composables/useDetailRouteLoader'
 import { useI18n } from 'vue-i18n'
 import LazyImg from '@/components/LazyImg.vue'
 import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
@@ -23,7 +24,6 @@ const settings = useTrackTableSettings()
 const playerStore = usePlayerStore()
 const { t } = useI18n()
 
-const route = useRoute()
 const router = useRouter()
 const album = ref<AlbumDTO | null>(null)
 const tracks = shallowRef<TrackDTO[]>([])
@@ -46,7 +46,7 @@ const tableHeight = computed(() => {
 
 // Drop a track from this view if an edit moved it to a different album.
 useLibraryUpdates(tracks, {
-  belongs: t => t.album?.id === route.params.id,
+  belongs: t => t.album?.id === album.value?.id,
 })
 const albumTheme = ref<ThemeColors | null>(null)
 
@@ -66,12 +66,14 @@ const loadAlbumDetails = async (id: string) => {
       LibraryService.GetAlbumByID(id),
       LibraryService.GetTracksByAlbumID(id)
     ])
+    if (isStale(id)) return
     album.value = albumData
     tracks.value = tracksData.filter((t): t is TrackDTO => t !== null)
 
     // Fetch album colors for local theme
     try {
       const colors = await LibraryService.GetAlbumColors(id)
+      if (isStale(id)) return
       albumTheme.value = colors
     } catch (e) {
       console.warn('Failed to fetch album colors', e)
@@ -79,19 +81,11 @@ const loadAlbumDetails = async (id: string) => {
   } catch (err) {
     console.error('Failed to load album details:', err)
   } finally {
-    isLoading.value = false
+    if (!isStale(id)) isLoading.value = false
   }
 }
 
-onMounted(() => {
-  const id = route.params.id as string
-  if (id) loadAlbumDetails(id)
-})
-
-onBeforeRouteUpdate((to) => {
-  const newId = to.params.id
-  if (newId) loadAlbumDetails(newId as string)
-})
+const { isStale } = useDetailRouteLoader(loadAlbumDetails)
 
 const getTotalDuration = (tracks: TrackDTO[]) => {
   const totalSeconds = tracks.reduce((acc, t) => acc + (t.duration || 0), 0)

--- a/frontend/src/views/AlbumDetailView.vue
+++ b/frontend/src/views/AlbumDetailView.vue
@@ -59,7 +59,15 @@ function openContextMenu(e: MouseEvent) {
   }
 }
 
+// Synchronous token marking the most recently requested album, set before
+// any await so a fast-resolving load can't be mistaken for stale (comparing
+// against vue-router's reactive route.params.id instead is racy: it may not
+// have finished updating yet by the time a quick fetch resolves).
+let currentAlbumId: string | null = null
+const isStale = (id: string) => currentAlbumId !== id
+
 const loadAlbumDetails = async (id: string) => {
+  currentAlbumId = id
   isLoading.value = true
   try {
     const [albumData, tracksData] = await Promise.all([
@@ -85,7 +93,7 @@ const loadAlbumDetails = async (id: string) => {
   }
 }
 
-const { isStale } = useDetailRouteLoader(loadAlbumDetails)
+useDetailRouteLoader(loadAlbumDetails)
 
 const getTotalDuration = (tracks: TrackDTO[]) => {
   const totalSeconds = tracks.reduce((acc, t) => acc + (t.duration || 0), 0)

--- a/frontend/src/views/AlbumDetailView.vue
+++ b/frontend/src/views/AlbumDetailView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ref, shallowRef, computed, onMounted, watch } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { ref, shallowRef, computed, onMounted } from 'vue'
+import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import LazyImg from '@/components/LazyImg.vue'
 import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
@@ -88,7 +88,8 @@ onMounted(() => {
   if (id) loadAlbumDetails(id)
 })
 
-watch(() => route.params.id, (newId) => {
+onBeforeRouteUpdate((to) => {
+  const newId = to.params.id
   if (newId) loadAlbumDetails(newId as string)
 })
 

--- a/frontend/src/views/ArtistDetailView.vue
+++ b/frontend/src/views/ArtistDetailView.vue
@@ -7,9 +7,9 @@ import { DetailsButton } from '@airmedy/ui'
 import { hexToRgba } from '@airmedy/utils'
 import { Disc, ImagePlus, MoreVertical, Music, Play, Shuffle, Trash2 } from '@lucide/vue'
 import { Events } from '@wailsio/runtime'
-import { computed, onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, shallowRef } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useRoute, useRouter } from 'vue-router'
+import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router'
 import type { AlbumDTO, Artist, ThemeColors, TrackDTO } from '../../bindings/airmedy/internal/domain/models'
 import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
 import ContextMenu from '../components/ContextMenu.vue'
@@ -136,7 +136,8 @@ onUnmounted(() => {
   if (offArtworkUpdated) offArtworkUpdated()
 })
 
-watch(() => route.params.id, (newId) => {
+onBeforeRouteUpdate((to) => {
+  const newId = to.params.id
   if (newId) loadArtistDetails(newId as string)
 })
 </script>
@@ -147,10 +148,10 @@ watch(() => route.params.id, (newId) => {
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
     </div>
 
-    <div v-else-if="artist" class="flex-1 overflow-y-auto">
+    <div v-else-if="artist" class="flex-1 flex flex-col overflow-hidden">
       <!-- Artist Hero Section -->
       <div
-        class="p-8 md:p-12 flex flex-col md:flex-row gap-8 items-center bg-gradient-to-b from-dynamic-surface to-transparent border-b border-foreground/[0.06]"
+        class="flex-shrink-0 p-8 md:p-12 flex flex-col md:flex-row gap-8 items-center bg-gradient-to-b from-dynamic-surface to-transparent border-b border-foreground/[0.06]"
         :style="{ '--dynamic-surface': artistTheme ? hexToRgba(artistTheme.dominant, 0.15) : 'var(--bg-glass)' }">
         <div
           class="group relative w-32 h-32 xl:w-42 xl:h-42 rounded-full shadow-2xl overflow-hidden ring-2 ring-foreground/[0.08] bg-foreground/5 flex-shrink-0"
@@ -192,7 +193,7 @@ watch(() => route.params.id, (newId) => {
         </div>
       </div>
 
-      <div class="p-8">
+      <div class="flex-1 min-h-0">
         <GroupedAlbumList :tracks="tracks" :albums="albums" />
       </div>
     </div>

--- a/frontend/src/views/ArtistDetailView.vue
+++ b/frontend/src/views/ArtistDetailView.vue
@@ -9,7 +9,7 @@ import { Disc, ImagePlus, MoreVertical, Music, Play, Shuffle, Trash2 } from '@lu
 import { Events } from '@wailsio/runtime'
 import { computed, onMounted, onUnmounted, ref, shallowRef } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 import type { AlbumDTO, Artist, ThemeColors, TrackDTO } from '../../bindings/airmedy/internal/domain/models'
 import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
 import ContextMenu from '../components/ContextMenu.vue'
@@ -20,7 +20,6 @@ import { useDetailRouteLoader } from '@/composables/useDetailRouteLoader'
 
 const { t } = useI18n()
 
-const route = useRoute()
 const router = useRouter()
 const playerStore = usePlayerStore()
 const artist = ref<Artist | null>(null)
@@ -37,6 +36,13 @@ function openContextMenu(e: MouseEvent) {
   contextMenu.open(e, buildMenuItems(tracks.value))
 }
 
+// Synchronous token marking the most recently requested artist, set before
+// any await so a fast-resolving load can't be mistaken for stale (comparing
+// against vue-router's reactive route.params.id instead is racy: it may not
+// have finished updating yet by the time a quick fetch resolves).
+let currentArtistId: string | null = null
+const isStale = (id: string) => currentArtistId !== id
+
 const loadTheme = async (id: string) => {
   artistTheme.value = null
   try {
@@ -51,6 +57,7 @@ const loadTheme = async (id: string) => {
 // silent: event-driven reload that keeps the current view visible (no spinner /
 // theme flash) and swaps data in when it arrives.
 const loadArtistDetails = async (id: string, silent = false) => {
+  currentArtistId = id
   if (!silent) {
     isLoading.value = true
     loadTheme(id)
@@ -73,8 +80,10 @@ const loadArtistDetails = async (id: string, silent = false) => {
 }
 
 // Track edits can move tracks/albums in or out of this artist; refresh silently.
+// Reads our own loaded artist id, not route.params.id — this listener stays
+// registered while KeepAlive backgrounds this instance on an unrelated route.
 useLibrarySync(() => {
-  const id = route.params.id as string
+  const id = artist.value?.id
   if (id) loadArtistDetails(id, true)
 })
 
@@ -137,7 +146,7 @@ onUnmounted(() => {
   if (offArtworkUpdated) offArtworkUpdated()
 })
 
-const { isStale } = useDetailRouteLoader(loadArtistDetails)
+useDetailRouteLoader(loadArtistDetails)
 </script>
 
 <template>

--- a/frontend/src/views/ArtistDetailView.vue
+++ b/frontend/src/views/ArtistDetailView.vue
@@ -9,13 +9,14 @@ import { Disc, ImagePlus, MoreVertical, Music, Play, Shuffle, Trash2 } from '@lu
 import { Events } from '@wailsio/runtime'
 import { computed, onMounted, onUnmounted, ref, shallowRef } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import type { AlbumDTO, Artist, ThemeColors, TrackDTO } from '../../bindings/airmedy/internal/domain/models'
 import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
 import ContextMenu from '../components/ContextMenu.vue'
 import GroupedAlbumList from '../components/GroupedAlbumList.vue'
 import { usePlayerStore } from '../stores/player'
 import { useLibrarySync } from '@/composables/useLibrarySync'
+import { useDetailRouteLoader } from '@/composables/useDetailRouteLoader'
 
 const { t } = useI18n()
 
@@ -39,7 +40,9 @@ function openContextMenu(e: MouseEvent) {
 const loadTheme = async (id: string) => {
   artistTheme.value = null
   try {
-    artistTheme.value = await LibraryService.GetArtistColors(id)
+    const colors = await LibraryService.GetArtistColors(id)
+    if (isStale(id)) return
+    artistTheme.value = colors
   } catch (err) {
     console.error('Failed to load artist colors:', err)
   }
@@ -58,13 +61,14 @@ const loadArtistDetails = async (id: string, silent = false) => {
       LibraryService.GetAlbumsByArtistID(id),
       LibraryService.GetTracksByArtistID(id)
     ])
+    if (isStale(id)) return
     artist.value = artistData
     albums.value = albumsData.filter((a): a is AlbumDTO => a !== null)
     tracks.value = tracksData.filter((t): t is TrackDTO => t !== null)
   } catch (err) {
     console.error('Failed to load artist details:', err)
   } finally {
-    if (!silent) isLoading.value = false
+    if (!isStale(id)) isLoading.value = false
   }
 }
 
@@ -119,9 +123,6 @@ function openArtworkMenu(e: MouseEvent) {
 let offArtworkUpdated: (() => void) | null = null
 
 onMounted(() => {
-  const id = route.params.id as string
-  if (id) loadArtistDetails(id)
-
   // Artwork can change asynchronously (e.g. Deezer online fetch completes);
   // re-extract colors so the hero tint follows the new image.
   offArtworkUpdated = Events.On('artist-artwork-updated', (ev) => {
@@ -136,10 +137,7 @@ onUnmounted(() => {
   if (offArtworkUpdated) offArtworkUpdated()
 })
 
-onBeforeRouteUpdate((to) => {
-  const newId = to.params.id
-  if (newId) loadArtistDetails(newId as string)
-})
+const { isStale } = useDetailRouteLoader(loadArtistDetails)
 </script>
 
 <template>

--- a/frontend/src/views/ComposerDetailView.vue
+++ b/frontend/src/views/ComposerDetailView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ref, shallowRef, computed, onMounted, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { ref, shallowRef, computed, onMounted } from 'vue'
+import { useRoute, onBeforeRouteUpdate } from 'vue-router'
 import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
 import type { Composer, TrackDTO } from '../../bindings/airmedy/internal/domain/models'
 import GroupedAlbumList from '../components/GroupedAlbumList.vue'
@@ -57,7 +57,8 @@ onMounted(() => {
   if (id) loadComposerDetails(id)
 })
 
-watch(() => route.params.id, (newId) => {
+onBeforeRouteUpdate((to) => {
+  const newId = to.params.id
   if (newId) loadComposerDetails(newId as string)
 })
 </script>
@@ -90,7 +91,7 @@ watch(() => route.params.id, (newId) => {
       </div>
 
       <!-- Grouped Albums -->
-      <div class="flex-1 overflow-y-auto p-8">
+      <div class="flex-1 min-h-0">
         <GroupedAlbumList :tracks="tracks" />
       </div>
     </div>

--- a/frontend/src/views/ComposerDetailView.vue
+++ b/frontend/src/views/ComposerDetailView.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ref, shallowRef, computed } from 'vue'
-import { useRoute } from 'vue-router'
 import { useDetailRouteLoader } from '@/composables/useDetailRouteLoader'
 import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
 import type { Composer, TrackDTO } from '../../bindings/airmedy/internal/domain/models'
@@ -17,7 +16,6 @@ import { useLibrarySync } from '@/composables/useLibrarySync'
 
 const { t } = useI18n()
 
-const route = useRoute()
 const playerStore = usePlayerStore()
 const composer = ref<Composer | null>(null)
 const tracks = shallowRef<TrackDTO[]>([])
@@ -31,7 +29,15 @@ function openContextMenu(e: MouseEvent) {
   contextMenu.open(e, buildMenuItems(tracks.value))
 }
 
+// Synchronous token marking the most recently requested composer, set before
+// any await so a fast-resolving load can't be mistaken for stale (comparing
+// against vue-router's reactive route.params.id instead is racy: it may not
+// have finished updating yet by the time a quick fetch resolves).
+let currentComposerId: string | null = null
+const isStale = (id: string) => currentComposerId !== id
+
 const loadComposerDetails = async (id: string, silent = false) => {
+  currentComposerId = id
   if (!silent) isLoading.value = true
   try {
     const [composerData, tracksData] = await Promise.all([
@@ -49,12 +55,14 @@ const loadComposerDetails = async (id: string, silent = false) => {
 }
 
 // Track edits can move tracks in or out of this composer; refresh silently.
+// Reads our own loaded composer id, not route.params.id — this listener stays
+// registered while KeepAlive backgrounds this instance on an unrelated route.
 useLibrarySync(() => {
-  const id = route.params.id as string
+  const id = composer.value?.id
   if (id) loadComposerDetails(id, true)
 })
 
-const { isStale } = useDetailRouteLoader(loadComposerDetails)
+useDetailRouteLoader(loadComposerDetails)
 </script>
 
 <template>

--- a/frontend/src/views/ComposerDetailView.vue
+++ b/frontend/src/views/ComposerDetailView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ref, shallowRef, computed, onMounted } from 'vue'
-import { useRoute, onBeforeRouteUpdate } from 'vue-router'
+import { ref, shallowRef, computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { useDetailRouteLoader } from '@/composables/useDetailRouteLoader'
 import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
 import type { Composer, TrackDTO } from '../../bindings/airmedy/internal/domain/models'
 import GroupedAlbumList from '../components/GroupedAlbumList.vue'
@@ -37,12 +38,13 @@ const loadComposerDetails = async (id: string, silent = false) => {
       LibraryService.GetComposerByID(id),
       LibraryService.GetTracksByComposerID(id)
     ])
+    if (isStale(id)) return
     composer.value = composerData
     tracks.value = tracksData.filter((t): t is TrackDTO => t !== null)
   } catch (err) {
     console.error('Failed to load composer details:', err)
   } finally {
-    if (!silent) isLoading.value = false
+    if (!isStale(id)) isLoading.value = false
   }
 }
 
@@ -52,15 +54,7 @@ useLibrarySync(() => {
   if (id) loadComposerDetails(id, true)
 })
 
-onMounted(() => {
-  const id = route.params.id as string
-  if (id) loadComposerDetails(id)
-})
-
-onBeforeRouteUpdate((to) => {
-  const newId = to.params.id
-  if (newId) loadComposerDetails(newId as string)
-})
+const { isStale } = useDetailRouteLoader(loadComposerDetails)
 </script>
 
 <template>

--- a/frontend/src/views/GenreDetailView.vue
+++ b/frontend/src/views/GenreDetailView.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ref, shallowRef, computed } from 'vue'
-import { useRoute } from 'vue-router'
 import { useDetailRouteLoader } from '@/composables/useDetailRouteLoader'
 import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
 import type { Genre, TrackDTO } from '../../bindings/airmedy/internal/domain/models'
@@ -17,7 +16,6 @@ import { useLibrarySync } from '@/composables/useLibrarySync'
 
 const { t } = useI18n()
 
-const route = useRoute()
 const playerStore = usePlayerStore()
 const genre = ref<Genre | null>(null)
 const tracks = shallowRef<TrackDTO[]>([])
@@ -31,7 +29,15 @@ function openContextMenu(e: MouseEvent) {
   contextMenu.open(e, buildMenuItems(tracks.value))
 }
 
+// Synchronous token marking the most recently requested genre, set before
+// any await so a fast-resolving load can't be mistaken for stale (comparing
+// against vue-router's reactive route.params.id instead is racy: it may not
+// have finished updating yet by the time a quick fetch resolves).
+let currentGenreId: string | null = null
+const isStale = (id: string) => currentGenreId !== id
+
 const loadGenreDetails = async (id: string, silent = false) => {
+  currentGenreId = id
   if (!silent) isLoading.value = true
   try {
     const [genreData, tracksData] = await Promise.all([
@@ -49,12 +55,14 @@ const loadGenreDetails = async (id: string, silent = false) => {
 }
 
 // Track edits can move tracks in or out of this genre; refresh silently.
+// Reads our own loaded genre id, not route.params.id — this listener stays
+// registered while KeepAlive backgrounds this instance on an unrelated route.
 useLibrarySync(() => {
-  const id = route.params.id as string
+  const id = genre.value?.id
   if (id) loadGenreDetails(id, true)
 })
 
-const { isStale } = useDetailRouteLoader(loadGenreDetails)
+useDetailRouteLoader(loadGenreDetails)
 </script>
 
 <template>

--- a/frontend/src/views/GenreDetailView.vue
+++ b/frontend/src/views/GenreDetailView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ref, shallowRef, computed, onMounted } from 'vue'
-import { useRoute, onBeforeRouteUpdate } from 'vue-router'
+import { ref, shallowRef, computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { useDetailRouteLoader } from '@/composables/useDetailRouteLoader'
 import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
 import type { Genre, TrackDTO } from '../../bindings/airmedy/internal/domain/models'
 import GroupedAlbumList from '../components/GroupedAlbumList.vue'
@@ -37,12 +38,13 @@ const loadGenreDetails = async (id: string, silent = false) => {
       LibraryService.GetGenreByID(id),
       LibraryService.GetTracksByGenreID(id)
     ])
+    if (isStale(id)) return
     genre.value = genreData
     tracks.value = tracksData.filter((t): t is TrackDTO => t !== null)
   } catch (err) {
     console.error('Failed to load genre details:', err)
   } finally {
-    if (!silent) isLoading.value = false
+    if (!isStale(id)) isLoading.value = false
   }
 }
 
@@ -52,15 +54,7 @@ useLibrarySync(() => {
   if (id) loadGenreDetails(id, true)
 })
 
-onMounted(() => {
-  const id = route.params.id as string
-  if (id) loadGenreDetails(id)
-})
-
-onBeforeRouteUpdate((to) => {
-  const newId = to.params.id
-  if (newId) loadGenreDetails(newId as string)
-})
+const { isStale } = useDetailRouteLoader(loadGenreDetails)
 </script>
 
 <template>

--- a/frontend/src/views/GenreDetailView.vue
+++ b/frontend/src/views/GenreDetailView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ref, shallowRef, computed, onMounted, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { ref, shallowRef, computed, onMounted } from 'vue'
+import { useRoute, onBeforeRouteUpdate } from 'vue-router'
 import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
 import type { Genre, TrackDTO } from '../../bindings/airmedy/internal/domain/models'
 import GroupedAlbumList from '../components/GroupedAlbumList.vue'
@@ -57,7 +57,8 @@ onMounted(() => {
   if (id) loadGenreDetails(id)
 })
 
-watch(() => route.params.id, (newId) => {
+onBeforeRouteUpdate((to) => {
+  const newId = to.params.id
   if (newId) loadGenreDetails(newId as string)
 })
 </script>
@@ -90,7 +91,7 @@ watch(() => route.params.id, (newId) => {
       </div>
 
       <!-- Grouped Albums -->
-      <div class="flex-1 overflow-y-auto p-8">
+      <div class="flex-1 min-h-0">
         <GroupedAlbumList :tracks="tracks" />
       </div>
     </div>

--- a/frontend/src/views/PlaylistDetailView.spec.ts
+++ b/frontend/src/views/PlaylistDetailView.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import { createPinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import PlaylistDetailView from './PlaylistDetailView.vue'
+
+vi.mock('../../bindings/airmedy/internal/infra/wails/playlistservice', () => {
+  const playlists: Record<string, any> = {
+    A: { id: 'A', name: 'Playlist A', description: '', artwork_key: null, is_smart: false, rules: null },
+    B: { id: 'B', name: 'Playlist B', description: '', artwork_key: null, is_smart: false, rules: null },
+  }
+  return {
+    GetPlaylistByID: vi.fn((id: string) => Promise.resolve(playlists[id] ?? null)),
+    GetPlaylistTracks: vi.fn(() => Promise.resolve([])),
+    GetPlaylistColors: vi.fn(() => Promise.resolve(null)),
+    GetPlaylistsForTrack: vi.fn(() => Promise.resolve([])),
+  }
+})
+
+vi.mock('../../bindings/airmedy/internal/infra/wails/libraryservice', () => ({
+  GetFavoriteTracks: vi.fn(() => Promise.resolve([])),
+  GetAlbumColors: vi.fn(() => Promise.resolve(null)),
+}))
+
+vi.mock('@wailsio/runtime', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    Events: { On: vi.fn(() => () => {}) },
+  }
+})
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/', component: { template: '<div/>' } },
+    { path: '/playlists', name: 'playlists', component: { template: '<div>Playlists list</div>' } },
+    { path: '/playlists/:id', name: 'playlist-detail', component: PlaylistDetailView },
+  ],
+})
+
+function flushPromises() {
+  return new Promise(resolve => setTimeout(resolve, 0)).then(() => new Promise(resolve => setTimeout(resolve, 0)))
+}
+
+describe('PlaylistDetailView navigation between two playlists', () => {
+  it('updates playlist.name when navigating back and forth between A and B repeatedly', async () => {
+    router.push('/playlists/A')
+    await router.isReady()
+
+    const wrapper = mount({ template: '<router-view v-slot="{ Component }"><KeepAlive :max="3"><component :is="Component" /></KeepAlive></router-view>' }, {
+      global: {
+        plugins: [router, createPinia(), createI18n({ legacy: false, locale: 'en', messages: { en: {} } })],
+        stubs: { LazyImg: true, ContextMenu: true, PlaylistArtwork: true, ConfirmDialog: true, CreatePlaylistDialog: true, SmartPlaylistDialog: true },
+      },
+    })
+
+    await flushPromises()
+    expect(wrapper.text()).toContain('Playlist A')
+
+    await router.push('/playlists/B')
+    await flushPromises()
+    expect(wrapper.text()).toContain('Playlist B')
+    expect(wrapper.text()).not.toContain('Playlist A')
+
+    await router.push('/playlists/A')
+    await flushPromises()
+    expect(wrapper.text()).toContain('Playlist A')
+    expect(wrapper.text()).not.toContain('Playlist B')
+
+    await router.push('/playlists/B')
+    await flushPromises()
+    expect(wrapper.text()).toContain('Playlist B')
+    expect(wrapper.text()).not.toContain('Playlist A')
+  })
+
+  it('updates when navigating through an unrelated route in between (A -> playlists list -> B)', async () => {
+    router.push('/playlists/A')
+    await router.isReady()
+
+    const wrapper = mount({ template: '<router-view v-slot="{ Component }"><KeepAlive :max="3"><component :is="Component" /></KeepAlive></router-view>' }, {
+      global: {
+        plugins: [router, createPinia(), createI18n({ legacy: false, locale: 'en', messages: { en: {} } })],
+        stubs: { LazyImg: true, ContextMenu: true, PlaylistArtwork: true, ConfirmDialog: true, CreatePlaylistDialog: true, SmartPlaylistDialog: true },
+      },
+    })
+
+    await flushPromises()
+    expect(wrapper.text()).toContain('Playlist A')
+
+    // Go to an unrelated route (the playlists list), then into a different playlist.
+    await router.push('/playlists')
+    await flushPromises()
+    expect(wrapper.text()).toContain('Playlists list')
+
+    await router.push('/playlists/B')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Playlist B')
+    expect(wrapper.text()).not.toContain('Playlist A')
+  })
+})

--- a/frontend/src/views/PlaylistDetailView.vue
+++ b/frontend/src/views/PlaylistDetailView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, shallowRef, onMounted, computed, watch, onUnmounted } from 'vue'
-import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { Play, Shuffle, MoreVertical, Clock, Music, X, Search, Sparkles } from '@lucide/vue'
 import * as PlaylistService from '../../bindings/airmedy/internal/infra/wails/playlistservice'
@@ -22,6 +22,7 @@ import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import { emptyConfig, type SmartPlaylistConfig } from '@/lib/smartPlaylistFields'
 import { Input } from '@airmedy/ui'
 import { useLibraryUpdates } from '@/composables/useLibraryUpdates'
+import { useDetailRouteLoader } from '@/composables/useDetailRouteLoader'
 import { usePlaylistsStore } from '@/stores/playlists'
 import { Events } from '@wailsio/runtime'
 
@@ -124,6 +125,7 @@ async function load(silent = false, idOverride?: string) {
         PlaylistService.GetPlaylistByID(id),
         LibraryService.GetFavoriteTracks(),
       ])
+      if (isStale(id)) return
       playlist.value = p ?? ({ id: 'favorites', name: t('sidebar.favorites'), description: '', artwork_key: null } as Playlist)
       if (playlist.value.name === 'Favorites') {
         playlist.value = { ...playlist.value, name: t('sidebar.favorites') }
@@ -133,7 +135,7 @@ async function load(silent = false, idOverride?: string) {
     } catch (e) {
       console.error('Failed to load favorite tracks', e)
     } finally {
-      if (!silent) isLoading.value = false
+      if (!silent && !isStale(id)) isLoading.value = false
     }
     return
   }
@@ -143,22 +145,24 @@ async function load(silent = false, idOverride?: string) {
       PlaylistService.GetPlaylistByID(id),
       PlaylistService.GetPlaylistTracks(id),
     ])
+    if (isStale(id)) return
     playlist.value = p
     tracks.value = t.filter((t): t is TrackDTO => t !== null)
   } catch (e) {
     console.error('Failed to load playlist', e)
   } finally {
-    if (!silent) isLoading.value = false
+    if (!silent && !isStale(id)) isLoading.value = false
   }
 }
 
 async function loadTheme() {
   if (!playlist.value) return
-  
+  const id = playlist.value.id
+
   try {
     // 1. Try playlist custom theme
-    let colors: ThemeColors | null = await PlaylistService.GetPlaylistColors(playlist.value.id)
-    
+    let colors: ThemeColors | null = await PlaylistService.GetPlaylistColors(id)
+
     // 2. Fallback to first track's album theme if no custom artwork
     if (!colors && tracks.value.length > 0) {
       const trackWithAlbum = tracks.value.find(t => t.album_id)
@@ -166,7 +170,8 @@ async function loadTheme() {
         colors = await LibraryService.GetAlbumColors(trackWithAlbum.album_id)
       }
     }
-    
+
+    if (playlist.value?.id !== id) return
     playlistTheme.value = colors
   } catch (e) {
     console.warn('Failed to load playlist theme', e)
@@ -174,12 +179,9 @@ async function loadTheme() {
 }
 
 watch(tracks, () => loadTheme())
-onBeforeRouteUpdate((to) => {
-  const newId = to.params.id
-  if (newId) load(false, newId as string)
-})
+const { isStale } = useDetailRouteLoader((id) => load(false, id))
 watch(() => favoritesStore.version, () => {
-  if (route.params.id === 'favorites') load(true)
+  if (playlist.value?.id === 'favorites') load(true)
 })
 
 const sessionId = Math.random().toString(36).substring(2, 15)
@@ -187,14 +189,14 @@ const sessionId = Math.random().toString(36).substring(2, 15)
 const handlePlaylistChange = (ev: Events.WailsEvent) => {
   const data = ev.data as { playlist_id: string, sender_id: string }
   if (data.sender_id === sessionId) return
-  if (data.playlist_id === route.params.id) {
+  if (data.playlist_id === playlist.value?.id) {
     load(true)
   }
 }
 
 const handlePlaylistDeleted = (ev: Events.WailsEvent) => {
   const deletedId = ev.data as string
-  if (deletedId === route.params.id) {
+  if (deletedId === playlist.value?.id) {
     router.push('/')
   }
 }
@@ -203,7 +205,6 @@ let offPlaylistChange: (() => void) | null = null
 let offPlaylistDeleted: (() => void) | null = null
 
 onMounted(() => {
-  load()
   offPlaylistChange = Events.On('playlist:tracks-changed', handlePlaylistChange)
   offPlaylistDeleted = Events.On('playlist:deleted', handlePlaylistDeleted)
 })

--- a/frontend/src/views/PlaylistDetailView.vue
+++ b/frontend/src/views/PlaylistDetailView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, shallowRef, onMounted, computed, watch, onUnmounted } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { Play, Shuffle, MoreVertical, Clock, Music, X, Search, Sparkles } from '@lucide/vue'
 import * as PlaylistService from '../../bindings/airmedy/internal/infra/wails/playlistservice'
@@ -110,8 +110,8 @@ function openContextMenu(e: MouseEvent) {
   }))
 }
 
-async function load(silent = false) {
-  const id = route.params.id as string
+async function load(silent = false, idOverride?: string) {
+  const id = idOverride ?? (route.params.id as string)
   if (!id) return
 
   if (!silent) isLoading.value = true
@@ -174,7 +174,10 @@ async function loadTheme() {
 }
 
 watch(tracks, () => loadTheme())
-watch(() => route.params.id, () => load())
+onBeforeRouteUpdate((to) => {
+  const newId = to.params.id
+  if (newId) load(false, newId as string)
+})
 watch(() => favoritesStore.version, () => {
   if (route.params.id === 'favorites') load(true)
 })

--- a/frontend/src/views/PlaylistDetailView.vue
+++ b/frontend/src/views/PlaylistDetailView.vue
@@ -111,9 +111,17 @@ function openContextMenu(e: MouseEvent) {
   }))
 }
 
+// Synchronous token marking the most recently requested playlist, set before
+// any await so a fast-resolving load can't be mistaken for stale (comparing
+// against vue-router's reactive route.params.id instead is racy: it may not
+// have finished updating yet by the time a quick fetch resolves).
+let currentPlaylistId: string | null = null
+const isStale = (id: string) => currentPlaylistId !== id
+
 async function load(silent = false, idOverride?: string) {
   const id = idOverride ?? (route.params.id as string)
   if (!id) return
+  currentPlaylistId = id
 
   if (!silent) isLoading.value = true
 
@@ -179,9 +187,9 @@ async function loadTheme() {
 }
 
 watch(tracks, () => loadTheme())
-const { isStale } = useDetailRouteLoader((id) => load(false, id))
+useDetailRouteLoader((id) => load(false, id))
 watch(() => favoritesStore.version, () => {
-  if (playlist.value?.id === 'favorites') load(true)
+  if (playlist.value?.id === 'favorites') load(true, 'favorites')
 })
 
 const sessionId = Math.random().toString(36).substring(2, 15)
@@ -189,8 +197,11 @@ const sessionId = Math.random().toString(36).substring(2, 15)
 const handlePlaylistChange = (ev: Events.WailsEvent) => {
   const data = ev.data as { playlist_id: string, sender_id: string }
   if (data.sender_id === sessionId) return
+  // This listener stays registered while KeepAlive backgrounds this instance
+  // on an unrelated route, so `id` must come from our own state, not the
+  // (possibly unrelated) global route.params.id.
   if (data.playlist_id === playlist.value?.id) {
-    load(true)
+    load(true, playlist.value.id)
   }
 }
 

--- a/frontend/src/views/PlaylistDetailView.vue
+++ b/frontend/src/views/PlaylistDetailView.vue
@@ -368,7 +368,7 @@ async function handleReorder(newTracks: TrackDTO[]) {
         :show-artwork="true"
         :simple-mode="true"
         :allow-dnd="playlist.id !== 'favorites' && !playlist.is_smart"
-        :context-menu-options="{ playlistId: playlist.id }"
+        :context-menu-options="{ playlistId: playlist.id, isSmartPlaylist: playlist.is_smart }"
         @play-track="(_, index, queue) => playerStore.playTracks(queue, index)"
         @reorder="handleReorder"
         @navigate-album="id => router.push(`/albums/${id}`)"

--- a/frontend/src/views/PlaylistDetailView.vue
+++ b/frontend/src/views/PlaylistDetailView.vue
@@ -36,6 +36,7 @@ const playlistsStore = usePlaylistsStore()
 const playlist = ref<Playlist | null>(null)
 const tracks = shallowRef<TrackDTO[]>([])
 const isLoading = ref(true)
+const tracksLoading = ref(false)
 const searchQuery = ref('')
 
 const filteredTracks = computed(() => {
@@ -123,6 +124,14 @@ async function load(silent = false, idOverride?: string) {
   if (!id) return
   currentPlaylistId = id
 
+  // Switching to a different playlist: drop the old track list so a
+  // track-derived artwork mosaic (no custom artwork_key) doesn't flash the
+  // previous playlist's covers while the new tracks are still loading.
+  if (playlist.value?.id !== id) {
+    tracks.value = []
+    playlistTheme.value = null
+  }
+
   if (!silent) isLoading.value = true
 
   // Favorites has a real playlist row (for artwork/theme) but its track list
@@ -149,17 +158,26 @@ async function load(silent = false, idOverride?: string) {
   }
 
   try {
-    const [p, t] = await Promise.all([
-      PlaylistService.GetPlaylistByID(id),
-      PlaylistService.GetPlaylistTracks(id),
-    ])
+    const p = await PlaylistService.GetPlaylistByID(id)
     if (isStale(id)) return
     playlist.value = p
-    tracks.value = t.filter((t): t is TrackDTO => t !== null)
   } catch (e) {
     console.error('Failed to load playlist', e)
   } finally {
     if (!silent && !isStale(id)) isLoading.value = false
+  }
+
+  if (isStale(id)) return
+
+  tracksLoading.value = true
+  try {
+    const t = await PlaylistService.GetPlaylistTracks(id)
+    if (isStale(id)) return
+    tracks.value = t.filter((t): t is TrackDTO => t !== null)
+  } catch (e) {
+    console.error('Failed to load playlist tracks', e)
+  } finally {
+    if (!isStale(id)) tracksLoading.value = false
   }
 }
 
@@ -226,6 +244,7 @@ onUnmounted(() => {
 })
 
 const totalDurationFormatted = computed(() => {
+  if (tracksLoading.value) return '--'
   const totalSeconds = tracks.value.reduce((acc, t) => acc + (t.duration || 0), 0)
   return formatTotalDuration(totalSeconds, t)
 })
@@ -349,7 +368,7 @@ async function handleReorder(newTracks: TrackDTO[]) {
       <div class="flex gap-2 text-sm items-end flex-wrap">
         <div class="flex items-center gap-2">
           <Music class="w-4 h-4" />
-          <span>{{ tracks.length }} {{ $t('library.songs') }}</span>
+          <span>{{ tracksLoading ? '--' : tracks.length }} {{ $t('library.songs') }}</span>
         </div>
         <div class="flex items-center gap-2">
           <Clock class="w-4 h-4" />
@@ -376,6 +395,7 @@ async function handleReorder(newTracks: TrackDTO[]) {
     <template #body>
       <TrackTable
         :tracks="filteredTracks"
+        :is-loading="tracksLoading"
         :show-artwork="true"
         :simple-mode="true"
         :allow-dnd="playlist.id !== 'favorites' && !playlist.is_smart"


### PR DESCRIPTION
## Summary
- Virtualize GroupedAlbumList (artist/genre/composer detail) with DynamicScroller so only visible album groups render, not the whole library
- Fix stray "album not found" errors from KeepAlive-cached detail views reacting to unrelated route changes (watch → onBeforeRouteUpdate)
- Fix race condition where opening playlists/albums/artists/genres/composers in quick succession could show stale content from an earlier, slower-resolving request
- Hide smart playlists from "Add to Playlist" menus and hide "Remove from Playlist" for smart playlist tracks (both previously failed silently server-side)
- Extract shared route-param-load wiring into useDetailRouteLoader composable

## Test plan
- [ ] Open an artist/genre/composer with many albums, confirm DOM stays small while scrolling (DevTools Elements panel)
- [ ] Click between album/artist/genre/composer/playlist pages, confirm no "not found" errors in backend log
- [ ] Rapidly click through several playlists/albums, confirm displayed tracks always match the last one clicked
- [ ] Right-click a track: confirm smart playlists don't appear in "Add to Playlist"; open a smart playlist and confirm "Remove from Playlist" is absent