### PR TITLE
feat(app): vary mood radio queues

### DIFF
--- a/catalog/analysis/README.md
+++ b/catalog/analysis/README.md
@@ -275,19 +275,33 @@ backfills it.
 
 "Give me more like this" queue seeding/auto-refill, gated on
 `AppSettings.LibraryAnalysisEnabled` (energy/danceability/tempo are its only
-inputs). `MoodRadioService.SeedMoodRadio(seedTrackID, limit)` calls
-`TrackQueryRepository.FindSimilar`, which ranks analyzed tracks by weighted-
-euclidean distance over `energy`/`danceability`/`tempo` (tempo scaled `/200`
-to bring its BPM range in line with the 0-1 normalized features), computed
-entirely in SQL via correlated subqueries against the seed's own feature row,
-excluding unanalyzed tracks and the seed itself. If the seed track itself has
-no analyzed feature row, `FindSimilar` returns no results (rather than an
-arbitrary order from NULL-valued distances).
+inputs). `MoodRadioService.GenerateMoodRadio(seedTrackID, excludeTrackIDs,
+limit)` forwards to `app/moodradio.Service`. The service asks
+`TrackQueryRepository.FindSimilar` for the nearest 80 analyzed candidates,
+excluding the seed and every supplied queue/history ID. SQLite ranks candidates
+by weighted-euclidean distance over `energy`/`danceability`/`tempo` (tempo
+scaled `/200` to bring its BPM range in line with the 0-1 normalized features),
+computed entirely in SQL via correlated subqueries against the seed's own
+feature row. If the seed track itself has no analyzed feature row, `FindSimilar`
+returns no results (rather than an arbitrary order from NULL-valued distances).
+The exclusion IDs are encoded as one JSON array and filtered with SQLite
+`json_each(?)`, so a large playback queue does not consume one SQL bind
+parameter per track.
+
+The app service turns those deterministic candidates into a varied batch. Its
+first three selections are weighted-random within the top 20; remaining
+selections use the full candidate pool with rank weight `1 / sqrt(rank + 1)`.
+Selection is without replacement and avoids a primary artist from the previous
+three tracks plus a second track from an already selected album whenever an
+alternative exists. It relaxes the album rule first, then artist cooldown, so
+small libraries still receive a full batch.
 
 The frontend store starts Mood Radio by seeding + prepending the seed track
 (`FindSimilar` always excludes it), then auto-refills the queue as it drains
 below `REFILL_THRESHOLD` (3) remaining tracks, appending `SEED_BATCH_SIZE` (15)
-more similar tracks at a time and deduping against what's already queued.
+more similar tracks at a time. The whole existing queue is supplied as
+`excludeTrackIDs` on refill, so already queued/played tracks are removed before
+the SQL candidate limit rather than being discarded too late in the frontend.
 Turning off Library Analysis mid-session stops the radio immediately (watched
 reactively), since its only data source just went away.
 

--- a/catalog/architecture/README.md
+++ b/catalog/architecture/README.md
@@ -21,7 +21,7 @@ flowchart TB
     end
 
     subgraph APP["internal/app — Application Services"]
-        AppSvc["library/ · player/ · playlist/ · eq/ · lyrics/ · config/ · i18n/ · updater/<br/>lastfm/ · remoteserver/ · appsettings/ · singleinstance/<br/><i>orchestrates domain entities + ports; framework-agnostic</i>"]
+        AppSvc["library/ · player/ · playlist/ · moodradio/ · eq/ · lyrics/ · config/ · i18n/ · updater/<br/>lastfm/ · remoteserver/ · appsettings/ · singleinstance/<br/><i>orchestrates domain entities + ports; framework-agnostic</i>"]
     end
 
     subgraph DOMAIN["internal/domain — Core"]

--- a/frontend/src/stores/moodRadio.test.ts
+++ b/frontend/src/stores/moodRadio.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { nextTick } from 'vue'
+
+const mockGenerateMoodRadio = vi.fn()
+const mockPlayTrackIDs = vi.fn()
+const mockAppendTracks = vi.fn()
+
+vi.mock('@wailsio/runtime', () => ({
+  Events: { On: vi.fn(() => () => {}) },
+  Create: {
+    Nullable: (fn: (value: unknown) => unknown) => (value: unknown) => value == null ? null : fn(value),
+    Array: (fn: (value: unknown) => unknown) => (values: unknown[]) => (values ?? []).map(fn),
+    Struct: (ctor: new (value: unknown) => unknown) => (value: unknown) => value == null ? null : new ctor(value),
+    Map: () => (value: unknown) => value,
+  },
+  Call: { ByID: vi.fn() },
+}))
+
+vi.mock('../../bindings/airmedy/internal/infra/wails/moodradioservice', () => ({
+  GenerateMoodRadio: (...args: unknown[]) => mockGenerateMoodRadio(...args),
+}))
+
+vi.mock('../../bindings/airmedy/internal/infra/wails/playerservice', () => ({
+  PlayTrackIDs: (...args: unknown[]) => mockPlayTrackIDs(...args),
+  AppendTracks: (...args: unknown[]) => mockAppendTracks(...args),
+}))
+
+import { useAppStore } from './app'
+import { useMoodRadioStore } from './moodRadio'
+import { usePlayerStore } from './player'
+
+describe('useMoodRadioStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    mockGenerateMoodRadio.mockResolvedValue([])
+    mockPlayTrackIDs.mockResolvedValue(undefined)
+    mockAppendTracks.mockResolvedValue(undefined)
+  })
+
+  it('starts with generated candidates and the seed track first', async () => {
+    mockGenerateMoodRadio.mockResolvedValue([{ id: 'similar' }])
+
+    await useMoodRadioStore().start({ id: 'seed' } as any)
+
+    expect(mockGenerateMoodRadio).toHaveBeenCalledWith('seed', [], 15)
+    expect(mockPlayTrackIDs).toHaveBeenCalledWith(['seed', 'similar'], 0)
+  })
+
+  it('excludes the full existing queue when refilling', async () => {
+    const app = useAppStore()
+    app.libraryAnalysisEnabled = true
+    const player = usePlayerStore()
+    const radio = useMoodRadioStore()
+    radio.active = true
+    radio.init()
+    player.queue = [{ id: 'seed' }, { id: 'current' }] as any
+    player.currentTrack = { id: 'current' } as any
+
+    await nextTick()
+    await nextTick()
+
+    expect(mockGenerateMoodRadio).toHaveBeenCalledWith('current', ['seed', 'current'], 15)
+    radio.dispose()
+  })
+})

--- a/frontend/src/stores/moodRadio.ts
+++ b/frontend/src/stores/moodRadio.ts
@@ -18,11 +18,11 @@ export const useMoodRadioStore = defineStore('moodRadio', () => {
     seedTrackId.value = seedTrack.id
     active.value = true
     try {
-      // SeedMoodRadio/FindSimilar excludes the seed track from its results
+      // GenerateMoodRadio/FindSimilar excludes the seed track from its results
       // (it's always excluded as a candidate for itself), so it has to be
       // prepended here — otherwise the track the user picked never plays,
       // a similar track plays first instead.
-      const similar = await fetchSimilar(seedTrack.id)
+      const similar = await fetchSimilar(seedTrack.id, [])
       const tracks = [seedTrack, ...similar.filter(t => t.id !== seedTrack.id)]
       const playerStore = usePlayerStore()
       await playerStore.playTracks(tracks, 0, true)
@@ -40,14 +40,14 @@ export const useMoodRadioStore = defineStore('moodRadio', () => {
     seedTrackId.value = null
   }
 
-  async function fetchSimilar(trackId: string): Promise<TrackDTO[]> {
-    const result = await MoodRadioService.SeedMoodRadio(trackId, SEED_BATCH_SIZE)
+  async function fetchSimilar(trackId: string, excludeTrackIDs: string[]): Promise<TrackDTO[]> {
+    const result = await MoodRadioService.GenerateMoodRadio(trackId, excludeTrackIDs, SEED_BATCH_SIZE)
     return result.filter(Boolean) as TrackDTO[]
   }
 
   async function refillIfNeeded() {
     if (!active.value || refilling) return
-    // Library analysis feeds SeedMoodRadio's similarity search; if the user
+    // Library analysis feeds GenerateMoodRadio's similarity search; if the user
     // disables it mid-session (the context menu already hides the "Start
     // Mood Radio" entry in that case), the queue must stop silently growing
     // instead of continuing to fetch "similar" tracks from stale data.
@@ -73,7 +73,7 @@ export const useMoodRadioStore = defineStore('moodRadio', () => {
     refilling = true
     try {
       const existingSet = new Set(playerStore.queue.map(t => t.id))
-      const next = (await fetchSimilar(seed)).filter(t => !existingSet.has(t.id))
+      const next = await fetchSimilar(seed, [...existingSet])
       if (next.length) {
         // AppendTracks adds straight to the tail in one mutation. The
         // previous approach (PlayNextTracks then ReorderQueueIDs) fired two

--- a/internal/app/module.go
+++ b/internal/app/module.go
@@ -9,6 +9,7 @@ import (
 	"airmedy/internal/app/lastfm"
 	"airmedy/internal/app/library"
 	"airmedy/internal/app/lyrics"
+	"airmedy/internal/app/moodradio"
 	"airmedy/internal/app/normalization"
 	"airmedy/internal/app/player"
 	"airmedy/internal/app/playlist"
@@ -93,6 +94,7 @@ var Module = fx.Module("app",
 	lyrics.Module,
 	eq.Module,
 	normalization.Module,
+	moodradio.Module,
 	lastfm.Module,
 	appsettings.Module,
 	remoteserver.Module,

--- a/internal/app/moodradio/module.go
+++ b/internal/app/moodradio/module.go
@@ -1,0 +1,5 @@
+package moodradio
+
+import "go.uber.org/fx"
+
+var Module = fx.Module("moodradio", fx.Provide(NewService))

--- a/internal/app/moodradio/service.go
+++ b/internal/app/moodradio/service.go
@@ -1,0 +1,133 @@
+package moodradio
+
+import (
+	"context"
+	"math"
+	"math/rand/v2"
+
+	"airmedy/internal/domain"
+)
+
+const (
+	candidateLimit        = 80
+	openingCandidateLimit = 20
+	openingTrackCount     = 3
+	artistCooldown        = 3
+)
+
+// Service turns deterministic nearest-neighbour candidates into a varied
+// Mood Radio batch while preserving the seed's audio characteristics.
+type Service struct {
+	tracks        domain.TrackQueryRepository
+	randomFloat64 func() float64
+}
+
+func NewService(tracks domain.TrackQueryRepository) *Service {
+	return &Service{tracks: tracks, randomFloat64: rand.Float64}
+}
+
+// Generate returns a varied batch of tracks related to seedTrackID. Tracks in
+// excludeTrackIDs are removed before candidate ranking, so queue refills do
+// not run out merely because their closest neighbours were already queued.
+func (s *Service) Generate(ctx context.Context, seedTrackID string, excludeTrackIDs []string, limit int) ([]*domain.TrackDTO, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	candidates, err := s.tracks.FindSimilar(ctx, seedTrackID, excludeTrackIDs, max(candidateLimit, limit))
+	if err != nil {
+		return nil, err
+	}
+	return s.selectTracks(candidates, limit), nil
+}
+
+func (s *Service) selectTracks(candidates []*domain.TrackDTO, limit int) []*domain.TrackDTO {
+	if limit > len(candidates) {
+		limit = len(candidates)
+	}
+	selected := make([]*domain.TrackDTO, 0, limit)
+	usedAlbums := make(map[string]struct{})
+	recentArtists := make([]string, 0, artistCooldown)
+
+	for len(selected) < limit && len(candidates) > 0 {
+		windowSize := len(candidates)
+		if len(selected) < openingTrackCount {
+			windowSize = min(windowSize, openingCandidateLimit)
+		}
+		window := candidates[:windowSize]
+		index := s.pickCandidate(window, usedAlbums, recentArtists)
+		track := candidates[index]
+		selected = append(selected, track)
+		candidates = append(candidates[:index], candidates[index+1:]...)
+
+		if track.AlbumID != "" {
+			usedAlbums[track.AlbumID] = struct{}{}
+		}
+		if artistID := primaryArtistID(track); artistID != "" {
+			recentArtists = append(recentArtists, artistID)
+			if len(recentArtists) > artistCooldown {
+				recentArtists = recentArtists[1:]
+			}
+		}
+	}
+	return selected
+}
+
+// pickCandidate enforces album and artist diversity when possible. It first
+// relaxes the album rule, then the artist cooldown, so small libraries still
+// get a full radio batch.
+func (s *Service) pickCandidate(window []*domain.TrackDTO, usedAlbums map[string]struct{}, recentArtists []string) int {
+	for _, rules := range []struct{ album, artist bool }{{true, true}, {false, true}, {false, false}} {
+		eligible := make([]int, 0, len(window))
+		for i, track := range window {
+			if rules.album && track.AlbumID != "" {
+				if _, used := usedAlbums[track.AlbumID]; used {
+					continue
+				}
+			}
+			if rules.artist && contains(recentArtists, primaryArtistID(track)) {
+				continue
+			}
+			eligible = append(eligible, i)
+		}
+		if len(eligible) > 0 {
+			return eligible[s.weightedIndex(eligible)]
+		}
+	}
+	return 0
+}
+
+func (s *Service) weightedIndex(eligible []int) int {
+	total := 0.0
+	for _, index := range eligible {
+		total += rankWeight(index)
+	}
+	target := s.randomFloat64() * total
+	for i, index := range eligible {
+		target -= rankWeight(index)
+		if target <= 0 {
+			return i
+		}
+	}
+	return len(eligible) - 1
+}
+
+func rankWeight(rank int) float64 { return 1 / math.Sqrt(float64(rank+1)) }
+
+func primaryArtistID(track *domain.TrackDTO) string {
+	if len(track.Artists) == 0 || track.Artists[0] == nil {
+		return ""
+	}
+	return track.Artists[0].ID
+}
+
+func contains(values []string, value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, current := range values {
+		if current == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/moodradio/service_test.go
+++ b/internal/app/moodradio/service_test.go
@@ -1,0 +1,88 @@
+package moodradio
+
+import (
+	"context"
+	"testing"
+
+	"airmedy/internal/domain"
+)
+
+type trackQueryRepositoryStub struct {
+	candidates []*domain.TrackDTO
+	seed       string
+	excludes   []string
+	limit      int
+}
+
+func (s *trackQueryRepositoryStub) FindSimilar(_ context.Context, seedTrackID string, excludeTrackIDs []string, limit int) ([]*domain.TrackDTO, error) {
+	s.seed = seedTrackID
+	s.excludes = append([]string(nil), excludeTrackIDs...)
+	s.limit = limit
+	return append([]*domain.TrackDTO(nil), s.candidates...), nil
+}
+
+func (s *trackQueryRepositoryStub) MoodDensityGrid(context.Context, int) (*domain.MoodDensityGrid, error) {
+	return nil, nil
+}
+
+func TestServiceGenerateUsesCandidatePoolAndForwardsExclusions(t *testing.T) {
+	candidates := make([]*domain.TrackDTO, 90)
+	for i := range candidates {
+		candidates[i] = track("track-"+string(rune('a'+i%26)), "album-"+string(rune('a'+i%26)), "artist-"+string(rune('a'+i%26)))
+	}
+	repo := &trackQueryRepositoryStub{candidates: candidates}
+	service := NewService(repo)
+	service.randomFloat64 = func() float64 { return 0 }
+
+	got, err := service.Generate(context.Background(), "seed", []string{"queued-1", "queued-2"}, 15)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if repo.seed != "seed" || repo.limit != candidateLimit || len(repo.excludes) != 2 {
+		t.Fatalf("unexpected repository request: seed=%q limit=%d excludes=%v", repo.seed, repo.limit, repo.excludes)
+	}
+	if len(got) != 15 {
+		t.Fatalf("expected 15 selected tracks, got %d", len(got))
+	}
+	seen := map[string]struct{}{}
+	for _, candidate := range got {
+		if _, exists := seen[candidate.ID]; exists {
+			t.Fatalf("duplicate selected track %q", candidate.ID)
+		}
+		seen[candidate.ID] = struct{}{}
+	}
+}
+
+func TestServiceGenerateDiversifiesArtistAndAlbumWhenAlternativesExist(t *testing.T) {
+	repo := &trackQueryRepositoryStub{candidates: []*domain.TrackDTO{
+		track("one", "album-a", "artist-a"),
+		track("two", "album-b", "artist-a"),
+		track("three", "album-a", "artist-b"),
+		track("four", "album-c", "artist-c"),
+	}}
+	service := NewService(repo)
+	service.randomFloat64 = func() float64 { return 0 }
+
+	got, err := service.Generate(context.Background(), "seed", nil, 3)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if got[0].ID != "one" || got[1].ID != "four" || got[2].ID != "three" {
+		t.Fatalf("expected diversity-aware order [one four three], got %v", trackIDs(got))
+	}
+}
+
+func track(id, albumID, artistID string) *domain.TrackDTO {
+	return &domain.TrackDTO{
+		Track:   domain.Track{ID: id, AlbumID: albumID},
+		Artists: []*domain.Artist{{ID: artistID}},
+	}
+}
+
+func trackIDs(tracks []*domain.TrackDTO) []string {
+	ids := make([]string, len(tracks))
+	for i, track := range tracks {
+		ids[i] = track.ID
+	}
+	return ids
+}

--- a/internal/domain/repositories.go
+++ b/internal/domain/repositories.go
@@ -245,9 +245,9 @@ type AnalysisRepository interface {
 type TrackQueryRepository interface {
 	// FindSimilar returns up to limit tracks most similar to seedTrackID by
 	// weighted-euclidean distance over analyzed mood/tempo features,
-	// nearest first, excluding the seed track itself and any unanalyzed
-	// track. Returns no tracks if the seed itself is unanalyzed.
-	FindSimilar(ctx context.Context, seedTrackID string, limit int) ([]*TrackDTO, error)
+	// nearest first, excluding the seed, excluded track IDs, and any
+	// unanalyzed track. Returns no tracks if the seed itself is unanalyzed.
+	FindSimilar(ctx context.Context, seedTrackID string, excludeTrackIDs []string, limit int) ([]*TrackDTO, error)
 	// MoodDensityGrid buckets all tracks with a non-null energy and
 	// danceability into a gridSize x gridSize grid for the Mood Playlist
 	// heatmap. See MoodDensityGrid for the bucket layout.

--- a/internal/infra/sqlite/track_query_repository.go
+++ b/internal/infra/sqlite/track_query_repository.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"airmedy/internal/domain"
@@ -24,7 +25,7 @@ const (
 	similarityWeightTempo        = 1.0
 )
 
-func (r *trackQueryRepository) FindSimilar(ctx context.Context, seedTrackID string, limit int) ([]*domain.TrackDTO, error) {
+func (r *trackQueryRepository) FindSimilar(ctx context.Context, seedTrackID string, excludeTrackIDs []string, limit int) ([]*domain.TrackDTO, error) {
 	// If the seed track itself has no analyzed feature row, every correlated
 	// subquery below yields NULL, so all distances are NULL and ORDER BY
 	// degenerates to an arbitrary order — returning tracks unrelated to the
@@ -50,11 +51,29 @@ func (r *trackQueryRepository) FindSimilar(ctx context.Context, seedTrackID stri
 	// dominate the distance regardless of weighting. Unanalyzed tracks
 	// (NULL features) are excluded so they never rank as spuriously "close"
 	// due to SQL NULL arithmetic.
+	exclusions := ""
+	var exclusionJSON string
+	if len(excludeTrackIDs) > 0 {
+		exclusionBytes, err := json.Marshal(excludeTrackIDs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode excluded track IDs: %w", err)
+		}
+		exclusionJSON = string(exclusionBytes)
+		// json_each keeps the entire exclusion list in one bind parameter. This
+		// avoids SQLite's variable limit when a user's queue has thousands of
+		// tracks, without needing a connection-scoped temporary table.
+		exclusions = `
+		  AND NOT EXISTS (
+			  SELECT 1 FROM json_each(?) excluded
+			  WHERE excluded.value = t.id
+		  )`
+	}
 	query := `
 		SELECT t.id
 		FROM tracks t
 		JOIN track_features tf ON tf.track_id = t.id
 		WHERE t.id != ?
+		` + exclusions + `
 		  AND tf.energy IS NOT NULL
 		  AND tf.danceability IS NOT NULL
 		  AND tf.tempo IS NOT NULL
@@ -70,11 +89,16 @@ func (r *trackQueryRepository) FindSimilar(ctx context.Context, seedTrackID stri
 	`
 	args := []any{
 		seedTrackID,
+	}
+	if exclusionJSON != "" {
+		args = append(args, exclusionJSON)
+	}
+	args = append(args,
 		similarityWeightEnergy, seedTrackID, seedTrackID,
 		similarityWeightDanceability, seedTrackID, seedTrackID,
 		similarityWeightTempo, seedTrackID, seedTrackID,
 		limit,
-	}
+	)
 
 	var ids []string
 	if err := r.db.Ext(ctx).SelectContext(ctx, &ids, query, args...); err != nil {

--- a/internal/infra/sqlite/track_query_repository_test.go
+++ b/internal/infra/sqlite/track_query_repository_test.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"testing"
@@ -79,4 +80,100 @@ func TestTrackQueryRepository_MoodDensityGrid(t *testing.T) {
 	if sum != grid.AnalyzedCount {
 		t.Fatalf("sum of bucket counts (%d) should equal AnalyzedCount (%d)", sum, grid.AnalyzedCount)
 	}
+}
+
+func TestTrackQueryRepository_FindSimilarExcludesQueuedTracksBeforeLimit(t *testing.T) {
+	dbPath := "test_find_similar_exclusions.db"
+	defer func() { _ = os.Remove(dbPath) }()
+
+	db, err := NewDB(dbPath, slog.Default())
+	if err != nil {
+		t.Fatalf("failed to create test db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	trackRepo := NewTrackRepository(db)
+	queryRepo := NewTrackQueryRepository(db, trackRepo)
+	for _, track := range []*domain.Track{
+		{ID: "seed", Path: "/m/seed.mp3", Title: "Seed", SortTitle: "seed", Format: "mp3"},
+		{ID: "closest", Path: "/m/closest.mp3", Title: "Closest", SortTitle: "closest", Format: "mp3"},
+		{ID: "next", Path: "/m/next.mp3", Title: "Next", SortTitle: "next", Format: "mp3"},
+		{ID: "far", Path: "/m/far.mp3", Title: "Far", SortTitle: "far", Format: "mp3"},
+	} {
+		if err := trackRepo.Save(ctx, track); err != nil {
+			t.Fatalf("failed to save track %s: %v", track.ID, err)
+		}
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO track_features (track_id, energy, danceability, tempo) VALUES
+			('seed', 0.50, 0.50, 120),
+			('closest', 0.51, 0.50, 120),
+			('next', 0.55, 0.50, 120),
+			('far', 0.90, 0.90, 180)
+	`); err != nil {
+		t.Fatalf("failed to seed track features: %v", err)
+	}
+
+	tracks, err := queryRepo.FindSimilar(ctx, "seed", []string{"closest"}, 2)
+	if err != nil {
+		t.Fatalf("FindSimilar: %v", err)
+	}
+	if len(tracks) != 2 || tracks[0].ID != "next" || tracks[1].ID != "far" {
+		t.Fatalf("expected excluded closest track to be skipped before LIMIT, got %#v", trackIDs(tracks))
+	}
+}
+
+func TestTrackQueryRepository_FindSimilarSupportsLargeExclusionLists(t *testing.T) {
+	dbPath := "test_find_similar_large_exclusions.db"
+	defer func() { _ = os.Remove(dbPath) }()
+
+	db, err := NewDB(dbPath, slog.Default())
+	if err != nil {
+		t.Fatalf("failed to create test db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	trackRepo := NewTrackRepository(db)
+	queryRepo := NewTrackQueryRepository(db, trackRepo)
+	for _, track := range []*domain.Track{
+		{ID: "seed", Path: "/m/seed.mp3", Title: "Seed", SortTitle: "seed", Format: "mp3"},
+		{ID: "closest", Path: "/m/closest.mp3", Title: "Closest", SortTitle: "closest", Format: "mp3"},
+		{ID: "next", Path: "/m/next.mp3", Title: "Next", SortTitle: "next", Format: "mp3"},
+	} {
+		if err := trackRepo.Save(ctx, track); err != nil {
+			t.Fatalf("failed to save track %s: %v", track.ID, err)
+		}
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO track_features (track_id, energy, danceability, tempo) VALUES
+			('seed', 0.50, 0.50, 120),
+			('closest', 0.51, 0.50, 120),
+			('next', 0.55, 0.50, 120)
+	`); err != nil {
+		t.Fatalf("failed to seed track features: %v", err)
+	}
+
+	excluded := make([]string, 0, 3001)
+	for i := 0; i < 3000; i++ {
+		excluded = append(excluded, fmt.Sprintf("queued-%d", i))
+	}
+	excluded = append(excluded, "closest")
+
+	tracks, err := queryRepo.FindSimilar(ctx, "seed", excluded, 1)
+	if err != nil {
+		t.Fatalf("FindSimilar with 3,001 exclusions: %v", err)
+	}
+	if len(tracks) != 1 || tracks[0].ID != "next" {
+		t.Fatalf("expected next track after excluding closest, got %#v", trackIDs(tracks))
+	}
+}
+
+func trackIDs(tracks []*domain.TrackDTO) []string {
+	ids := make([]string, len(tracks))
+	for i, track := range tracks {
+		ids[i] = track.ID
+	}
+	return ids
 }

--- a/internal/infra/wails/mood_radio_service.go
+++ b/internal/infra/wails/mood_radio_service.go
@@ -3,22 +3,22 @@ package wails
 import (
 	"context"
 
+	"airmedy/internal/app/moodradio"
 	"airmedy/internal/domain"
 )
 
-// MoodRadioService is the Wails binding for Mood Radio's "give me more like
-// this" queue seeding, backed directly by TrackQueryRepository — thin
-// enough that it doesn't warrant its own app-layer service.
+// MoodRadioService is the Wails binding for Mood Radio's queue generation.
 type MoodRadioService struct {
+	service        *moodradio.Service
 	trackQueryRepo domain.TrackQueryRepository
 }
 
-func NewMoodRadioService(trackQueryRepo domain.TrackQueryRepository) *MoodRadioService {
-	return &MoodRadioService{trackQueryRepo: trackQueryRepo}
+func NewMoodRadioService(service *moodradio.Service, trackQueryRepo domain.TrackQueryRepository) *MoodRadioService {
+	return &MoodRadioService{service: service, trackQueryRepo: trackQueryRepo}
 }
 
-func (s *MoodRadioService) SeedMoodRadio(seedTrackID string, limit int) ([]*domain.TrackDTO, error) {
-	return s.trackQueryRepo.FindSimilar(context.Background(), seedTrackID, limit)
+func (s *MoodRadioService) GenerateMoodRadio(seedTrackID string, excludeTrackIDs []string, limit int) ([]*domain.TrackDTO, error) {
+	return s.service.Generate(context.Background(), seedTrackID, excludeTrackIDs, limit)
 }
 
 // GetMoodDensityGrid buckets analyzed tracks into a gridSize x gridSize


### PR DESCRIPTION
## Summary
- generate varied Mood Radio batches from a ranked candidate pool
- avoid repeated artists/albums where alternatives exist
- exclude the current queue before candidate limiting, using SQLite JSON filtering to support large queues

## Verification
- wails3 task verify