### PR TITLE
fix(ui): prevent lyrics loading race

### DIFF
--- a/catalog/lyrics/README.md
+++ b/catalog/lyrics/README.md
@@ -237,7 +237,9 @@ player:lyrics → { track_id, request_id, state: "loading" | "ready" | "error", 
 ```
 
 `PlayerStatus.lyrics_request_id` identifies the currently expected request before the terminal
-event arrives. The player store accepts an event only when both track and request IDs match;
+event arrives. Delivery of the status and lyric event is independent, so the player store accepts
+the same-track event when its request ID is equal to or newer than the latest seen ID, and ignores
+only older IDs; a late older status likewise cannot restore loading after a newer terminal event.
 `error` ends loading without clearing an already displayed lyric. `GetCurrentLyrics` returns the
 same request-identified snapshot so a late startup pull cannot overwrite a newer request.
 When the status and `ready` event arrive in the same browser tick, the track-change watcher keeps

--- a/frontend/src/composables/useTrackContextMenu.ts
+++ b/frontend/src/composables/useTrackContextMenu.ts
@@ -108,6 +108,7 @@ export function useTrackContextMenu(onEditMetadata: (track: TrackDTO) => void) {
     })
 
     if (appStore.libraryAnalysisEnabled) {
+      items.push({ separator: true })
       items.push({
         label: t('context_menu.start_mood_radio'),
         icon: Radio,

--- a/frontend/src/stores/player.test.ts
+++ b/frontend/src/stores/player.test.ts
@@ -162,6 +162,50 @@ describe('usePlayerStore', () => {
     store.dispose()
   })
 
+  it('keeps a manually selected lyric ready when its event arrives before the status update', async () => {
+    vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    mockGetStatus.mockResolvedValue({
+      track_id: 't1',
+      lyrics_request_id: 2,
+      playback_state: PlaybackState.PlaybackStatePlaying,
+      position: 0,
+      duration: 180,
+      volume: 1,
+      muted: false,
+      repeat_mode: RepeatMode.RepeatModeOff,
+      shuffle: false,
+    })
+    mockGetQueue.mockResolvedValue([{ id: 't1' }])
+    mockGetCurrentLyrics.mockResolvedValue({
+      track_id: 't1', request_id: 2, state: 'ready', lyric: { track_id: 't1', content: 'local lyric' },
+    })
+
+    const store = usePlayerStore()
+    await store.init()
+    const lyricsListener = (Events.On as any).mock.calls.find(([name]: [string]) => name === 'player:lyrics')[1]
+    const statusListener = (Events.On as any).mock.calls.find(([name]: [string]) => name === 'player:status')[1]
+
+    // This is the event ordering produced when a second manual selection's
+    // `ready` event overtakes its `player:status` notification.
+    lyricsListener({ data: { track_id: 't1', request_id: 3, state: 'ready', lyric: { track_id: 't1', content: 'selected lyric' } } })
+    statusListener({ data: {
+      track_id: 't1',
+      lyrics_request_id: 3,
+      playback_state: PlaybackState.PlaybackStatePlaying,
+      position: 0,
+      duration: 180,
+      volume: 1,
+      muted: false,
+      repeat_mode: RepeatMode.RepeatModeOff,
+      shuffle: false,
+    } })
+
+    expect(store.lyrics?.content).toBe('selected lyric')
+    expect(store.lyricsLoading).toBe(false)
+    store.dispose()
+  })
+
   it('toggleQueue flips isQueueOpen and closes other drawers', () => {
     const store = usePlayerStore()
     store.isLyricsOpen = true

--- a/frontend/src/stores/player.ts
+++ b/frontend/src/stores/player.ts
@@ -162,7 +162,11 @@ export const usePlayerStore = defineStore('player', () => {
         status.value = s
         if (s.theme) theme.value = s.theme
 
-        if (s.track_id && s.lyrics_request_id !== lyricsRequestId.value) {
+        // Wails events are delivered independently, so a terminal lyric event
+        // can arrive before the accompanying status update. Request IDs are
+        // monotonic: never let a late status for an older request put the UI
+        // back into loading after accepting a newer terminal event.
+        if (s.track_id && s.lyrics_request_id > lyricsRequestId.value) {
           lyricsRequestId.value = s.lyrics_request_id
           lyrics.value = null
           lyricsLoading.value = true
@@ -207,7 +211,10 @@ export const usePlayerStore = defineStore('player', () => {
       Events.On('player:lyrics', (ev: Events.WailsEvent) => {
         const event = ev.data as LyricsEvent
         if (!event || event.track_id !== currentTrack.value?.id) return
-        if (lyricsRequestId.value !== 0 && event.request_id !== lyricsRequestId.value) return
+        // A newer lyric event may beat its status event to the frontend. It is
+        // authoritative for that request; only discard events from an older
+        // request, which are necessarily stale.
+        if (event.request_id < lyricsRequestId.value) return
         lyricsRequestId.value = event.request_id
         if (event.state === 'loading') {
           lyricsLoading.value = true


### PR DESCRIPTION
## Summary
- prevent manually selected lyrics from being discarded when the lyrics-ready event arrives before its status update
- separate the Mood Radio context-menu action from surrounding items

## Verification
- wails3 task verify