### PR TITLE
fix(frontend): remove Google Fonts Inter to fix italic text on WKWebView

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,12 +4,6 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/airmedy.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap"
-      rel="stylesheet"
-    />
     <title>Airmedy</title>
   </head>
   <body>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -8,7 +8,7 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Inter', 'ui-sans-serif', 'system-ui', '-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', '"Noto Sans"', 'sans-serif', '"Apple Color Emoji"', '"Segoe UI Emoji"', '"Segoe UI Symbol"', '"Noto Color Emoji"'],
+        sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', '"PingFang SC"', '"Microsoft YaHei"', '"Hiragino Kaku Gothic Pro"', '"Meiryo"', '"Apple SD Gothic Neo"', '"Malgun Gothic"', 'sans-serif'],
       },
       colors: {
         background: 'var(--bg-main)',


### PR DESCRIPTION
## Summary
- Removed Google Fonts Inter variable font; italic axis was breaking bold text rendering on WKWebView
- Falls back to system font stack

## Test plan
- [ ] Verify italic/bold text renders correctly on WKWebView (macOS app)
- [ ] Verify font fallback looks acceptable across platforms