### PR TITLE
fix(player): reload edited track safely

### DIFF
--- a/catalog/metadata/README.md
+++ b/catalog/metadata/README.md
@@ -157,6 +157,16 @@ type MetadataUpdate struct {
 
 After writing tags and optional artwork, `library/service.go` re-extracts the file and upserts the updated track to DB and search index.
 
+### Editing the Current Track During Playback
+
+Writing tags can rewrite the media container, so the Wails metadata binding
+stops a currently playing or paused track before calling `WriteMetadata()`.
+After re-import completes, it reloads the track through `PlayerService` using
+the fresh DTO. A playing track resumes at its prior position (clamped to a
+shorter updated duration); paused and stopped tracks retain their state.
+If the user selected a different track while the write was in progress, the
+new playback is left untouched.
+
 ## Raw Metadata Storage
 
 All extracted tags are serialized as JSON and stored in `tracks.other_metadata` (TEXT column). This allows future migrations to re-parse additional fields without re-scanning files.

--- a/catalog/player/README.md
+++ b/catalog/player/README.md
@@ -48,6 +48,18 @@ type AudioPlayer interface {
 }
 ```
 
+## Reload After Media-File Mutation
+
+`PlayerService.ReloadCurrentTrackAfterFileMutation()` is used after an edit
+that rewrites the audio file, such as embedded metadata. The caller stops the
+current decoder before the write, then reloads only if the same track is still
+current when re-import finishes. The player seeks to the saved position before
+resuming, clamps it to the refreshed duration, and retains paused or stopped
+state without starting playback. This shared service flow applies to every platform; platform
+adapters must treat `Load()` as a hard replacement of any active/preloaded
+source. Miniaudio already unloads both slots in `ma_player_load`; Darwin resets
+its active deck before enqueueing the replacement decoder.
+
 ## GaplessPlayer Interface (Optional)
 
 Implemented by audio adapters that support gapless or near-gapless transitions. Detected via type assertion in `PlayerService`.

--- a/frontend/src/components/home/HomeAnalysis.vue
+++ b/frontend/src/components/home/HomeAnalysis.vue
@@ -408,8 +408,6 @@ onUnmounted(() => {
 
 .streak-card:hover {
   border-color: rgb(251 146 60 / 0.3);
-  box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.4), 0 0 32px rgb(244 63 94 / 0.12);
-  transform: scale(1.02);
 }
 
 .streak-card:hover .streak-glow {

--- a/internal/app/player/player_service.go
+++ b/internal/app/player/player_service.go
@@ -808,8 +808,7 @@ func (s *PlayerService) PeekPreviousTrack() *domain.TrackDTO {
 func (s *PlayerService) SyncTrack(track *domain.TrackDTO) {
 	s.mu.Lock()
 	if s.currentTrack != nil && s.currentTrack.ID == track.ID {
-		s.currentTrack.IsFavorite = track.IsFavorite
-		// Copy other relevant fields if needed, but for now focus on Favorite
+		s.currentTrack = track
 		s.mu.Unlock()
 		s.emitStatus()
 	} else {
@@ -818,6 +817,54 @@ func (s *PlayerService) SyncTrack(track *domain.TrackDTO) {
 
 	// Also update in queue if present
 	s.queue.UpdateTrack(track)
+}
+
+// ReloadCurrentTrackAfterFileMutation reloads a currently selected track from
+// disk after an operation (such as a tag write) changed its media file. The
+// caller must have stopped playback before modifying the file. A previously
+// paused or stopped track retains that state. If the user selected another
+// track while the mutation was in progress, this is a no-op.
+func (s *PlayerService) ReloadCurrentTrackAfterFileMutation(ctx context.Context, trackID string, position float64, previousState domain.PlaybackState) error {
+	s.mu.RLock()
+	current := s.currentTrack
+	s.mu.RUnlock()
+	if current == nil || current.ID != trackID {
+		return nil
+	}
+
+	track, err := s.trackRepo.GetByID(ctx, trackID)
+	if err != nil {
+		return fmt.Errorf("get updated track %s: %w", trackID, err)
+	}
+	if track == nil {
+		return fmt.Errorf("updated track not found: %s", trackID)
+	}
+
+	// Check again after the repository call so a concurrent track change is
+	// never overwritten by the completion of a metadata write.
+	s.mu.RLock()
+	stillCurrent := s.currentTrack != nil && s.currentTrack.ID == trackID
+	s.mu.RUnlock()
+	if !stillCurrent {
+		return nil
+	}
+
+	if position < 0 {
+		position = 0
+	}
+	if duration := float64(track.Duration); duration > 0 && position > duration {
+		position = duration
+	}
+
+	s.queue.UpdateTrack(track)
+	switch previousState {
+	case domain.PlaybackStatePlaying:
+		return s.loadAndPlayAtPosition(track, position, domain.PlaybackEndStopped)
+	case domain.PlaybackStatePaused:
+		return s.loadInactiveAtPosition(track, position, true)
+	default:
+		return s.loadInactiveAtPosition(track, position, false)
+	}
 }
 
 // ReapplyNormalization recomputes and pushes the pre-amp gain for the
@@ -840,6 +887,55 @@ func (s *PlayerService) loadAndPlay(track *domain.TrackDTO) error {
 }
 
 func (s *PlayerService) loadAndPlayWithEndReason(track *domain.TrackDTO, previousReason domain.PlaybackEndReason) error {
+	return s.loadAndPlayAtPosition(track, 0, previousReason)
+}
+
+func (s *PlayerService) loadInactiveAtPosition(track *domain.TrackDTO, position float64, paused bool) error {
+	s.stopPositionTicker()
+	s.mu.Lock()
+	s.nextPreQueued = nil
+	s.mu.Unlock()
+
+	if err := s.player.Load(track); err != nil {
+		s.logger.Error("failed to reload inactive track", "track", track.Path, "error", err)
+		return err
+	}
+	if s.normSvc != nil {
+		s.normSvc.ApplyToPlayer(context.Background(), track, s.queue.PeekNext())
+	}
+	if position > 0 {
+		if err := s.player.Seek(position); err != nil {
+			return fmt.Errorf("seek reloaded inactive track: %w", err)
+		}
+	}
+	if paused {
+		if err := s.player.Pause(); err != nil {
+			return fmt.Errorf("pause reloaded track: %w", err)
+		}
+	}
+
+	s.mu.Lock()
+	s.currentTrack = track
+	s.currentTheme = nil
+	s.trackStartTime = time.Now().Add(-time.Duration(position) * time.Second)
+	s.mu.Unlock()
+	lyricsCtx, lyricsRequestID := s.startLyricsRequest()
+
+	s.emitStatus()
+	s.emitTrackMetadata()
+	s.emitRemoteState()
+	if paused {
+		s.pushNowPlaying(track, position)
+		s.setNowPlayingPlaybackState(false)
+	}
+	go s.extractAndEmitPalette(track)
+	s.emitLyricsEvent(track.ID, lyricsRequestID, "loading", nil)
+	go s.fetchAndEmitLyrics(lyricsCtx, lyricsRequestID, track, false)
+	s.saveState(context.Background())
+	return nil
+}
+
+func (s *PlayerService) loadAndPlayAtPosition(track *domain.TrackDTO, position float64, previousReason domain.PlaybackEndReason) error {
 	// A hard load supersedes any in-flight crossfade.
 	s.snapActiveCrossfade()
 	s.flushListening(context.Background())
@@ -860,6 +956,12 @@ func (s *PlayerService) loadAndPlayWithEndReason(track *domain.TrackDTO, previou
 	if s.normSvc != nil {
 		s.normSvc.ApplyToPlayer(context.Background(), track, s.queue.PeekNext())
 	}
+	if position > 0 {
+		if err := s.player.Seek(position); err != nil {
+			s.logger.Error("failed to seek loaded track", "track", track.Path, "position", position, "error", err)
+			return err
+		}
+	}
 
 	s.mu.RLock()
 	loadListeners := append([]func(*domain.TrackDTO){}, s.trackLoadListeners...)
@@ -873,12 +975,12 @@ func (s *PlayerService) loadAndPlayWithEndReason(track *domain.TrackDTO, previou
 		return err
 	}
 	s.startListening(track)
-	s.startPlaybackAttempt(track, 0)
+	s.startPlaybackAttempt(track, position)
 
 	s.mu.Lock()
 	s.currentTrack = track
 	s.currentTheme = nil
-	s.trackStartTime = time.Now()
+	s.trackStartTime = time.Now().Add(-time.Duration(position) * time.Second)
 	delete(s.playCounted, track.ID)
 	delete(s.npReported, track.ID)
 	delete(s.posConfirmed, track.ID)
@@ -890,7 +992,7 @@ func (s *PlayerService) loadAndPlayWithEndReason(track *domain.TrackDTO, previou
 	s.emitTrackMetadata()
 	s.emitRemoteState()
 
-	s.pushNowPlaying(track, 0)
+	s.pushNowPlaying(track, position)
 
 	go s.extractAndEmitPalette(track)
 	s.emitLyricsEvent(track.ID, lyricsRequestID, "loading", nil)

--- a/internal/app/player/player_service_test.go
+++ b/internal/app/player/player_service_test.go
@@ -168,6 +168,18 @@ type fakeTrackRepo struct {
 
 func (r *fakeTrackRepo) IncrementPlayCount(_ context.Context, _ string) error { return nil }
 
+type reloadTrackRepo struct {
+	fakeTrackRepo
+	track *domain.TrackDTO
+}
+
+func (r *reloadTrackRepo) GetByID(_ context.Context, id string) (*domain.TrackDTO, error) {
+	if r.track != nil && r.track.ID == id {
+		return r.track, nil
+	}
+	return nil, nil
+}
+
 type fakePlayerStateRepo struct {
 	domain.PlayerStateRepository
 	mu         sync.Mutex
@@ -256,6 +268,77 @@ func TestPositionTicker_StartsOnPlay(t *testing.T) {
 	n := atomic.LoadInt64(&tickCount)
 	if n < 2 {
 		t.Errorf("expected ≥2 ticker ticks, got %d", n)
+	}
+}
+
+func TestReloadCurrentTrackAfterFileMutationRestoresPositionAndMetadata(t *testing.T) {
+	fp := &fakePlayer{status: domain.PlayerStatus{Volume: 1}}
+	s, _ := newTestService(t, fp)
+	original := &domain.TrackDTO{Track: domain.Track{ID: "track-1", Title: "Before", Duration: 120}}
+	updated := &domain.TrackDTO{Track: domain.Track{ID: "track-1", Title: "After", Duration: 90}}
+	s.trackRepo = &reloadTrackRepo{track: updated}
+	s.queue.SetQueue([]*domain.TrackDTO{original}, 0)
+
+	if err := s.loadAndPlay(original); err != nil {
+		t.Fatalf("start track: %v", err)
+	}
+	if err := s.Stop(); err != nil {
+		t.Fatalf("stop before metadata write: %v", err)
+	}
+	if err := s.ReloadCurrentTrackAfterFileMutation(context.Background(), original.ID, 42, domain.PlaybackStatePlaying); err != nil {
+		t.Fatalf("reload current track: %v", err)
+	}
+
+	status := fp.GetStatus()
+	if status.TrackID != original.ID || status.Position != 42 || status.PlaybackState != domain.PlaybackStatePlaying {
+		t.Fatalf("unexpected restored playback status: %+v", status)
+	}
+	if fp.loadCalls != 2 {
+		t.Fatalf("Load called %d times, want 2", fp.loadCalls)
+	}
+	if got := s.GetCurrentTrack(); got == nil || got.Title != "After" {
+		t.Fatalf("current metadata was not refreshed: %+v", got)
+	}
+	if queue := s.GetQueue(); len(queue) != 1 || queue[0].Title != "After" {
+		t.Fatalf("queue metadata was not refreshed: %+v", queue)
+	}
+}
+
+func TestReloadCurrentTrackAfterFileMutationKeepsPausedTrackPaused(t *testing.T) {
+	fp := &fakePlayer{status: domain.PlayerStatus{Volume: 1}}
+	s, _ := newTestService(t, fp)
+	original := &domain.TrackDTO{Track: domain.Track{ID: "track-1", Title: "Before", Duration: 120}}
+	updated := &domain.TrackDTO{Track: domain.Track{ID: "track-1", Title: "After", Duration: 30}}
+	s.trackRepo = &reloadTrackRepo{track: updated}
+	s.queue.SetQueue([]*domain.TrackDTO{original}, 0)
+	s.currentTrack = original
+
+	if err := s.ReloadCurrentTrackAfterFileMutation(context.Background(), original.ID, 42, domain.PlaybackStatePaused); err != nil {
+		t.Fatalf("reload paused track: %v", err)
+	}
+
+	status := fp.GetStatus()
+	if status.Position != 30 || status.PlaybackState != domain.PlaybackStatePaused {
+		t.Fatalf("paused playback was not restored: %+v", status)
+	}
+}
+
+func TestReloadCurrentTrackAfterFileMutationKeepsStoppedTrackStopped(t *testing.T) {
+	fp := &fakePlayer{status: domain.PlayerStatus{Volume: 1}}
+	s, _ := newTestService(t, fp)
+	original := &domain.TrackDTO{Track: domain.Track{ID: "track-1", Title: "Before", Duration: 120}}
+	updated := &domain.TrackDTO{Track: domain.Track{ID: "track-1", Title: "After", Duration: 120}}
+	s.trackRepo = &reloadTrackRepo{track: updated}
+	s.queue.SetQueue([]*domain.TrackDTO{original}, 0)
+	s.currentTrack = original
+
+	if err := s.ReloadCurrentTrackAfterFileMutation(context.Background(), original.ID, 18, domain.PlaybackStateStopped); err != nil {
+		t.Fatalf("reload stopped track: %v", err)
+	}
+
+	status := fp.GetStatus()
+	if status.Position != 18 || status.PlaybackState != domain.PlaybackStateStopped {
+		t.Fatalf("stopped playback was not restored: %+v", status)
 	}
 }
 

--- a/internal/app/player/queue_service.go
+++ b/internal/app/player/queue_service.go
@@ -564,14 +564,14 @@ func (s *QueueService) UpdateTrack(track *domain.TrackDTO) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for _, t := range s.originalList {
+	for i, t := range s.originalList {
 		if t.ID == track.ID {
-			t.IsFavorite = track.IsFavorite
+			s.originalList[i] = track
 		}
 	}
-	for _, t := range s.shuffledList {
+	for i, t := range s.shuffledList {
 		if t.ID == track.ID {
-			t.IsFavorite = track.IsFavorite
+			s.shuffledList[i] = track
 		}
 	}
 }

--- a/internal/infra/audio/native_player_darwin.m
+++ b/internal/infra/audio/native_player_darwin.m
@@ -406,6 +406,10 @@ static AVAudioUnitEffect *MakeStereoWidenerNode(void) {
         [self.idleDeck reset];
         self.preloadedPath = nil;
     });
+    // A hard load must discard the current decoder as well. This is
+    // particularly important after metadata writes, which can replace or
+    // rewrite the file while its previous decoder was loaded.
+    [self.activeDeck reset];
 
     if (![self.activeDeck enqueuePath:path forImmediatePlayback:YES]) {
         return;

--- a/internal/infra/wails/library_service.go
+++ b/internal/infra/wails/library_service.go
@@ -8,24 +8,27 @@ import (
 	"strings"
 
 	"airmedy/internal/app/library"
+	"airmedy/internal/app/player"
 	"airmedy/internal/domain"
 	"airmedy/internal/infra/artwork"
 	"github.com/wailsapp/wails/v3/pkg/application"
 )
 
 type LibraryService struct {
-	libService   *library.LibraryService
-	folderRepo   domain.WatchedFolderRepository
-	trackRepo    domain.TrackRepository
-	albumRepo    domain.AlbumRepository
-	artistRepo   domain.ArtistRepository
-	genreRepo    domain.GenreRepository
-	composerRepo domain.ComposerRepository
-	artworkCache domain.ArtworkCache
+	libService    *library.LibraryService
+	playerService *player.PlayerService
+	folderRepo    domain.WatchedFolderRepository
+	trackRepo     domain.TrackRepository
+	albumRepo     domain.AlbumRepository
+	artistRepo    domain.ArtistRepository
+	genreRepo     domain.GenreRepository
+	composerRepo  domain.ComposerRepository
+	artworkCache  domain.ArtworkCache
 }
 
 func NewLibraryService(
 	libService *library.LibraryService,
+	playerService *player.PlayerService,
 	folderRepo domain.WatchedFolderRepository,
 	trackRepo domain.TrackRepository,
 	albumRepo domain.AlbumRepository,
@@ -35,14 +38,15 @@ func NewLibraryService(
 	artworkCache domain.ArtworkCache,
 ) *LibraryService {
 	return &LibraryService{
-		libService:   libService,
-		folderRepo:   folderRepo,
-		trackRepo:    trackRepo,
-		albumRepo:    albumRepo,
-		artistRepo:   artistRepo,
-		genreRepo:    genreRepo,
-		composerRepo: composerRepo,
-		artworkCache: artworkCache,
+		libService:    libService,
+		playerService: playerService,
+		folderRepo:    folderRepo,
+		trackRepo:     trackRepo,
+		albumRepo:     albumRepo,
+		artistRepo:    artistRepo,
+		genreRepo:     genreRepo,
+		composerRepo:  composerRepo,
+		artworkCache:  artworkCache,
 	}
 }
 
@@ -288,7 +292,40 @@ func (s *LibraryService) ShowInExplorer(trackID string) error {
 }
 
 func (s *LibraryService) UpdateTrackMetadata(trackID string, update domain.MetadataUpdate) error {
-	return s.libService.UpdateMetadata(context.Background(), trackID, update)
+	ctx := context.Background()
+	current := s.playerService.GetCurrentTrack()
+	previousState := domain.PlaybackStateStopped
+	reload := false
+	position := 0.0
+	if current != nil && current.ID == trackID {
+		status := s.playerService.GetStatus()
+		previousState = status.PlaybackState
+		reload = true
+		position = status.Position
+		if previousState != domain.PlaybackStateStopped {
+			if err := s.playerService.Stop(); err != nil {
+				return fmt.Errorf("stop track before updating metadata: %w", err)
+			}
+		}
+	}
+
+	if err := s.libService.UpdateMetadata(ctx, trackID, update); err != nil {
+		// The writer may fail after touching the container. Re-open the current
+		// file when possible so a playback session is not left stopped with a
+		// stale decoder; preserve the original edit error for the caller.
+		if reload {
+			if restoreErr := s.playerService.ReloadCurrentTrackAfterFileMutation(ctx, trackID, position, previousState); restoreErr != nil {
+				return fmt.Errorf("update metadata: %w (also failed to restore playback: %v)", err, restoreErr)
+			}
+		}
+		return err
+	}
+	if reload {
+		if err := s.playerService.ReloadCurrentTrackAfterFileMutation(ctx, trackID, position, previousState); err != nil {
+			return fmt.Errorf("reload track after updating metadata: %w", err)
+		}
+	}
+	return nil
 }
 
 func (s *LibraryService) GetAlbumColors(id string) (*domain.ThemeColors, error) {


### PR DESCRIPTION
## Summary
- stop and reload the current decoder around metadata file writes
- restore the prior playing, paused, or stopped state and playback position
- reset the Darwin active deck on hard loads while keeping the miniaudio hard-load flow

## Verification
- wails3 task verify