### PR TITLE
fix: improve lyrics delivery and cached view refresh

### DIFF
--- a/catalog/architecture/README.md
+++ b/catalog/architecture/README.md
@@ -131,7 +131,7 @@ Go emits events via `application.EmitEvent(name, data)`. Frontend subscribes via
 
 **App events:** `language:changed`
 
-**Player events:** `player:status`, `player:queue-updated`, `player:theme`, `player:lyrics`
+**Player events:** `player:status`, `player:queue-updated`, `player:theme`, `player:lyrics`. Lyrics events carry a monotonic request ID; the current ID is also included in player status so the frontend can reject late results from cancelled requests.
 
 Automatic macOS track-transition notifications are emitted natively through the injected
 `domain.TrackTransitionNotifier`; they do not traverse the Wails event bus. Their activation

--- a/catalog/lyrics/README.md
+++ b/catalog/lyrics/README.md
@@ -240,6 +240,9 @@ player:lyrics → { track_id, request_id, state: "loading" | "ready" | "error", 
 event arrives. The player store accepts an event only when both track and request IDs match;
 `error` ends loading without clearing an already displayed lyric. `GetCurrentLyrics` returns the
 same request-identified snapshot so a late startup pull cannot overwrite a newer request.
+When the status and `ready` event arrive in the same browser tick, the track-change watcher keeps
+a lyric whose `track_id` already matches the new track; this prevents Vue's deferred watcher flush
+from clearing a successfully resolved automatic lyric.
 
 ## LRC Format Parser (`useLyrics.ts`)
 
@@ -301,5 +304,7 @@ Parsed into `{ text: "English text", secondary: "中文翻译" }`.
 **Refresh button:** For the current track, the context menu calls `PlayerService.RefreshCurrentLyrics()` so it uses the same request-ID lifecycle as automatic loading. Other selected tracks still call `FetchLyrics()` only to refresh their cache.
 
 **Manual Search:** In the track context menu (`context_menu.find_lyrics`), opens `FindLyricsDialog.vue`. This allows users to manually search for lyrics by title and artist. It provides a list of candidates from both LRCLIB and KuGou, scored using the same "Search and Rank" logic as the automatic fetch. Users preview a candidate and confirm via the "Select" button, which always upserts the DB row (`SaveLyrics`) and, if the "Save .lrc file" checkbox is checked, also calls `SaveLyricsFile` (see Manual `.lrc` File Save above). An info icon next to the checkbox shows a hover tooltip (`Tooltip` component, `@airmedy/ui`) explaining the save-location priority.
+
+For the currently playing track, the dialog then calls `PlayerService.PublishCurrentLyrics`. This advances the lyric request ID, cancels any in-flight automatic lookup, and emits the selected lyric as `ready`; a late provider response therefore cannot overwrite or hide the manual selection.
 
 **Manual Edit:** Users can manually edit lyrics in the `MetadataEditDialog`. These edits are written to the file's `LYRICS` tag and stored as `meta_content` in the database.

--- a/catalog/lyrics/README.md
+++ b/catalog/lyrics/README.md
@@ -217,6 +217,8 @@ Providers are wired via FX value group `lyrics_providers`. `LyricsService` recei
 ```typescript
 GetLyrics(trackID: string): Lyric | null
 FetchLyrics(trackID: string, track: TrackDTO): Lyric | null
+PlayerService.GetCurrentLyrics(): LyricsEvent | null
+PlayerService.RefreshCurrentLyrics(): number
 SaveLyrics(trackID: string, content: string, source: string): void
 SaveLyricsFile(audioPath: string, content: string): void
 DeleteLyrics(trackID: string): void
@@ -226,13 +228,18 @@ DeleteLyrics(trackID: string): void
 
 ## Event Delivery
 
-On track load, `PlayerService` calls `LyricsService.GetLyrics()` (or fetches if uncached) and emits:
+On track load (and when the current track is manually refreshed), `PlayerService` creates a
+monotonic request ID, cancels the preceding lyric context, and uses a 35-second total deadline.
+It emits a lifecycle event:
 
 ```
-player:lyrics → { track_id, content, source } | null
+player:lyrics → { track_id, request_id, state: "loading" | "ready" | "error", lyric?: Lyric }
 ```
 
-The player store receives this and sets `playerStore.lyrics`.
+`PlayerStatus.lyrics_request_id` identifies the currently expected request before the terminal
+event arrives. The player store accepts an event only when both track and request IDs match;
+`error` ends loading without clearing an already displayed lyric. `GetCurrentLyrics` returns the
+same request-identified snapshot so a late startup pull cannot overwrite a newer request.
 
 ## LRC Format Parser (`useLyrics.ts`)
 
@@ -291,7 +298,7 @@ Parsed into `{ text: "English text", secondary: "中文翻译" }`.
 
 **Fullscreen player:** Lyrics panel shown as the right column or via tab in the fullscreen overlay.
 
-**Refresh button:** In the track context menu (`context_menu.refresh_lyrics`), calls `FetchLyrics()` to force re-fetch even if cached.
+**Refresh button:** For the current track, the context menu calls `PlayerService.RefreshCurrentLyrics()` so it uses the same request-ID lifecycle as automatic loading. Other selected tracks still call `FetchLyrics()` only to refresh their cache.
 
 **Manual Search:** In the track context menu (`context_menu.find_lyrics`), opens `FindLyricsDialog.vue`. This allows users to manually search for lyrics by title and artist. It provides a list of candidates from both LRCLIB and KuGou, scored using the same "Search and Rank" logic as the automatic fetch. Users preview a candidate and confirm via the "Select" button, which always upserts the DB row (`SaveLyrics`) and, if the "Save .lrc file" checkbox is checked, also calls `SaveLyricsFile` (see Manual `.lrc` File Save above). An info icon next to the checkbox shows a hover tooltip (`Tooltip` component, `@airmedy/ui`) explaining the save-location priority.
 

--- a/catalog/player/README.md
+++ b/catalog/player/README.md
@@ -606,10 +606,10 @@ On app startup, `Load()` restores queue, seeks to saved position, but does not a
 
 | Event                  | When                                                   |
 | ---------------------- | ------------------------------------------------------ |
-| `player:status`        | On any state change (Play, Pause, Seek, Stop, Track Change) |
+| `player:status`        | On any state change (Play, Pause, Seek, Stop, Track Change); includes `lyrics_request_id` for the active lyric lifecycle |
 | `player:queue-updated` | Queue modified (insert, remove, reorder, new playlist) |
 | `player:theme`         | New track loaded — artwork color palette               |
-| `player:lyrics`        | New track loaded — lyrics object (may be null)         |
+| `player:lyrics`        | Current lyric lifecycle — `{ track_id, request_id, state, lyric? }`; stale request IDs are discarded by the UI |
 | `player:artwork-crossfade` | Automatic audio crossfade begins/ends; fullscreen artwork transition payload |
 
 ## Frontend Store (`stores/player.ts`)

--- a/catalog/ui/README.md
+++ b/catalog/ui/README.md
@@ -190,6 +190,11 @@ Row height: 56px (default) or 36px (compact mode), header height: 40px. Column v
 - `airmedy:track-table-widths`
 - `airmedy:track-table-collapsed`
 
+For small, non-virtualized embedded lists, `autoHeight` lets the table expand to
+its rows instead of creating a nested vertical scroll region. The Home analytics
+"Most played tracks" table uses this mode so normal wheel/trackpad scrolling
+continues through the page.
+
 ## Context Menu System
 
 **`useContextMenu()`** composable: manages position, visibility, and items for a generic `ContextMenu.vue`.
@@ -327,6 +332,8 @@ completed, skipped, and stopped attempts; the three slices total 100% and the
 card remains unavailable until at least one playback attempt has ended. The
 same row includes a one-column Average Session card, calculated from actual
 audio-running seconds per finalized playback attempt.
+Every donut's adjacent breakdown is sorted by value descending. Genre
+breakdowns place the aggregate `Other` entry last regardless of its value.
 Library growth is an SVG ECharts area chart with a fading primary-color gradient
 inside its chart; the Library Growth and Streak cards themselves intentionally
 do not inherit the current track's artwork surface color.

--- a/catalog/ui/README.md
+++ b/catalog/ui/README.md
@@ -42,6 +42,32 @@ Hash history mode (`createWebHashHistory`). All views lazy-loaded except HomeVie
 
 The `/mini-player` route bypasses the MainLayout wrapper and renders directly.
 
+### Cached Route Data Refresh
+
+`MainLayout` and entity explorer routes use `KeepAlive` to preserve UI state.
+`useLibrarySync` therefore treats Wails library data events as invalidations:
+the currently visible view reloads silently (with closely spaced events
+coalesced), while a deactivated cached view is marked dirty and reloads only
+when `onActivated` runs. This preserves scroll/filter state and avoids fetching
+data for routes the user cannot see. `library:track-updated`, `library:updated`,
+and non-background `library:sync-finished` all use this behavior.
+
+`SearchView` uses the same invalidation flow. Its Pinia store retains a search
+response, so `useLibrarySync` calls `searchStore.refresh()` for a non-empty
+query. Refresh bypasses typing debounce, keeps the existing results visible,
+and supersedes any pending older request.
+
+`HomeOverview` also uses `useLibrarySync` to silently reload its listening
+carousels after library mutations. This prevents a cached home track from
+linking to an album ID that was removed after a metadata edit.
+
+Album and playlist detail pages use the same invalidation flow so their cached
+headers and membership cannot outlive metadata changes. This is essential for
+smart playlists, whose rules can add or remove a track after its metadata is
+edited. Home Analytics silently refreshes its hydrated top-track DTOs and
+summary data, and Playlists refreshes mosaic-preview tracks even when playlist
+membership itself did not change.
+
 ### Mini Player Window Lifecycle
 
 The mini player window is **destroyed on close and recreated on open** (not just hidden). `WindowService` holds a factory function (`SetMiniWindowFactory`) that creates a fresh `WebviewWindow` each time. Closing the window does not call `e.Cancel()` on the `WindowClosing` hook, so Wails destroys the native window and frees its memory. Reopening calls the factory to create a new window. This resets all Vue/Pinia state in that webview.

--- a/catalog/ui/README.md
+++ b/catalog/ui/README.md
@@ -357,6 +357,7 @@ SVG-rendered `vue-echarts` components.
 - **Path Morphing**: Play/Pause buttons in `PlayerFooter`, `PlayerPlaybackControls`, and `MiniPlayer` use SVG path morphing for Apple Music-style fluid transitions.
 - **Tactile Feedback**: Interactive buttons use a `scale-95` active state for a "pressed" feel.
 - **Glass-Morphism**: Surfaces use `var(--bg-glass)` with `backdrop-filter: blur(30px)`.
+- **Lyrics lifecycle**: `stores/player.ts` tracks `lyrics_request_id` from `player:status` and applies a `player:lyrics` update only when its track and request IDs both match. A matching error ends loading without clearing an already shown lyric.
 
 ### Development Tools Overlay
 

--- a/frontend/src/assets/index.css
+++ b/frontend/src/assets/index.css
@@ -122,6 +122,11 @@ img {
   user-select: none;
 }
 
+a {
+  -webkit-user-drag: none;
+  user-select: none;
+}
+
 /* Custom Scrollbar Global */
 ::-webkit-scrollbar {
   width: 10px;

--- a/frontend/src/components/FindLyricsDialog.spec.ts
+++ b/frontend/src/components/FindLyricsDialog.spec.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { createTestI18n } from '@airmedy/utils'
+
+const saveLyrics = vi.fn().mockResolvedValue(undefined)
+const searchLyrics = vi.fn()
+const publishCurrentLyrics = vi.fn().mockResolvedValue(3)
+
+vi.mock('../../bindings/airmedy/internal/infra/wails/lyricsservice', () => ({
+  SaveLyrics: (...args: unknown[]) => saveLyrics(...args),
+  SaveLyricsFile: vi.fn(),
+  SearchLyrics: (...args: unknown[]) => searchLyrics(...args),
+}))
+
+vi.mock('../../bindings/airmedy/internal/infra/wails/playerservice', () => ({
+  PublishCurrentLyrics: (...args: unknown[]) => publishCurrentLyrics(...args),
+}))
+
+vi.mock('@/stores/player', () => ({
+  usePlayerStore: () => ({
+    currentTrack: { id: 'track-1' },
+    lyrics: null,
+  }),
+}))
+
+import FindLyricsDialog from './FindLyricsDialog.vue'
+import { useFindLyricsDialog } from '@/composables/useFindLyricsDialog'
+
+function mountDialog() {
+  return mount(FindLyricsDialog, {
+    global: {
+      plugins: [createTestI18n()],
+      stubs: {
+        Modal: { template: '<div><slot /></div>' },
+        Input: { template: '<input />' },
+        Checkbox: { template: '<span />' },
+        Tooltip: { template: '<span><slot /></span>' },
+      },
+    },
+  })
+}
+
+describe('FindLyricsDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useFindLyricsDialog().close()
+  })
+
+  it('publishes a selected lyric for the playing track after saving it', async () => {
+    searchLyrics.mockResolvedValue([{
+      track_name: 'Song',
+      artist_name: 'Artist',
+      duration: 180,
+      provider: 'lrclib',
+      content: '[00:01.00]Chosen lyric',
+      source: 'lrclib-synced',
+    }])
+    const wrapper = mountDialog()
+    useFindLyricsDialog().open({ id: 'track-1', title: 'Song', duration: 180, artists: [{ name: 'Artist' }] } as any)
+    await nextTick()
+
+    await wrapper.findAll('button').find(button => button.text() === 'find_lyrics.search')!.trigger('click')
+    await nextTick()
+    await nextTick()
+    await wrapper.findAll('div').find(div => div.text().includes('Song') && div.classes().includes('cursor-pointer'))!.trigger('click')
+    await wrapper.findAll('button').find(button => button.text() === 'find_lyrics.select')!.trigger('click')
+
+    expect(saveLyrics).toHaveBeenCalledWith('track-1', '[00:01.00]Chosen lyric', 'lrclib-synced')
+    expect(publishCurrentLyrics).toHaveBeenCalledWith(expect.objectContaining({
+      track_id: 'track-1',
+      content: '[00:01.00]Chosen lyric',
+      source: 'lrclib-synced',
+    }))
+  })
+})

--- a/frontend/src/components/FindLyricsDialog.vue
+++ b/frontend/src/components/FindLyricsDialog.vue
@@ -10,6 +10,7 @@ import { useFindLyricsDialog } from '@/composables/useFindLyricsDialog'
 import { usePlayerStore } from '@/stores/player'
 import { formatTime, decodeHTMLEntities } from '@airmedy/utils'
 import * as LyricsService from '../../bindings/airmedy/internal/infra/wails/lyricsservice'
+import * as PlayerService from '../../bindings/airmedy/internal/infra/wails/playerservice'
 import type { LyricsSearchResult } from '../../bindings/airmedy/internal/domain/models'
 
 const { t } = useI18n()
@@ -62,9 +63,11 @@ async function save() {
       await LyricsService.SaveLyricsFile(targetTrack.value.path, selected.content)
     }
 
-    // Update player store if it's the current track
+    // Publish through PlayerService rather than mutating the Pinia store.
+    // This cancels a late automatic lookup and gives this selection a request
+    // ID, so its lifecycle is consistent with lyrics loaded on track changes.
     if (playerStore.currentTrack?.id === targetTrack.value.id) {
-      playerStore.lyrics = {
+      await PlayerService.PublishCurrentLyrics({
         track_id: targetTrack.value.id,
         content: selected.content,
         source: selected.source,
@@ -72,7 +75,7 @@ async function save() {
         meta_source: playerStore.lyrics?.meta_source || '',
         created_at: '',
         updated_at: ''
-      } as any
+      } as any)
     }
     
     close()

--- a/frontend/src/components/FindLyricsDialog.vue
+++ b/frontend/src/components/FindLyricsDialog.vue
@@ -11,7 +11,7 @@ import { usePlayerStore } from '@/stores/player'
 import { formatTime, decodeHTMLEntities } from '@airmedy/utils'
 import * as LyricsService from '../../bindings/airmedy/internal/infra/wails/lyricsservice'
 import * as PlayerService from '../../bindings/airmedy/internal/infra/wails/playerservice'
-import type { LyricsSearchResult } from '../../bindings/airmedy/internal/domain/models'
+import { Lyric, type LyricsSearchResult } from '../../bindings/airmedy/internal/domain/models'
 
 const { t } = useI18n()
 const { isVisible, targetTrack, close } = useFindLyricsDialog()
@@ -67,15 +67,13 @@ async function save() {
     // This cancels a late automatic lookup and gives this selection a request
     // ID, so its lifecycle is consistent with lyrics loaded on track changes.
     if (playerStore.currentTrack?.id === targetTrack.value.id) {
-      await PlayerService.PublishCurrentLyrics({
+      await PlayerService.PublishCurrentLyrics(new Lyric({
         track_id: targetTrack.value.id,
         content: selected.content,
         source: selected.source,
         meta_content: playerStore.lyrics?.meta_content || '',
         meta_source: playerStore.lyrics?.meta_source || '',
-        created_at: '',
-        updated_at: ''
-      } as any)
+      }))
     }
     
     close()

--- a/frontend/src/components/TrackTable.spec.ts
+++ b/frontend/src/components/TrackTable.spec.ts
@@ -50,4 +50,26 @@ describe('TrackTable', () => {
 
     expect((list.element as HTMLElement).scrollLeft).toBe(128)
   })
+
+  it('can expand a non-virtualized table instead of creating a nested vertical scroller', () => {
+    const wrapper = mount(TrackTable, {
+      props: {
+        tracks: [{ id: 'track-1' } as TrackDTO],
+        virtualScroll: false,
+        autoHeight: true,
+      },
+      global: {
+        plugins: [createTestingPinia({ createSpy: vi.fn })],
+        mocks: { $t: (key: string) => key },
+        stubs: {
+          TrackContextMenu: true,
+          TrackTableHeader: true,
+          TrackTableRow: true,
+        },
+      },
+    })
+
+    expect(wrapper.find('.overflow-auto').exists()).toBe(false)
+    expect(wrapper.find('.overflow-visible').exists()).toBe(true)
+  })
 })

--- a/frontend/src/components/TrackTable.vue
+++ b/frontend/src/components/TrackTable.vue
@@ -35,10 +35,12 @@ const props = withDefaults(defineProps<{
   contextMenuOptions?: TrackContextMenuOptions
   allowDnd?: boolean
   virtualScroll?: boolean
+  autoHeight?: boolean
   storageKey?: string
 }>(), {
   allowDnd: false,
-  virtualScroll: true
+  virtualScroll: true,
+  autoHeight: false,
 })
 
 const emit = defineEmits<{
@@ -340,8 +342,8 @@ defineExpose({ scrollToCurrentTrack, optionalColumns, sortColumn, sortDir, cycle
 </script>
 
 <template>
-  <div class="h-full flex flex-col overflow-hidden">
-    <div class="flex-1 overflow-hidden">
+  <div :class="autoHeight ? 'flex flex-col overflow-visible' : 'h-full flex flex-col overflow-hidden'">
+    <div :class="autoHeight ? 'overflow-visible' : 'flex-1 overflow-hidden'">
       <div v-if="isLoading" class="h-full flex items-center justify-center">
         <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
       </div>
@@ -352,7 +354,7 @@ defineExpose({ scrollToCurrentTrack, optionalColumns, sortColumn, sortDir, cycle
         <p>{{ $t('library.no_tracks') }}</p>
       </div>
 
-      <div v-else class="h-full flex flex-col overflow-hidden">
+      <div v-else :class="autoHeight ? 'flex flex-col overflow-visible' : 'h-full flex flex-col overflow-hidden'">
         <div
           ref="headerContainerRef"
           data-testid="track-table-header-scroll-container"
@@ -400,7 +402,7 @@ defineExpose({ scrollToCurrentTrack, optionalColumns, sortColumn, sortDir, cycle
         <div
           v-else
           ref="plainListRef"
-          class="flex-1 overflow-auto custom-scrollbar"
+          :class="autoHeight ? 'overflow-visible' : 'flex-1 overflow-auto custom-scrollbar'"
           :style="{ minWidth: totalMinWidth }"
           @scroll="handleScroll"
         >

--- a/frontend/src/components/home/HomeAnalysis.spec.ts
+++ b/frontend/src/components/home/HomeAnalysis.spec.ts
@@ -159,4 +159,37 @@ describe('HomeAnalysis playback outcomes', () => {
     expect(wrapper.get('[data-testid="analytics-average-session-card"]').text()).toContain('3 min')
     expect(wrapper.getComponent({ name: 'PlaybackOutcomesChart' }).props()).toMatchObject({ completed: 75, skipped: 20, stopped: 5 })
   })
+
+  it('sorts each donut breakdown descending and keeps Other at the bottom', async () => {
+    vi.mocked(AnalyticsService.GetInsights).mockReturnValue(cancellable({
+      quality: [
+        { kind: 'lossless', count: 3 }, { kind: 'lossy', count: 20 }, { kind: 'hi_res', count: 10 },
+      ],
+      genres: [
+        { name: 'Other', listened_seconds: 50, is_other: true },
+        { name: 'Rock', listened_seconds: 10, is_other: false },
+        { name: 'Pop', listened_seconds: 30, is_other: false },
+      ],
+      completed: 1, skipped: 9, stopped: 5,
+      library_growth: [], activity: [], top_artists: [], top_tracks: [],
+    }) as unknown as ReturnType<typeof AnalyticsService.GetInsights>)
+
+    const wrapper = mount(HomeAnalysis, { global: { plugins: [createTestingPinia({ createSpy: vi.fn })], stubs: { AudioQualityChart: true, GenreDistributionChart: true, LibraryGrowthChart: true, ListeningActivityChart: true, PlaybackOutcomesChart: true, TabSwitcher: true, TopArtistsCarousel: true, TrackTable: true } } })
+    await flushPromises()
+
+    const rowText = (testId: string) => wrapper.get(`[data-testid="${testId}"]`).findAll(':scope > div').map(row => row.text())
+    expect(rowText('analytics-quality-breakdown')).toMatchObject([
+      expect.stringContaining('analytics.quality_lossy'),
+      expect.stringContaining('analytics.quality_hi_res'),
+      expect.stringContaining('analytics.quality_lossless'),
+    ])
+    expect(rowText('analytics-genre-breakdown')).toMatchObject([
+      expect.stringContaining('Pop'), expect.stringContaining('Rock'), expect.stringContaining('analytics.genre_other'),
+    ])
+    expect(rowText('analytics-playback-outcomes-breakdown')).toMatchObject([
+      expect.stringContaining('analytics.outcome_skipped'),
+      expect.stringContaining('analytics.outcome_stopped'),
+      expect.stringContaining('analytics.outcome_completed'),
+    ])
+  })
 })

--- a/frontend/src/components/home/HomeAnalysis.vue
+++ b/frontend/src/components/home/HomeAnalysis.vue
@@ -16,6 +16,7 @@ import GenreDistributionChart from './GenreDistributionChart.vue'
 import ListeningActivityChart from './ListeningActivityChart.vue'
 import LibraryGrowthChart from './LibraryGrowthChart.vue'
 import PlaybackOutcomesChart from './PlaybackOutcomesChart.vue'
+import { useLibrarySync } from '@/composables/useLibrarySync'
 
 const { t, locale } = useI18n()
 const playerStore = usePlayerStore()
@@ -84,9 +85,12 @@ const formatBytes = (bytes: number) => new Intl.NumberFormat(locale.value, {
   style: 'unit', unit: 'gigabyte', unitDisplay: 'narrow', maximumFractionDigits: 1,
 }).format(bytes / 1024 / 1024 / 1024)
 
-async function load() {
+async function loadInsights(silent = false) {
   request?.cancel()
-  loading.value = true; error.value = false
+  if (!silent) {
+    loading.value = true
+    error.value = false
+  }
   const pending = AnalyticsService.GetInsights(period.value)
   request = pending
   try {
@@ -127,7 +131,18 @@ async function loadTopTrackQueue(topTracks: { id: string; play_count: number; li
   }
 }
 
-watch(period, load, { immediate: true })
+function load() {
+  return loadInsights()
+}
+
+watch(period, () => {
+  void loadInsights()
+}, { immediate: true })
+// Rehydrate top-track DTOs and library summaries after metadata edits without
+// replacing the currently visible analytics UI with a loading state.
+useLibrarySync(() => {
+  void loadInsights(true)
+})
 onUnmounted(() => {
   request?.cancel()
   topTrackRequest?.cancel()

--- a/frontend/src/components/home/HomeAnalysis.vue
+++ b/frontend/src/components/home/HomeAnalysis.vue
@@ -41,6 +41,16 @@ const periodOptions = computed(() => [
 ])
 const totalQuality = computed(() => insights.value?.quality.reduce((sum: number, item: any) => sum + item.count, 0) || 0)
 const totalGenres = computed(() => insights.value?.genres.reduce((sum: number, item: any) => sum + item.listened_seconds, 0) || 0)
+const sortedQuality = computed(() => [...(insights.value?.quality ?? [])].sort((a, b) => b.count - a.count))
+const sortedGenres = computed(() => [...(insights.value?.genres ?? [])].sort((a, b) => {
+  if (a.is_other !== b.is_other) return a.is_other ? 1 : -1
+  return b.listened_seconds - a.listened_seconds
+}))
+const sortedPlaybackOutcomes = computed(() => [
+  { key: 'completed', value: insights.value?.completed ?? 0 },
+  { key: 'skipped', value: insights.value?.skipped ?? 0 },
+  { key: 'stopped', value: insights.value?.stopped ?? 0 },
+].sort((a, b) => b.value - a.value))
 const hasListeningData = computed(() => (insights.value?.listened_seconds ?? 0) > 0)
 const emptyInsights = () => ({
   listened_seconds: 0,
@@ -175,9 +185,9 @@ onUnmounted(() => {
               <AudioLines class="h-4 w-4" />{{ t('analytics.quality') }}
             </h2>
             <div v-if="insights.quality?.length" class="flex flex-1 flex-col gap-5 @md:flex-row @md:items-center @md:gap-8">
-              <AudioQualityChart :quality="insights.quality" />
-              <div class="min-w-0 flex-1 space-y-2.5">
-                <div v-for="item in insights.quality" :key="item.kind"
+              <AudioQualityChart :quality="sortedQuality" />
+              <div data-testid="analytics-quality-breakdown" class="min-w-0 flex-1 space-y-2.5">
+                <div v-for="item in sortedQuality" :key="item.kind"
                   class="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-3 text-xs">
                   <span class="truncate text-[color:var(--text-muted)]">{{ t(`analytics.quality_${item.kind}`) }}</span>
                   <span class="text-right tabular-nums text-[color:var(--text-muted)]">{{ formatNumber(item.count) }}</span>
@@ -255,7 +265,7 @@ onUnmounted(() => {
             data-testid="analytics-streak-card"
             class="streak-card group relative flex min-h-[17rem] flex-col overflow-hidden rounded-xl border border-[var(--border-glass)] bg-[var(--bg-glass)] p-6 backdrop-blur-[30px] @5xl:col-span-1">
             <div data-testid="analytics-streak-glow" aria-hidden="true" class="streak-glow pointer-events-none absolute -right-16 -bottom-16 h-52 w-52 rounded-full" />
-            <Flame aria-hidden="true" class="streak-watermark pointer-events-none absolute -right-7 -bottom-8 h-40 w-40" stroke-width="1" />
+            <Flame aria-hidden="true" class="streak-watermark pointer-events-none absolute -right-10 -bottom-8 h-40 w-40" stroke-width="0.25" fill="currentColor" />
             <div class="relative mb-6 flex items-center gap-2 text-xs font-medium text-[color:var(--text-muted)]">
               <Flame class="h-4 w-4" />{{ t('analytics.streak') }}
             </div>
@@ -273,9 +283,9 @@ onUnmounted(() => {
               </div>
               <div v-if="insights.genres?.length"
                 class="flex flex-1 flex-col gap-5 @md:flex-row @md:items-center @md:gap-6">
-                <GenreDistributionChart :genres="insights.genres" />
-                <div class="min-w-0 flex-1 space-y-2.5">
-                  <div v-for="genre in insights.genres" :key="genre.is_other ? 'other' : genre.name"
+                <GenreDistributionChart :genres="sortedGenres" />
+                <div data-testid="analytics-genre-breakdown" class="min-w-0 flex-1 space-y-2.5">
+                  <div v-for="genre in sortedGenres" :key="genre.is_other ? 'other' : genre.name"
                     class="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-3 text-xs">
                     <span class="truncate text-[color:var(--text-muted)]">{{ genre.is_other ? t('analytics.genre_other')
                       : genre.name }}</span>
@@ -298,8 +308,8 @@ onUnmounted(() => {
               </div>
               <div v-if="(insights.completed + insights.skipped + insights.stopped) > 0" class="flex flex-1 flex-col items-center gap-5 @md:flex-row @md:gap-6">
                 <PlaybackOutcomesChart :completed="insights.completed" :skipped="insights.skipped" :stopped="insights.stopped" />
-                <div class="min-w-0 flex-1 space-y-2.5 text-xs">
-                  <div v-for="item in [{ key: 'completed', value: insights.completed }, { key: 'skipped', value: insights.skipped }, { key: 'stopped', value: insights.stopped }]" :key="item.key" class="grid grid-cols-[minmax(0,1fr)_auto_auto] gap-x-3">
+                <div data-testid="analytics-playback-outcomes-breakdown" class="min-w-0 flex-1 space-y-2.5 text-xs">
+                  <div v-for="item in sortedPlaybackOutcomes" :key="item.key" class="grid grid-cols-[minmax(0,1fr)_auto_auto] gap-x-3">
                     <span class="truncate text-[color:var(--text-muted)]">{{ t(`analytics.outcome_${item.key}`) }}</span>
                     <span class="tabular-nums text-[color:var(--text-muted)]">{{ formatNumber(item.value) }}</span>
                     <span class="w-9 text-right tabular-nums text-[color:var(--text-muted)]">{{ Math.round(item.value / (insights.completed + insights.skipped + insights.stopped) * 100) }}%</span>
@@ -319,16 +329,18 @@ onUnmounted(() => {
               </div>
             </article>
           </div>
+          <TopArtistsCarousel :artists="insights.top_artists" />
           <div class="grid gap-4">
             <article
               class="flex min-h-[17rem] flex-col rounded-xl border border-[var(--border-glass)] bg-[var(--bg-glass)] p-5 backdrop-blur-[30px]">
               <h2 class="mb-4 flex items-center gap-2 text-xs font-medium text-[color:var(--text-muted)]">
                 <Music class="h-4 w-4" />{{ t('analytics.top_tracks') }}
               </h2>
-              <div v-if="topTrackQueue.length" class="mt-3 h-96">
+              <div v-if="topTrackQueue.length" class="mt-3">
                 <TrackTable :tracks="topTrackQueue" :show-artwork="true" simple-mode
                   :simple-columns="['index', 'title', 'artist', 'listened_seconds', 'play_count']"
                   :additional-columns="topTrackColumns" :virtual-scroll="false" variant="glass"
+                  auto-height
                   @play-track="(_, index, queue) => playerStore.playTracks(queue, index)" />
               </div>
               <div v-else-if="topTracksLoading" class="flex-1 animate-pulse rounded-lg bg-white/[0.04]" />
@@ -342,7 +354,6 @@ onUnmounted(() => {
               </div>
             </article>
           </div>
-          <TopArtistsCarousel :artists="insights.top_artists" />
       </template>
     </div>
   </section>

--- a/frontend/src/components/home/HomeOverview.spec.ts
+++ b/frontend/src/components/home/HomeOverview.spec.ts
@@ -1,0 +1,72 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const handlers = vi.hoisted(() => new Map<string, (event: { data?: unknown }) => void>())
+const mockGetTrackCount = vi.hoisted(() => vi.fn())
+const mockGetRecentlyPlayedTracks = vi.hoisted(() => vi.fn())
+const mockGetMostListenedTracks = vi.hoisted(() => vi.fn())
+const mockGetLeastListenedTracks = vi.hoisted(() => vi.fn())
+
+vi.mock('@wailsio/runtime', () => ({
+  Events: {
+    On: vi.fn((name: string, handler: (event: { data?: unknown }) => void) => {
+      handlers.set(name, handler)
+      return () => handlers.delete(name)
+    }),
+  },
+  Create: {
+    Nullable: (fn: (value: unknown) => unknown) => (value: unknown) => value == null ? null : fn(value),
+    Array: (fn: (value: unknown) => unknown) => (value: unknown[]) => (value ?? []).map(fn),
+    Struct: (ctor: new (value: unknown) => unknown) => (value: unknown) => value == null ? null : new ctor(value),
+    Map: () => (value: unknown) => value,
+  },
+}))
+
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+vi.mock('../../../bindings/airmedy/internal/infra/wails/libraryservice', () => ({
+  GetTrackCount: mockGetTrackCount,
+  GetRecentlyPlayedTracks: mockGetRecentlyPlayedTracks,
+  GetMostListenedTracks: mockGetMostListenedTracks,
+  GetLeastListenedTracks: mockGetLeastListenedTracks,
+}))
+
+import HomeOverview from './HomeOverview.vue'
+
+describe('HomeOverview', () => {
+  let pinia = createPinia()
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    handlers.clear()
+    pinia = createPinia()
+    setActivePinia(pinia)
+    mockGetTrackCount.mockResolvedValue(1)
+    mockGetRecentlyPlayedTracks.mockResolvedValue([])
+    mockGetMostListenedTracks.mockResolvedValue([])
+    mockGetLeastListenedTracks.mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('refreshes carousel tracks after a metadata update', async () => {
+    mount(HomeOverview, {
+      global: {
+        plugins: [pinia],
+        stubs: { HomeSection: true, TrackCard: true, TrackContextMenu: true },
+      },
+    })
+    await flushPromises()
+
+    handlers.get('library:track-updated')?.({})
+    await vi.advanceTimersByTimeAsync(50)
+    await flushPromises()
+
+    expect(mockGetRecentlyPlayedTracks).toHaveBeenCalledTimes(2)
+    expect(mockGetMostListenedTracks).toHaveBeenCalledTimes(2)
+    expect(mockGetLeastListenedTracks).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/components/home/HomeOverview.vue
+++ b/frontend/src/components/home/HomeOverview.vue
@@ -1,15 +1,15 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, shallowRef } from 'vue'
+import { onMounted, ref, shallowRef } from 'vue'
 import { useRouter } from 'vue-router'
 import { Ghost, History, Music, Podium, Settings as SettingsIcon } from '@lucide/vue'
 import { useI18n } from 'vue-i18n'
-import { Events } from '@wailsio/runtime'
 import * as LibraryService from '../../../bindings/airmedy/internal/infra/wails/libraryservice'
 import type { TrackDTO } from '../../../bindings/airmedy/internal/domain/models'
 import { usePlayerStore } from '@/stores/player'
 import HomeSection from '@/components/HomeSection.vue'
 import TrackCard from '@/components/TrackCard.vue'
 import TrackContextMenu from '@/components/TrackContextMenu.vue'
+import { useLibrarySync } from '@/composables/useLibrarySync'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -21,8 +21,8 @@ const mostListened = shallowRef<TrackDTO[]>([])
 const leastListened = shallowRef<TrackDTO[]>([])
 const contextMenu = ref<InstanceType<typeof TrackContextMenu> | null>(null)
 
-async function fetchData() {
-  loading.value = true
+async function fetchData(silent = false) {
+  if (!silent) loading.value = true
   try {
     hasTracks.value = (await LibraryService.GetTrackCount()) > 0
     if (!hasTracks.value) return
@@ -30,7 +30,9 @@ async function fetchData() {
     recentlyPlayed.value = (recent || []).filter((track): track is TrackDTO => track !== null)
     mostListened.value = (most || []).filter((track): track is TrackDTO => track !== null)
     leastListened.value = (least || []).filter((track): track is TrackDTO => track !== null)
-  } catch (error) { console.error('Failed to fetch home data:', error) } finally { loading.value = false }
+  } catch (error) { console.error('Failed to fetch home data:', error) } finally {
+    if (!silent) loading.value = false
+  }
 }
 const play = (track: TrackDTO) => playerStore.playTracks([track], 0)
 const playAll = (tracks: TrackDTO[]) => { if (tracks.length) playerStore.playTracks(tracks, 0) }
@@ -38,14 +40,15 @@ const openTrack = (track: TrackDTO) => { if (track.album) router.push(`/albums/$
 const openArtist = (id: string) => router.push(`/artists/${id}`)
 const openAlbum = (id: string) => router.push(`/albums/${id}`)
 const onMenu = (event: MouseEvent, track: TrackDTO) => contextMenu.value?.open(event, track)
-let off: (() => void) | undefined
 onMounted(() => {
-  fetchData()
-  off = Events.On('library:sync-finished', (event: Events.WailsEvent) => {
-    if (!(event.data as { background?: boolean })?.background) fetchData()
-  })
+  void fetchData()
 })
-onUnmounted(() => off?.())
+
+// Track metadata can change an album/artist relationship. Reload the carousel
+// data instead of retaining a TrackDTO whose album ID has since been removed.
+useLibrarySync(() => {
+  void fetchData(true)
+})
 </script>
 
 <template>

--- a/frontend/src/composables/useLibrarySync.spec.ts
+++ b/frontend/src/composables/useLibrarySync.spec.ts
@@ -1,0 +1,71 @@
+import { defineComponent, h, KeepAlive, nextTick, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useLibrarySync } from './useLibrarySync'
+
+const handlers = vi.hoisted(() => new Map<string, (event: { data?: unknown }) => void>())
+
+vi.mock('@wailsio/runtime', () => ({
+  Events: {
+    On: vi.fn((name: string, handler: (event: { data?: unknown }) => void) => {
+      handlers.set(name, handler)
+      const off = vi.fn(() => handlers.delete(name))
+      return off
+    }),
+  },
+}))
+
+describe('useLibrarySync', () => {
+  const reload = vi.fn()
+  const show = ref(true)
+
+  const Probe = defineComponent({
+    setup() {
+      useLibrarySync(reload)
+      return () => h('div')
+    },
+  })
+
+  const Host = defineComponent({
+    setup: () => () => h(KeepAlive, null, [show.value ? h(Probe) : null]),
+  })
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    handlers.clear()
+    reload.mockReset()
+    show.value = true
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('coalesces visible-view updates into one reload', async () => {
+    mount(Host)
+    await nextTick()
+
+    handlers.get('library:track-updated')?.({})
+    handlers.get('library:updated')?.({})
+    await vi.advanceTimersByTimeAsync(50)
+
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('defers updates received while cached until the view is activated', async () => {
+    mount(Host)
+    await nextTick()
+    show.value = false
+    await nextTick()
+
+    handlers.get('library:track-updated')?.({})
+    await vi.advanceTimersByTimeAsync(50)
+    expect(reload).not.toHaveBeenCalled()
+
+    show.value = true
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(50)
+
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/composables/useLibrarySync.ts
+++ b/frontend/src/composables/useLibrarySync.ts
@@ -1,24 +1,68 @@
-import { onMounted, onUnmounted } from 'vue'
+import { onActivated, onDeactivated, onMounted, onUnmounted } from 'vue'
 import { Events } from '@wailsio/runtime'
 
+const RELOAD_DEBOUNCE_MS = 50
+
+// Keeps view data fresh without turning KeepAlive into a source of background
+// database work. A cached view is marked dirty while inactive, then refreshes
+// once when the user returns to it. The visible view refreshes promptly, with
+// the paired `library:track-updated` / `library:updated` events coalesced.
 export function useLibrarySync(reloadFn: () => void) {
   let offSyncFinished: (() => void) | null = null
   let offLibraryUpdated: (() => void) | null = null
   let offTrackUpdated: (() => void) | null = null
+  let reloadTimer: ReturnType<typeof setTimeout> | null = null
+  let isActive = false
+  let isDirty = false
+
+  const scheduleReload = () => {
+    if (reloadTimer !== null) return
+    reloadTimer = setTimeout(() => {
+      reloadTimer = null
+      reloadFn()
+    }, RELOAD_DEBOUNCE_MS)
+  }
+
+  const handleLibraryChange = () => {
+    if (isActive) {
+      scheduleReload()
+      return
+    }
+    isDirty = true
+  }
 
   onMounted(() => {
+    // onMounted also covers a consumer rendered outside KeepAlive.
+    isActive = true
     offSyncFinished = Events.On('library:sync-finished', (ev: Events.WailsEvent) => {
       // Background syncs (startup / periodic) do not trigger a reload — the UI
       // would flash unnecessarily when nothing visible changed. Data-refresh
       // events (library:updated, library:track-updated) still fire for real
       // changes and are handled below.
-      if (!(ev.data as { background?: boolean })?.background) reloadFn()
+      if (!(ev.data as { background?: boolean })?.background) handleLibraryChange()
     })
-    offLibraryUpdated = Events.On('library:updated', reloadFn)
-    offTrackUpdated = Events.On('library:track-updated', reloadFn)
+    offLibraryUpdated = Events.On('library:updated', handleLibraryChange)
+    offTrackUpdated = Events.On('library:track-updated', handleLibraryChange)
+  })
+
+  onActivated(() => {
+    isActive = true
+    if (!isDirty) return
+    isDirty = false
+    scheduleReload()
+  })
+
+  onDeactivated(() => {
+    isActive = false
+    if (reloadTimer !== null) {
+      clearTimeout(reloadTimer)
+      reloadTimer = null
+      isDirty = true
+    }
   })
 
   onUnmounted(() => {
+    if (reloadTimer !== null) clearTimeout(reloadTimer)
     offSyncFinished?.()
     offLibraryUpdated?.()
     offTrackUpdated?.()

--- a/frontend/src/composables/useTrackContextMenu.ts
+++ b/frontend/src/composables/useTrackContextMenu.ts
@@ -84,12 +84,11 @@ export function useTrackContextMenu(onEditMetadata: (track: TrackDTO) => void) {
       icon: RefreshCw,
       action: async () => {
         const isCurrentTrack = playerStore.currentTrack?.id === track.id
-        if (isCurrentTrack) playerStore.lyricsLoading = true
-        const lyric = await LyricsService.FetchLyrics(track.id, track)
         if (isCurrentTrack) {
-          playerStore.lyrics = lyric ?? null
-          playerStore.lyricsLoading = false
+          await playerStore.refreshCurrentLyrics()
+          return
         }
+        await LyricsService.FetchLyrics(track.id, track)
       },
     })
 
@@ -251,13 +250,12 @@ export function useTrackContextMenu(onEditMetadata: (track: TrackDTO) => void) {
       label: t('context_menu.refresh_lyrics'),
       icon: RefreshCw,
       action: async () => {
-        for (const track of tracks) {
+        const currentTrackID = playerStore.currentTrack?.id
+        for (const track of tracks.filter(track => track.id !== currentTrackID)) {
           await LyricsService.FetchLyrics(track.id, track)
         }
-        // If current track is in the selection, update its lyrics in store
-        if (playerStore.currentTrack && tracks.some(t => t.id === playerStore.currentTrack?.id)) {
-          const lyric = await LyricsService.GetLyrics(playerStore.currentTrack.id)
-          playerStore.lyrics = lyric ?? null
+        if (currentTrackID && playerStore.currentTrack?.id === currentTrackID && tracks.some(track => track.id === currentTrackID)) {
+          await playerStore.refreshCurrentLyrics()
         }
       },
     })

--- a/frontend/src/stores/player.test.ts
+++ b/frontend/src/stores/player.test.ts
@@ -6,7 +6,7 @@ import { PlaybackState, RepeatMode } from '../../bindings/airmedy/internal/domai
 // Mock Wails runtime — must be before any import that uses it
 vi.mock('@wailsio/runtime', () => ({
   Events: {
-    On: vi.fn(),
+    On: vi.fn(() => () => {}),
     Off: vi.fn(),
   },
   Create: {
@@ -23,11 +23,14 @@ vi.mock('@wailsio/runtime', () => ({
 // Mock PlayerService bindings
 const mockGetStatus = vi.fn()
 const mockGetQueue = vi.fn()
+const mockGetCurrentLyrics = vi.fn()
 const mockAppendTracks = vi.fn()
 const mockGenerateMoodRadio = vi.fn()
 vi.mock('../../bindings/airmedy/internal/infra/wails/playerservice', () => ({
   GetStatus: () => mockGetStatus(),
   GetQueue: () => mockGetQueue(),
+  GetCurrentLyrics: () => mockGetCurrentLyrics(),
+  RefreshCurrentLyrics: vi.fn(),
   Play: vi.fn(),
   Pause: vi.fn(),
   Stop: vi.fn(),
@@ -49,6 +52,7 @@ vi.mock('../../bindings/airmedy/internal/infra/wails/moodradioservice', () => ({
 import { useAppStore } from './app'
 import { useMoodRadioStore } from './moodRadio'
 import { usePlayerStore } from './player'
+import { Events } from '@wailsio/runtime'
 
 describe('usePlayerStore', () => {
   beforeEach(() => {
@@ -109,6 +113,40 @@ describe('usePlayerStore', () => {
   it('returns null artworkUrl when no currentTrack', () => {
     const store = usePlayerStore()
     expect(store.artworkUrl).toBeNull()
+  })
+
+  it('ignores stale lyric events and clears loading after the matching terminal event', async () => {
+    vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    mockGetStatus.mockResolvedValue({
+      track_id: 't1',
+      lyrics_request_id: 2,
+      playback_state: PlaybackState.PlaybackStatePlaying,
+      position: 0,
+      duration: 180,
+      volume: 1,
+      muted: false,
+      repeat_mode: RepeatMode.RepeatModeOff,
+      shuffle: false,
+    })
+    mockGetQueue.mockResolvedValue([{ id: 't1' }])
+    mockGetCurrentLyrics.mockResolvedValue({
+      track_id: 't1', request_id: 2, state: 'ready', lyric: { track_id: 't1', content: 'initial' },
+    })
+
+    const store = usePlayerStore()
+    await store.init()
+    const lyricsListener = (Events.On as any).mock.calls.find(([name]: [string]) => name === 'player:lyrics')[1]
+
+    lyricsListener({ data: { track_id: 't1', request_id: 1, state: 'ready', lyric: { track_id: 't1', content: 'stale' } } })
+    expect(store.lyrics?.content).toBe('initial')
+
+    lyricsListener({ data: { track_id: 't1', request_id: 2, state: 'loading' } })
+    expect(store.lyricsLoading).toBe(true)
+    lyricsListener({ data: { track_id: 't1', request_id: 2, state: 'error' } })
+    expect(store.lyrics?.content).toBe('initial')
+    expect(store.lyricsLoading).toBe(false)
+    store.dispose()
   })
 
   it('toggleQueue flips isQueueOpen and closes other drawers', () => {

--- a/frontend/src/stores/player.test.ts
+++ b/frontend/src/stores/player.test.ts
@@ -115,6 +115,19 @@ describe('usePlayerStore', () => {
     expect(store.artworkUrl).toBeNull()
   })
 
+  it('keeps lyrics that arrive for a newly selected track before the track watcher flushes', async () => {
+    const store = usePlayerStore()
+    store.currentTrack = { id: 'old-track' } as any
+    await nextTick()
+
+    store.currentTrack = { id: 'new-track' } as any
+    store.lyrics = { track_id: 'new-track', content: '[00:01.00]Ready' } as any
+    await nextTick()
+
+    expect(store.lyrics?.content).toBe('[00:01.00]Ready')
+    expect(store.lyricsLoading).toBe(false)
+  })
+
   it('ignores stale lyric events and clears loading after the matching terminal event', async () => {
     vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1))
     vi.stubGlobal('cancelAnimationFrame', vi.fn())

--- a/frontend/src/stores/player.ts
+++ b/frontend/src/stores/player.ts
@@ -95,8 +95,13 @@ export const usePlayerStore = defineStore('player', () => {
   // Clear lyrics immediately whenever the playing track changes
   watch(currentTrack, (newTrack, oldTrack) => {
     if (newTrack?.id !== oldTrack?.id) {
-      lyrics.value = null
-      lyricsLoading.value = !!newTrack
+      // Events from the backend can deliver `ready` immediately after the
+      // status event that changes currentTrack. This watcher runs on Vue's
+      // next flush, so do not erase a lyric that already belongs to the new
+      // track (otherwise automatic lyrics appear to load and then vanish).
+      const hasNewTrackLyrics = lyrics.value?.track_id === newTrack?.id
+      if (!hasNewTrackLyrics) lyrics.value = null
+      lyricsLoading.value = !!newTrack && !hasNewTrackLyrics
     }
   })
 

--- a/frontend/src/stores/player.ts
+++ b/frontend/src/stores/player.ts
@@ -24,6 +24,13 @@ type ArtworkCrossfadeEvent = {
   duration_ms?: number
 }
 
+type LyricsEvent = {
+  track_id: string
+  request_id: number
+  state: 'loading' | 'ready' | 'error'
+  lyric?: Lyric | null
+}
+
 export const usePlayerStore = defineStore('player', () => {
   // State
   const status = shallowRef<PlayerStatus | null>(null)
@@ -38,6 +45,7 @@ export const usePlayerStore = defineStore('player', () => {
   const playerMode = ref<PlayerMode>('sticky')
   const lyrics = ref<Lyric | null>(null)
   const lyricsLoading = ref(false)
+  const lyricsRequestId = ref(0)
   const artworkCrossfade = shallowRef<ArtworkCrossfadeState | null>(null)
 
   // Interpolation state
@@ -88,7 +96,7 @@ export const usePlayerStore = defineStore('player', () => {
   watch(currentTrack, (newTrack, oldTrack) => {
     if (newTrack?.id !== oldTrack?.id) {
       lyrics.value = null
-      lyricsLoading.value = true
+      lyricsLoading.value = !!newTrack
     }
   })
 
@@ -105,6 +113,7 @@ export const usePlayerStore = defineStore('player', () => {
       const s = await PlayerService.GetStatus()
       status.value = s
       theme.value = s.theme
+      lyricsRequestId.value = s.lyrics_request_id
 
       const q = await PlayerService.GetQueue()
       queue.value = (q.filter(Boolean) as TrackDTO[])
@@ -148,6 +157,12 @@ export const usePlayerStore = defineStore('player', () => {
         status.value = s
         if (s.theme) theme.value = s.theme
 
+        if (s.track_id && s.lyrics_request_id !== lyricsRequestId.value) {
+          lyricsRequestId.value = s.lyrics_request_id
+          lyrics.value = null
+          lyricsLoading.value = true
+        }
+
         if (s?.track_id) {
           const found = queue.value.find((t) => t.id === s.track_id)
           if (found) currentTrack.value = found
@@ -185,12 +200,16 @@ export const usePlayerStore = defineStore('player', () => {
       }),
 
       Events.On('player:lyrics', (ev: Events.WailsEvent) => {
-        const lyric = (ev.data as Lyric) ?? null
-        // Discard stale lyrics from a previous track (race condition on fast skipping)
-        if (lyric && lyric.track_id !== currentTrack.value?.id) return
-        // Discard a stale null if we already have correct lyrics for the current track
-        if (!lyric && lyrics.value?.track_id === currentTrack.value?.id) return
-        lyrics.value = lyric
+        const event = ev.data as LyricsEvent
+        if (!event || event.track_id !== currentTrack.value?.id) return
+        if (lyricsRequestId.value !== 0 && event.request_id !== lyricsRequestId.value) return
+        lyricsRequestId.value = event.request_id
+        if (event.state === 'loading') {
+          lyricsLoading.value = true
+          return
+        }
+        if (event.state === 'ready') lyrics.value = event.lyric ?? null
+        // An error ends loading but deliberately preserves lyrics already shown.
         lyricsLoading.value = false
       }),
 
@@ -241,14 +260,19 @@ export const usePlayerStore = defineStore('player', () => {
     // only in a sibling file or embedded metadata tag, not just cached provider content.
     if (currentTrack.value) {
       const trackId = currentTrack.value.id
+
+      const requestId = lyricsRequestId.value
       try {
-        const lyric = await PlayerService.GetCurrentLyrics()
-        if (currentTrack.value?.id === trackId) {
-          lyrics.value = lyric ?? null
+        const event = await PlayerService.GetCurrentLyrics()
+        if (event && currentTrack.value?.id === trackId && event.request_id === requestId) {
+          if (event.state === 'ready') lyrics.value = event.lyric ?? null
           lyricsLoading.value = false
         }
       } catch (e) {
         logger.error('Failed to pull initial lyrics', e)
+        if (currentTrack.value?.id === trackId && lyricsRequestId.value === requestId) {
+          lyricsLoading.value = false
+        }
       }
     }
   }
@@ -278,6 +302,11 @@ export const usePlayerStore = defineStore('player', () => {
     } else {
       await play()
     }
+  }
+
+  async function refreshCurrentLyrics() {
+    if (!currentTrack.value) return
+    await PlayerService.RefreshCurrentLyrics()
   }
 
   async function next() {
@@ -470,6 +499,7 @@ export const usePlayerStore = defineStore('player', () => {
     play,
     pause,
     togglePlayPause,
+    refreshCurrentLyrics,
     next,
     previous,
     fastForward,

--- a/frontend/src/stores/search.spec.ts
+++ b/frontend/src/stores/search.spec.ts
@@ -1,0 +1,30 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSearch = vi.fn()
+
+vi.mock('../../bindings/airmedy/internal/infra/wails/searchservice', () => ({
+  Search: (...args: unknown[]) => mockSearch(...args),
+}))
+
+import { useSearchStore } from './search'
+
+describe('useSearchStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockSearch.mockReset()
+  })
+
+  it('refreshes the active query immediately without clearing visible results', async () => {
+    const store = useSearchStore()
+    store.query = 'old album'
+    store.results = { albums: [{ id: 'old' }] } as any
+    mockSearch.mockResolvedValue({ albums: [{ id: 'new' }] })
+
+    await store.refresh()
+
+    expect(mockSearch).toHaveBeenCalledWith('old album')
+    expect(store.results).toEqual({ albums: [{ id: 'new' }] })
+    expect(store.loading).toBe(false)
+  })
+})

--- a/frontend/src/stores/search.ts
+++ b/frontend/src/stores/search.ts
@@ -9,11 +9,31 @@ export const useSearchStore = defineStore('search', () => {
   const loading = ref(false)
 
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  let requestVersion = 0
+
+  async function runSearch(q: string, version: number) {
+    try {
+      const res = await SearchService.Search(q)
+      if (version === requestVersion) results.value = res
+    } catch (e) {
+      if (version === requestVersion) {
+        console.error('Search failed', e)
+        results.value = null
+      }
+    } finally {
+      if (version === requestVersion) loading.value = false
+    }
+  }
 
   async function search(q: string) {
     query.value = q
 
-    if (debounceTimer) clearTimeout(debounceTimer)
+    if (debounceTimer) {
+      clearTimeout(debounceTimer)
+      debounceTimer = null
+    }
+
+    const version = ++requestVersion
 
     if (!q.trim()) {
       results.value = null
@@ -23,17 +43,26 @@ export const useSearchStore = defineStore('search', () => {
 
     loading.value = true
 
-    debounceTimer = setTimeout(async () => {
-      try {
-        const res = await SearchService.Search(q.trim())
-        results.value = res
-      } catch (e) {
-        console.error('Search failed', e)
-        results.value = null
-      } finally {
-        loading.value = false
-      }
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null
+      void runSearch(q.trim(), version)
     }, 300)
+  }
+
+  // Re-run the existing query after a library mutation without resetting the
+  // visible results to a loading skeleton. It also supersedes any pending
+  // debounced input request so an older response cannot overwrite fresh data.
+  async function refresh() {
+    const q = query.value.trim()
+    if (!q) return
+
+    if (debounceTimer) {
+      clearTimeout(debounceTimer)
+      debounceTimer = null
+    }
+
+    const version = ++requestVersion
+    await runSearch(q, version)
   }
 
   function clear() {
@@ -41,7 +70,9 @@ export const useSearchStore = defineStore('search', () => {
     results.value = null
     loading.value = false
     if (debounceTimer) clearTimeout(debounceTimer)
+    debounceTimer = null
+    requestVersion++
   }
 
-  return { query, results, loading, search, clear }
+  return { query, results, loading, search, refresh, clear }
 })

--- a/frontend/src/views/AlbumDetailView.vue
+++ b/frontend/src/views/AlbumDetailView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, shallowRef, computed } from 'vue'
+import { ref, shallowRef, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useDetailRouteLoader } from '@/composables/useDetailRouteLoader'
 import { useI18n } from 'vue-i18n'
@@ -16,7 +16,9 @@ import ContextMenu from '@/components/ContextMenu.vue'
 import { DetailsButton, Input } from '@airmedy/ui'
 import DetailPageLayout from '@/components/DetailPageLayout.vue'
 import { useLibraryUpdates } from '@/composables/useLibraryUpdates'
+import { useLibrarySync } from '@/composables/useLibrarySync'
 import { useTrackTableSettings } from '@/composables/useTrackTableSettings'
+import { Events } from '@wailsio/runtime'
 
 const TABLE_HEADER_HEIGHT = 41
 const settings = useTrackTableSettings()
@@ -29,6 +31,23 @@ const album = ref<AlbumDTO | null>(null)
 const tracks = shallowRef<TrackDTO[]>([])
 const isLoading = ref(true)
 const searchQuery = ref('')
+
+// An album-name edit normally creates a new normalized album ID. Move the
+// detail route with the edited track instead of attempting to render the
+// deleted predecessor as an empty page. Register before useLibraryUpdates so
+// this observes membership before that composable removes the old track.
+const handleTrackUpdated = (event: Events.WailsEvent) => {
+  const updated = event.data as TrackDTO
+  if (!updated?.id || !updated.album?.id || updated.album.id === album.value?.id) return
+  if (tracks.value.some(track => track.id === updated.id)) {
+    router.replace(`/albums/${updated.album.id}`)
+  }
+}
+let offTrackUpdated: (() => void) | null = null
+onMounted(() => {
+  offTrackUpdated = Events.On('library:track-updated', handleTrackUpdated)
+})
+onUnmounted(() => offTrackUpdated?.())
 
 const filteredTracks = computed(() => {
   if (!searchQuery.value) return tracks.value
@@ -66,9 +85,9 @@ function openContextMenu(e: MouseEvent) {
 let currentAlbumId: string | null = null
 const isStale = (id: string) => currentAlbumId !== id
 
-const loadAlbumDetails = async (id: string) => {
+const loadAlbumDetails = async (id: string, silent = false) => {
   currentAlbumId = id
-  isLoading.value = true
+  if (!silent) isLoading.value = true
   try {
     const [albumData, tracksData] = await Promise.all([
       LibraryService.GetAlbumByID(id),
@@ -89,11 +108,19 @@ const loadAlbumDetails = async (id: string) => {
   } catch (err) {
     console.error('Failed to load album details:', err)
   } finally {
-    if (!isStale(id)) isLoading.value = false
+    if (!silent && !isStale(id)) isLoading.value = false
   }
 }
 
 useDetailRouteLoader(loadAlbumDetails)
+
+// An edit can replace this album's entity (for example, a title change creates
+// a new normalized album ID). Reload the header and membership rather than
+// retaining the now-stale album DTO.
+useLibrarySync(() => {
+  const id = album.value?.id
+  if (id) void loadAlbumDetails(id, true)
+})
 
 const getTotalDuration = (tracks: TrackDTO[]) => {
   const totalSeconds = tracks.reduce((acc, t) => acc + (t.duration || 0), 0)

--- a/frontend/src/views/PlaylistDetailView.vue
+++ b/frontend/src/views/PlaylistDetailView.vue
@@ -22,6 +22,7 @@ import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import { emptyConfig, type SmartPlaylistConfig } from '@/lib/smartPlaylistFields'
 import { Input } from '@airmedy/ui'
 import { useLibraryUpdates } from '@/composables/useLibraryUpdates'
+import { useLibrarySync } from '@/composables/useLibrarySync'
 import { useDetailRouteLoader } from '@/composables/useDetailRouteLoader'
 import { usePlaylistsStore } from '@/stores/playlists'
 import { Events } from '@wailsio/runtime'
@@ -206,6 +207,12 @@ async function loadTheme() {
 
 watch(tracks, () => loadTheme())
 useDetailRouteLoader((id) => load(false, id))
+// Smart playlist rules can gain or lose tracks after a metadata edit. A full
+// silent reload keeps both smart and regular playlist membership authoritative.
+useLibrarySync(() => {
+  const id = playlist.value?.id
+  if (id) void load(true, id)
+})
 watch(() => favoritesStore.version, () => {
   if (playlist.value?.id === 'favorites') load(true, 'favorites')
 })

--- a/frontend/src/views/PlaylistsView.vue
+++ b/frontend/src/views/PlaylistsView.vue
@@ -18,6 +18,7 @@ import * as PlaylistService from '../../bindings/airmedy/internal/infra/wails/pl
 import * as LibraryService from '../../bindings/airmedy/internal/infra/wails/libraryservice'
 import { foldUnicode } from '@airmedy/utils'
 import { useI18n } from 'vue-i18n'
+import { useLibrarySync } from '@/composables/useLibrarySync'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -199,6 +200,12 @@ async function loadArtworkTracks() {
 
   tracksByPlaylist.value = map
 }
+
+// A metadata edit can change the artwork source of a track used by a playlist
+// mosaic without changing playlist membership, so no playlist event is sent.
+useLibrarySync(() => {
+  void loadArtworkTracks()
+})
 
 const offArtworkChanged = Events.On('playlist:artwork-changed', (ev: Events.WailsEvent) => {
   const payload = ev.data as { playlist_id: string; artwork_key: string | null }

--- a/frontend/src/views/SearchView.vue
+++ b/frontend/src/views/SearchView.vue
@@ -15,6 +15,7 @@ import { useSearchStore } from '@/stores/search'
 import { usePlayerStore } from '@/stores/player'
 import { useContextMenu } from '@/composables/useContextMenu'
 import { useAlbumContextMenu } from '@/composables/useAlbumContextMenu'
+import { useLibrarySync } from '@/composables/useLibrarySync'
 import type { AlbumDTO, TrackDTO } from '../../bindings/airmedy/internal/domain/models'
 import { buildArtworkUrl } from '@airmedy/utils'
 
@@ -30,6 +31,13 @@ const { buildMenuItems: buildAlbumMenuItems } = useAlbumContextMenu()
 
 watch(inputValue, (val) => {
   store.search(val)
+})
+
+// Search results are a stored response, not a live query. Re-run the current
+// query after metadata/import mutations; useLibrarySync defers this while the
+// route is cached by KeepAlive and refreshes when it becomes visible again.
+useLibrarySync(() => {
+  void store.refresh()
 })
 
 onMounted(() => {

--- a/internal/app/player/player_service.go
+++ b/internal/app/player/player_service.go
@@ -30,6 +30,8 @@ type PlayerService struct {
 	logger                          *slog.Logger
 	artworkCache                    domain.ArtworkCache
 	lyricsService                   *lyrics.LyricsService
+	lyricsRequestID                 uint64
+	lyricsRequestCancel             context.CancelFunc
 	nowPlaying                      domain.NowPlayingController // nil on non-darwin or when unsupported
 	currentTrack                    *domain.TrackDTO
 	currentTheme                    *domain.ThemeColors
@@ -75,6 +77,8 @@ type PlayerService struct {
 
 	// emitStatusHook overrides event emission in tests (nil in production).
 	emitStatusHook func()
+	// emitLyricsHook captures lyric lifecycle events in tests.
+	emitLyricsHook func(domain.LyricsEvent)
 
 	trackLoadListeners []func(*domain.TrackDTO)
 
@@ -98,6 +102,8 @@ type listeningWrite struct {
 }
 
 const listeningWriteQueueSize = 64
+
+const lyricsFetchTimeout = 35 * time.Second
 
 func NewPlayerService(
 	player domain.AudioPlayer,
@@ -184,6 +190,7 @@ func NewPlayerService(
 // share SQLite; a delayed listening write must not consume the shutdown context
 // and prevent the resume position from being saved.
 func (s *PlayerService) shutdown(ctx context.Context) error {
+	s.cancelLyricsRequest()
 	s.stopPositionTicker()
 	s.saveState(ctx)
 	s.flushListening(ctx)
@@ -766,6 +773,7 @@ func (s *PlayerService) GetStatus() domain.PlayerStatus {
 	status.RepeatMode = s.queue.GetRepeatMode()
 	status.Shuffle = s.queue.GetShuffle()
 	status.Theme = s.currentTheme
+	status.LyricsRequestID = s.lyricsRequestID
 	return status
 }
 
@@ -875,6 +883,7 @@ func (s *PlayerService) loadAndPlayWithEndReason(track *domain.TrackDTO, previou
 	delete(s.npReported, track.ID)
 	delete(s.posConfirmed, track.ID)
 	s.mu.Unlock()
+	lyricsCtx, lyricsRequestID := s.startLyricsRequest()
 
 	s.startPositionTicker()
 	s.emitStatus()
@@ -884,7 +893,8 @@ func (s *PlayerService) loadAndPlayWithEndReason(track *domain.TrackDTO, previou
 	s.pushNowPlaying(track, 0)
 
 	go s.extractAndEmitPalette(track)
-	go s.fetchAndEmitLyrics(track)
+	s.emitLyricsEvent(track.ID, lyricsRequestID, "loading", nil)
+	go s.fetchAndEmitLyrics(lyricsCtx, lyricsRequestID, track, false)
 
 	s.saveState(context.Background())
 
@@ -932,6 +942,7 @@ func (s *PlayerService) transitionToTrack(track *domain.TrackDTO) {
 	delete(s.npReported, track.ID)
 	delete(s.posConfirmed, track.ID)
 	s.mu.Unlock()
+	lyricsCtx, lyricsRequestID := s.startLyricsRequest()
 	s.startListening(track)
 	s.startPlaybackAttempt(track, 0)
 
@@ -947,7 +958,8 @@ func (s *PlayerService) transitionToTrack(track *domain.TrackDTO) {
 	s.pushNowPlaying(track, 0)
 
 	go s.extractAndEmitPalette(track)
-	go s.fetchAndEmitLyrics(track)
+	s.emitLyricsEvent(track.ID, lyricsRequestID, "loading", nil)
+	go s.fetchAndEmitLyrics(lyricsCtx, lyricsRequestID, track, false)
 
 	s.saveState(context.Background())
 }
@@ -1037,37 +1049,85 @@ func (s *PlayerService) lyricsResolveParams(ctx context.Context, track *domain.T
 	return preferLocal, extraDirs
 }
 
-// GetCurrentLyrics resolves the best available lyric for the currently loaded
-// track (sibling file, embedded metadata tag, or cached provider content),
-// honoring the user's local-vs-provider preference. Used by the frontend on
-// startup to recover lyrics for a restored track, since the restore-time
-// player:lyrics emit happens before the frontend's listener is registered.
-func (s *PlayerService) GetCurrentLyrics() *domain.Lyric {
+// GetCurrentLyrics resolves a snapshot for the currently loaded lyric request.
+// The request id allows a startup pull that completes late to be discarded.
+func (s *PlayerService) GetCurrentLyrics() *domain.LyricsEvent {
 	if s.lyricsService == nil {
 		return nil
 	}
 	s.mu.RLock()
 	track := s.currentTrack
+	requestID := s.lyricsRequestID
 	s.mu.RUnlock()
 	if track == nil {
 		return nil
 	}
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), lyricsFetchTimeout)
+	defer cancel()
 	preferLocal, extraDirs := s.lyricsResolveParams(ctx, track)
-	return s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, preferLocal, extraDirs...)
+	lyric := s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, preferLocal, extraDirs...)
+	state := "ready"
+	if ctx.Err() != nil {
+		state = "error"
+	}
+	return &domain.LyricsEvent{TrackID: track.ID, RequestID: requestID, State: state, Lyric: lyric}
 }
 
-func (s *PlayerService) fetchAndEmitLyrics(track *domain.TrackDTO) {
+// RefreshCurrentLyrics starts a new, forced provider fetch for the playing
+// track. Its event lifecycle is identical to a track-change request.
+func (s *PlayerService) RefreshCurrentLyrics() uint64 {
+	s.mu.RLock()
+	track := s.currentTrack
+	s.mu.RUnlock()
+	if track == nil || s.lyricsService == nil {
+		return 0
+	}
+	ctx, requestID := s.startLyricsRequest()
+	s.emitStatus()
+	s.emitLyricsEvent(track.ID, requestID, "loading", nil)
+	go s.fetchAndEmitLyrics(ctx, requestID, track, true)
+	return requestID
+}
+
+func (s *PlayerService) startLyricsRequest() (context.Context, uint64) {
+	ctx, cancel := context.WithTimeout(context.Background(), lyricsFetchTimeout)
+	s.mu.Lock()
+	if s.lyricsRequestCancel != nil {
+		s.lyricsRequestCancel()
+	}
+	s.lyricsRequestID++
+	requestID := s.lyricsRequestID
+	s.lyricsRequestCancel = cancel
+	s.mu.Unlock()
+	return ctx, requestID
+}
+
+func (s *PlayerService) cancelLyricsRequest() {
+	s.mu.Lock()
+	if s.lyricsRequestCancel != nil {
+		s.lyricsRequestCancel()
+		s.lyricsRequestCancel = nil
+	}
+	s.mu.Unlock()
+}
+
+func (s *PlayerService) fetchAndEmitLyrics(ctx context.Context, requestID uint64, track *domain.TrackDTO, forceFetch bool) {
 	if s.lyricsService == nil {
+		s.emitLyricsEvent(track.ID, requestID, "ready", nil)
 		return
 	}
-	ctx := context.Background()
 
 	preferLocal, extraDirs := s.lyricsResolveParams(ctx, track)
+	if s.handleLyricsRequestContext(track.ID, requestID, ctx) {
+		return
+	}
 
 	settings, err := s.settingsRepo.Load(ctx)
 	if err != nil {
 		settings = &domain.AppSettings{}
+	}
+	if s.handleLyricsRequestContext(track.ID, requestID, ctx) {
+		return
 	}
 
 	// 1. Emit the best currently-available lyric for the chosen preference.
@@ -1079,58 +1139,78 @@ func (s *PlayerService) fetchAndEmitLyrics(track *domain.TrackDTO) {
 	dbLyric, _ := s.lyricsService.GetLyrics(ctx, track.ID)
 	hasExternal := dbLyric != nil && dbLyric.Content != ""
 	anyProviderEnabled := settings.EnableLrclib || settings.EnableKugou
-	willFetch := (!preferLocal || !hasLocal) && !hasExternal && anyProviderEnabled
+	willFetch := (forceFetch || ((!preferLocal || !hasLocal) && !hasExternal)) && anyProviderEnabled
 
-	// Only emit immediately if we are not going to fetch, or if the lyric
-	// we have is already the preferred type (e.g. we prefer local, or we have cached external).
-	// If we will fetch and prefer online lyrics, we hold off emitting the local fallback
-	// lyric to avoid a visual flash on the UI.
-	if lyric != nil && (!willFetch || preferLocal) {
-		s.emitLyrics(track.ID, lyric)
-	}
-
-	// 2. When local lyrics are preferred and present, they win outright. Don't
-	//    fetch providers, so nothing overrides the displayed local lyric.
-	if preferLocal && hasLocal {
+	if !willFetch {
+		s.emitLyricsEvent(track.ID, requestID, "ready", lyric)
 		return
 	}
 
-	// 3. Fetch from providers when enabled and not already cached.
+	// Fetch from providers when enabled. A forced refresh fetches even when a
+	// local/cached lyric exists, but final resolution still honors preference.
 	if willFetch {
 		if _, err := s.lyricsService.FetchFromProviders(ctx, track, settings.EnableLrclib, settings.EnableKugou); err != nil {
+			if s.handleLyricsRequestContext(track.ID, requestID, ctx) {
+				return
+			}
 			s.logger.Warn("failed to fetch lyrics from providers", "track_id", track.ID, "error", err)
+			s.emitLyricsEvent(track.ID, requestID, "error", nil)
+			return
 		}
+	}
+	if s.handleLyricsRequestContext(track.ID, requestID, ctx) {
+		return
 	}
 
 	// 4. Re-resolve so the final emit honors the preference now that provider
 	//    content may be cached. This is the single source of priority truth.
 	resolved := s.lyricsService.ResolveLyrics(ctx, track.ID, track.Path, preferLocal, extraDirs...)
-	s.emitLyrics(track.ID, resolved)
+	s.emitLyricsEvent(track.ID, requestID, "ready", resolved)
 }
 
-func (s *PlayerService) emitLyrics(trackID string, lyric *domain.Lyric) {
+// handleLyricsRequestContext suppresses terminal events for explicitly
+// cancelled requests, while making timeout a terminal error so the UI cannot
+// remain loading forever.
+func (s *PlayerService) handleLyricsRequestContext(trackID string, requestID uint64, ctx context.Context) bool {
+	if err := ctx.Err(); err != nil {
+		if err != context.Canceled {
+			s.logger.Warn("lyrics request timed out", "track_id", trackID, "request_id", requestID, "error", err)
+			s.emitLyricsEvent(trackID, requestID, "error", nil)
+		}
+		return true
+	}
+	return false
+}
+
+func (s *PlayerService) emitLyricsEvent(trackID string, requestID uint64, state string, lyric *domain.Lyric) {
 	s.mu.RLock()
 	currentID := ""
 	if s.currentTrack != nil {
 		currentID = s.currentTrack.ID
 	}
+	currentRequestID := s.lyricsRequestID
 	listeners := make([]func(*domain.Lyric), len(s.lyricsListeners))
 	copy(listeners, s.lyricsListeners)
 	s.mu.RUnlock()
 
-	if currentID != trackID {
+	if currentID != trackID || currentRequestID != requestID {
 		return
 	}
 
-	for _, f := range listeners {
-		f(lyric)
+	if state == "ready" {
+		for _, f := range listeners {
+			f(lyric)
+		}
+	}
+	if s.emitLyricsHook != nil {
+		s.emitLyricsHook(domain.LyricsEvent{TrackID: trackID, RequestID: requestID, State: state, Lyric: lyric})
 	}
 
 	a := application.Get()
 	if a == nil || a.Event == nil {
 		return
 	}
-	a.Event.Emit("player:lyrics", lyric)
+	a.Event.Emit("player:lyrics", domain.LyricsEvent{TrackID: trackID, RequestID: requestID, State: state, Lyric: lyric})
 }
 
 func (s *PlayerService) emitStatus() {
@@ -2122,6 +2202,7 @@ func (s *PlayerService) restoreState(ctx context.Context) {
 				s.mu.Lock()
 				s.currentTrack = currentTrack
 				s.mu.Unlock()
+				lyricsCtx, lyricsRequestID := s.startLyricsRequest()
 
 				if s.normSvc != nil {
 					s.normSvc.ApplyToPlayer(ctx, currentTrack, s.queue.PeekNext())
@@ -2130,7 +2211,8 @@ func (s *PlayerService) restoreState(ctx context.Context) {
 				s.pushNowPlaying(currentTrack, state.Position)
 
 				go s.extractAndEmitPalette(currentTrack)
-				go s.fetchAndEmitLyrics(currentTrack)
+				s.emitLyricsEvent(currentTrack.ID, lyricsRequestID, "loading", nil)
+				go s.fetchAndEmitLyrics(lyricsCtx, lyricsRequestID, currentTrack, false)
 			}
 		}
 	}

--- a/internal/app/player/player_service.go
+++ b/internal/app/player/player_service.go
@@ -1091,6 +1091,13 @@ func (s *PlayerService) RefreshCurrentLyrics() uint64 {
 
 func (s *PlayerService) startLyricsRequest() (context.Context, uint64) {
 	ctx, cancel := context.WithTimeout(context.Background(), lyricsFetchTimeout)
+	return ctx, s.beginLyricsRequest(cancel)
+}
+
+// beginLyricsRequest advances the request sequence and cancels any prior
+// asynchronous resolver. Callers that do not start asynchronous work (such as
+// a user selecting a lyric that is already available in the UI) pass nil.
+func (s *PlayerService) beginLyricsRequest(cancel context.CancelFunc) uint64 {
 	s.mu.Lock()
 	if s.lyricsRequestCancel != nil {
 		s.lyricsRequestCancel()
@@ -1099,7 +1106,7 @@ func (s *PlayerService) startLyricsRequest() (context.Context, uint64) {
 	requestID := s.lyricsRequestID
 	s.lyricsRequestCancel = cancel
 	s.mu.Unlock()
-	return ctx, requestID
+	return requestID
 }
 
 func (s *PlayerService) cancelLyricsRequest() {
@@ -1109,6 +1116,30 @@ func (s *PlayerService) cancelLyricsRequest() {
 		s.lyricsRequestCancel = nil
 	}
 	s.mu.Unlock()
+}
+
+// PublishCurrentLyrics immediately publishes a lyric selected by the user for
+// the track that is currently playing. It advances the lyric request ID first,
+// cancelling any automatic lookup still in flight so that a late provider
+// result cannot overwrite the user's selection in the UI.
+//
+// Persistence is deliberately handled by LyricsService before this method is
+// called; PlayerService owns only the playback-facing lifecycle event.
+func (s *PlayerService) PublishCurrentLyrics(lyric *domain.Lyric) uint64 {
+	if lyric == nil || lyric.TrackID == "" {
+		return 0
+	}
+	s.mu.RLock()
+	isCurrent := s.currentTrack != nil && s.currentTrack.ID == lyric.TrackID
+	s.mu.RUnlock()
+	if !isCurrent {
+		return 0
+	}
+
+	requestID := s.beginLyricsRequest(nil)
+	s.emitStatus()
+	s.emitLyricsEvent(lyric.TrackID, requestID, "ready", lyric)
+	return requestID
 }
 
 func (s *PlayerService) fetchAndEmitLyrics(ctx context.Context, requestID uint64, track *domain.TrackDTO, forceFetch bool) {

--- a/internal/app/player/player_service_test.go
+++ b/internal/app/player/player_service_test.go
@@ -299,6 +299,38 @@ func TestLyricsRequestCancelsPreviousAndRejectsStaleEvents(t *testing.T) {
 	}
 }
 
+func TestPublishCurrentLyricsCancelsLookupAndEmitsCurrentSelection(t *testing.T) {
+	s, _ := newTestService(t, &fakePlayer{status: domain.PlayerStatus{Volume: 1}})
+	track := &domain.TrackDTO{Track: domain.Track{ID: "track-a"}}
+	s.mu.Lock()
+	s.currentTrack = track
+	s.mu.Unlock()
+
+	lookupCtx, _ := s.startLyricsRequest()
+	var events []domain.LyricsEvent
+	s.emitLyricsHook = func(event domain.LyricsEvent) { events = append(events, event) }
+
+	requestID := s.PublishCurrentLyrics(&domain.Lyric{TrackID: track.ID, Content: "chosen lyric", Source: "lrclib-synced"})
+	if requestID == 0 {
+		t.Fatal("PublishCurrentLyrics returned no request ID")
+	}
+	select {
+	case <-lookupCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("publishing a manual lyric did not cancel the pending lookup")
+	}
+	if got := s.GetStatus().LyricsRequestID; got != requestID {
+		t.Fatalf("status lyrics request id = %d, want %d", got, requestID)
+	}
+	if len(events) != 1 || events[0].RequestID != requestID || events[0].State != "ready" || events[0].Lyric == nil || events[0].Lyric.Content != "chosen lyric" {
+		t.Fatalf("unexpected published lyrics event: %#v", events)
+	}
+
+	if got := s.PublishCurrentLyrics(&domain.Lyric{TrackID: "other", Content: "wrong"}); got != 0 {
+		t.Fatalf("publishing another track returned request ID %d, want 0", got)
+	}
+}
+
 func TestPositionTicker_StopsOnPause(t *testing.T) {
 	fp := &fakePlayer{status: domain.PlayerStatus{Volume: 1.0}}
 	s, _ := newTestService(t, fp)

--- a/internal/app/player/player_service_test.go
+++ b/internal/app/player/player_service_test.go
@@ -259,6 +259,46 @@ func TestPositionTicker_StartsOnPlay(t *testing.T) {
 	}
 }
 
+func TestLyricsRequestCancelsPreviousAndRejectsStaleEvents(t *testing.T) {
+	s, _ := newTestService(t, &fakePlayer{status: domain.PlayerStatus{Volume: 1}})
+	track := &domain.TrackDTO{Track: domain.Track{ID: "track-a"}}
+	s.mu.Lock()
+	s.currentTrack = track
+	s.mu.Unlock()
+
+	firstCtx, firstID := s.startLyricsRequest()
+	_, secondID := s.startLyricsRequest()
+	if secondID != firstID+1 {
+		t.Fatalf("second request id = %d, want %d", secondID, firstID+1)
+	}
+	select {
+	case <-firstCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("starting a newer lyrics request did not cancel the previous request")
+	}
+	if got := s.GetStatus().LyricsRequestID; got != secondID {
+		t.Fatalf("status lyrics request id = %d, want %d", got, secondID)
+	}
+
+	var events []domain.LyricsEvent
+	s.emitLyricsHook = func(event domain.LyricsEvent) { events = append(events, event) }
+	s.emitLyricsEvent(track.ID, firstID, "ready", &domain.Lyric{TrackID: track.ID, Content: "stale"})
+	s.emitLyricsEvent(track.ID, secondID, "ready", &domain.Lyric{TrackID: track.ID, Content: "current"})
+	if len(events) != 1 || events[0].Lyric == nil || events[0].Lyric.Content != "current" {
+		t.Fatalf("stale lyrics event was emitted: %#v", events)
+	}
+
+	timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), 0)
+	defer timeoutCancel()
+	<-timeoutCtx.Done()
+	if !s.handleLyricsRequestContext(track.ID, secondID, timeoutCtx) {
+		t.Fatal("timed-out lyrics request was not handled")
+	}
+	if len(events) != 2 || events[1].State != "error" {
+		t.Fatalf("timed-out request did not emit a terminal error: %#v", events)
+	}
+}
+
 func TestPositionTicker_StopsOnPause(t *testing.T) {
 	fp := &fakePlayer{status: domain.PlayerStatus{Volume: 1.0}}
 	s, _ := newTestService(t, fp)

--- a/internal/domain/audio.go
+++ b/internal/domain/audio.go
@@ -41,15 +41,25 @@ type RemotePlayerState struct {
 
 // PlayerStatus represents the full state of the playback engine for the UI
 type PlayerStatus struct {
-	TrackID       string        `json:"track_id"`
-	PlaybackState PlaybackState `json:"playback_state"`
-	Position      float64       `json:"position"` // Current position in seconds
-	Duration      float64       `json:"duration"` // Total duration in seconds
-	Volume        float64       `json:"volume"`   // 0.0 to 1.0
-	Muted         bool          `json:"muted"`
-	RepeatMode    RepeatMode    `json:"repeat_mode"`
-	Shuffle       bool          `json:"shuffle"`
-	Theme         *ThemeColors  `json:"theme"`
+	TrackID         string        `json:"track_id"`
+	LyricsRequestID uint64        `json:"lyrics_request_id"`
+	PlaybackState   PlaybackState `json:"playback_state"`
+	Position        float64       `json:"position"` // Current position in seconds
+	Duration        float64       `json:"duration"` // Total duration in seconds
+	Volume          float64       `json:"volume"`   // 0.0 to 1.0
+	Muted           bool          `json:"muted"`
+	RepeatMode      RepeatMode    `json:"repeat_mode"`
+	Shuffle         bool          `json:"shuffle"`
+	Theme           *ThemeColors  `json:"theme"`
+}
+
+// LyricsEvent is the lifecycle update for the current track's lyric request.
+// RequestID lets clients discard results from an older load of the same track.
+type LyricsEvent struct {
+	TrackID   string `json:"track_id"`
+	RequestID uint64 `json:"request_id"`
+	State     string `json:"state"` // loading, ready, or error
+	Lyric     *Lyric `json:"lyric,omitempty"`
 }
 
 // ThemeColors holds extracted palette data from the current track's artwork

--- a/internal/infra/wails/player_service.go
+++ b/internal/infra/wails/player_service.go
@@ -20,10 +20,15 @@ func (s *PlayerService) GetService() *player.PlayerService {
 	return s.service
 }
 
-// GetCurrentLyrics resolves the best lyric for the currently loaded track.
+// GetCurrentLyrics resolves a request-identified lyric snapshot for the current track.
 // The frontend pulls this on startup to recover lyrics for a restored track.
-func (s *PlayerService) GetCurrentLyrics() *domain.Lyric {
+func (s *PlayerService) GetCurrentLyrics() *domain.LyricsEvent {
 	return s.service.GetCurrentLyrics()
+}
+
+// RefreshCurrentLyrics starts a forced lyrics request for the playing track.
+func (s *PlayerService) RefreshCurrentLyrics() uint64 {
+	return s.service.RefreshCurrentLyrics()
 }
 
 func (s *PlayerService) Play() error {

--- a/internal/infra/wails/player_service.go
+++ b/internal/infra/wails/player_service.go
@@ -31,6 +31,13 @@ func (s *PlayerService) RefreshCurrentLyrics() uint64 {
 	return s.service.RefreshCurrentLyrics()
 }
 
+// PublishCurrentLyrics updates the active lyric view after a user manually
+// selects a saved lyric. The application service assigns a new request ID so
+// a pending automatic lookup cannot replace it.
+func (s *PlayerService) PublishCurrentLyrics(lyric *domain.Lyric) uint64 {
+	return s.service.PublishCurrentLyrics(lyric)
+}
+
 func (s *PlayerService) Play() error {
 	return s.service.Play()
 }


### PR DESCRIPTION
## Summary
- preserve automatic and manually selected lyrics through request-correlated player events
- send valid lyric timestamps through Wails bindings
- refresh cached library views and home analytics after library updates

## Verification
- wails3 task verify