### PR TITLE
fix(ui): preserve top artist artwork across pagination

### DIFF
--- a/catalog/artwork/README.md
+++ b/catalog/artwork/README.md
@@ -184,6 +184,13 @@ displayed image — so live changes and preference toggles both reflect instantl
 `GetArtistColors` so the hero tint follows async artwork changes (e.g. a Deezer
 fetch completing).
 
+`TopArtistsCarousel.vue` uses the same `ArtistCard` artwork path for analytics
+artists. It loads the full artist records by ID before rendering, so top artists
+also honor the online/local artwork preferences and background fetch behavior;
+the analytics `artwork_key` remains a fallback while those records load. When a
+card remounts after pagination, `ArtistCard` also applies the URL returned by
+`GetArtistArtwork`, covering cached artwork that does not emit a new event.
+
 ### Local file scan
 
 - `findArtistImageFile(dir)` looks for `artist.jpg`, then `artist.jpeg`, then

--- a/frontend/src/components/ArtistCard.spec.ts
+++ b/frontend/src/components/ArtistCard.spec.ts
@@ -1,0 +1,43 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+import { describe, expect, it, vi } from 'vitest'
+import ArtistCard from './ArtistCard.vue'
+import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
+
+vi.mock('@wailsio/runtime', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@wailsio/runtime')>(),
+  Events: { On: vi.fn(() => vi.fn()) },
+}))
+
+vi.mock('../../bindings/airmedy/internal/infra/wails/libraryservice', () => ({
+  GetArtistArtwork: vi.fn(),
+}))
+
+describe('ArtistCard artwork', () => {
+  it('uses the service URL when cached artwork is returned without an update event', async () => {
+    vi.mocked(LibraryService.GetArtistArtwork).mockResolvedValue('/artwork/cached-key')
+
+    const wrapper = mount(ArtistCard, {
+      props: {
+        artist: {
+          id: 'artist-a',
+          name: 'Artist A',
+          sort_name: 'Artist A',
+          normalization_key: 'artist-a',
+          artwork_key_manual: null,
+          artwork_key_local: null,
+          artwork_key_online: null,
+          artwork_key: '',
+          created_at: '2026-01-01T00:00:00.000Z',
+          updated_at: '2026-01-01T00:00:00.000Z',
+        },
+        variant: 'avatar',
+      },
+      global: { plugins: [createTestingPinia({ createSpy: vi.fn })] },
+    })
+    await flushPromises()
+
+    expect(LibraryService.GetArtistArtwork).toHaveBeenCalledWith('artist-a', 'artist-artwork:artist-a')
+    expect(wrapper.get('img').attributes('src')).toBe('/artwork/cached-key')
+  })
+})

--- a/frontend/src/components/ArtistCard.vue
+++ b/frontend/src/components/ArtistCard.vue
@@ -54,7 +54,14 @@ const seedKeys = () => {
 // manual, and not suppressed by a local image under prefer-local) and none cached.
 const maybeFetchOnline = () => {
   if (!canShowOnline.value || keys.manual || keys.online) return
-  LibraryService.GetArtistArtwork(props.artist.id, `artist-artwork:${props.artist.id}`)
+  const artistID = props.artist.id
+  LibraryService.GetArtistArtwork(artistID, `artist-artwork:${artistID}`)
+    .then((url) => {
+      // The artwork may already be cached by a card that was unmounted during
+      // carousel pagination. The service returns its resolved URL in that case
+      // without emitting another update event, so render it immediately.
+      if (url && props.artist.id === artistID) imageUrl.value = url
+    })
     .catch((err) => console.error(`[ArtistCard] artwork fetch failed for ${props.artist.name}:`, err))
 }
 

--- a/frontend/src/components/home/TopArtistsCarousel.spec.ts
+++ b/frontend/src/components/home/TopArtistsCarousel.spec.ts
@@ -1,0 +1,90 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import TopArtistsCarousel from './TopArtistsCarousel.vue'
+import * as LibraryService from '../../../bindings/airmedy/internal/infra/wails/libraryservice'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('../../../bindings/airmedy/internal/infra/wails/libraryservice', () => ({
+  GetAllArtists: vi.fn(),
+}))
+
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  disconnect() {}
+})
+
+function cancellable<T>(value: T) {
+  return Object.assign(Promise.resolve(value), { cancel: vi.fn() })
+}
+
+const analyticsArtists = [
+  { id: 'artist-a', name: 'Artist A', artwork_key: 'stale-key', listened_seconds: 120 },
+  { id: 'artist-b', name: 'Artist B', artwork_key: '', listened_seconds: 60 },
+]
+
+describe('TopArtistsCarousel artwork', () => {
+  it('loads full artists and passes them to ArtistCard for shared artwork behavior', async () => {
+    vi.mocked(LibraryService.GetAllArtists).mockReturnValue(cancellable([
+      { id: 'artist-a', name: 'Artist A', artwork_key_manual: null, artwork_key_local: null, artwork_key_online: 'online-key' },
+      { id: 'artist-b', name: 'Artist B', artwork_key_manual: null, artwork_key_local: 'local-key', artwork_key_online: null },
+      { id: 'unrelated', name: 'Unrelated', artwork_key_manual: null, artwork_key_local: null, artwork_key_online: 'other-key' },
+    ]) as unknown as ReturnType<typeof LibraryService.GetAllArtists>)
+
+    const wrapper = mount(TopArtistsCarousel, {
+      props: { artists: analyticsArtists },
+      global: {
+        stubs: {
+          ArtistCard: {
+            name: 'ArtistCard',
+            props: ['artist', 'variant'],
+            template: '<div data-testid="artist-card" />',
+          },
+          LazyImg: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(LibraryService.GetAllArtists).toHaveBeenCalledTimes(1)
+    const card = wrapper.findComponent({ name: 'ArtistCard' })
+    expect(card.props('variant')).toBe('avatar')
+    expect(card.props('artist')).toMatchObject({ id: 'artist-a', artwork_key_online: 'online-key' })
+    expect(wrapper.text()).toContain('Artist A')
+    expect(wrapper.text()).toContain('analytics.top_artists')
+
+    await wrapper.findAll('button')[1].trigger('click')
+    await flushPromises()
+    expect(wrapper.findAllComponents({ name: 'ArtistCard' }).some(component =>
+      (component.props('artist') as { id: string }).id === 'artist-b',
+    )).toBe(true)
+  })
+
+  it('keeps the analytics artwork fallback when artist loading fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.mocked(LibraryService.GetAllArtists).mockReturnValue(cancellable(Promise.reject(new Error('offline'))) as unknown as ReturnType<typeof LibraryService.GetAllArtists>)
+
+    const wrapper = mount(TopArtistsCarousel, {
+      props: { artists: [analyticsArtists[0]] },
+      global: {
+        stubs: {
+          ArtistCard: true,
+          LazyImg: { name: 'LazyImg', template: '<img data-testid="fallback-artwork" />' },
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="fallback-artwork"]').exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'ArtistCard' }).exists()).toBe(false)
+    consoleError.mockRestore()
+  })
+})

--- a/frontend/src/components/home/TopArtistsCarousel.vue
+++ b/frontend/src/components/home/TopArtistsCarousel.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { ChevronLeft, ChevronRight, Users } from '@lucide/vue'
 import { useI18n } from 'vue-i18n'
 import { buildArtworkUrl, formatTotalDuration } from '@airmedy/utils'
+import type { Artist } from '../../../bindings/airmedy/internal/domain/models'
+import * as LibraryService from '../../../bindings/airmedy/internal/infra/wails/libraryservice'
+import ArtistCard from '@/components/ArtistCard.vue'
 import LazyImg from '@/components/LazyImg.vue'
 
 const props = defineProps<{
@@ -16,7 +19,9 @@ const carouselRef = ref<HTMLElement | null>(null)
 const columnsPerPage = ref(4)
 const currentPage = ref(0)
 const transitionName = ref('slide-next')
+const artistsByID = shallowRef(new Map<string, Artist>())
 let resizeObserver: ResizeObserver | null = null
+let artistsRequest: ReturnType<typeof LibraryService.GetAllArtists> | null = null
 
 const itemsPerPage = computed(() => columnsPerPage.value)
 const totalPages = computed(() => Math.ceil(props.artists.length / itemsPerPage.value))
@@ -27,6 +32,36 @@ const paginatedArtists = computed(() => {
 })
 
 const formatTime = (seconds: number) => formatTotalDuration(seconds, t)
+
+const getArtist = (id: string) => artistsByID.value.get(id)
+
+async function loadArtistArtworkData() {
+  artistsRequest?.cancel()
+  const ids = new Set(props.artists.map(artist => artist.id))
+  if (!ids.size) {
+    artistsByID.value = new Map()
+    return
+  }
+
+  const pending = LibraryService.GetAllArtists()
+  artistsRequest = pending
+  try {
+    const artists = await pending
+    if (artistsRequest !== pending) return
+    artistsByID.value = new Map(
+      artists
+        .filter((artist): artist is Artist => artist !== null && ids.has(artist.id))
+        .map(artist => [artist.id, artist]),
+    )
+  } catch (err) {
+    if (artistsRequest === pending) {
+      artistsByID.value = new Map()
+      console.error('Failed to load top artist artwork data:', err)
+    }
+  } finally {
+    if (artistsRequest === pending) artistsRequest = null
+  }
+}
 
 function updateColumns() {
   if (!carouselRef.value) return
@@ -48,6 +83,7 @@ function previous() {
 }
 
 watch(() => props.artists.length, () => { currentPage.value = 0 })
+watch(() => props.artists.map(artist => artist.id).join(','), loadArtistArtworkData, { immediate: true })
 watch(totalPages, (pages) => {
   if (currentPage.value >= pages && pages > 0) currentPage.value = pages - 1
 })
@@ -60,6 +96,10 @@ onMounted(() => {
   }
 })
 onUnmounted(() => resizeObserver?.disconnect())
+onUnmounted(() => {
+  artistsRequest?.cancel()
+  artistsRequest = null
+})
 </script>
 
 <template>
@@ -76,7 +116,8 @@ onUnmounted(() => resizeObserver?.disconnect())
         <div :key="currentPage" class="grid gap-4" :style="{ gridTemplateColumns: `repeat(${columnsPerPage}, minmax(0, 1fr))` }">
           <button v-for="artist in paginatedArtists" :key="artist.id" type="button" class="group min-w-0 text-center cursor-pointer" @click="router.push(`/artists/${artist.id}`)">
             <div class="relative mx-auto aspect-square w-full max-w-32 overflow-hidden rounded-full border border-[var(--border-glass)] bg-white/[0.04] transition-all duration-300 group-hover:brightness-110">
-              <LazyImg v-if="artist.artwork_key" :src="buildArtworkUrl(artist.artwork_key, 'md')" :alt="artist.name" class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105" />
+              <ArtistCard v-if="getArtist(artist.id)" :key="artist.id" :artist="getArtist(artist.id)!" variant="avatar" />
+              <LazyImg v-else-if="artist.artwork_key" :src="buildArtworkUrl(artist.artwork_key, 'md')" :alt="artist.name" class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105" />
               <Users v-else class="absolute inset-0 m-auto h-9 w-9 text-[color:var(--text-muted)]" />
             </div>
             <p class="mt-3 truncate text-sm font-medium">{{ artist.name }}</p>


### PR DESCRIPTION
## Summary
- reuse full artist artwork data in the top artists carousel
- preserve cached artwork when artist cards remount during pagination
- keep carousel pagination to a single grid during transitions

## Testing
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/vue-tsc --noEmit --pretty false
- wails3 task verify