### PR TITLE
feat(ui): create playlists from context menu

### DIFF
--- a/catalog/playlists/README.md
+++ b/catalog/playlists/README.md
@@ -525,4 +525,6 @@ Playlists appear in the sidebar below the main navigation items, ordered by crea
 
 The `Add to Playlist` context menu item fetches `GetPlaylistsForTrack(trackID)` to show a checkmark next to playlists that already contain the track. Clicking a playlist name calls `AddTracksToPlaylist` (batch, for multi-track selection) or `RemoveTrackFromPlaylist` depending on current membership.
 
+Every Add to Playlist submenu starts with Create Playlist, followed by a divider and the existing manual playlists. Confirming its shared name dialog creates a normal playlist and immediately adds the tracks from the initiating track, multi-selection, album, or group; it does not navigate away from the current view.
+
 `AddTracksToPlaylist` uses a single DB transaction to assign sequential LexoRank positions, preventing the race condition that occurred when multiple `AddTrackToPlaylist` calls fired concurrently and all read the same max position.

--- a/catalog/ui/README.md
+++ b/catalog/ui/README.md
@@ -235,7 +235,7 @@ expand/collapse control for the full 50-track analytics ranking.
 | Refresh Lyrics      | `LyricsService.FetchLyrics()`                |
 | Find Lyrics         | Open `FindLyricsDialog.vue`                  |
 | Add/Remove Favorite | `LibraryService.ToggleFavorite()`            |
-| Add to Playlist     | Submenu with playlist list                   |
+| Add to Playlist     | Create Playlist action, divider, then playlist list |
 | Go to Album         | Router navigate to `/albums/:id`             |
 | Go to Artist(s)     | Submenu or direct navigate to `/artists/:id` |
 | Edit Metadata       | Open `MetadataEditDialog`                    |
@@ -401,6 +401,8 @@ overlay is not rendered in production builds.
 | `useContextMenu`        | Generic context menu state manager                      |
 | `useTrackContextMenu`   | Track-specific menu item builder                        |
 | `useGroupContextMenu`   | Multi-track selection menu (Play Next, Add to Playlist) |
+| `useAddToPlaylistMenu`  | Shared Create Playlist submenu prefix                   |
+| `useCreatePlaylistWithTracks` | Global create-then-add-tracks dialog state        |
 | `useTrackTableSettings` | Column config with localStorage persistence             |
 | `useLyrics`             | LRC parser for synced/plain view                        |
 | `useKeyboardShortcut`   | Global key binding registration                         |

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,6 +3,7 @@ import { onMounted, watch, onUnmounted, ref, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import MainLayout from './layouts/MainLayout.vue'
 import FindLyricsDialog from './components/FindLyricsDialog.vue'
+import CreatePlaylistWithTracksDialog from './components/CreatePlaylistWithTracksDialog.vue'
 import DevToolsOverlay from './components/DevToolsOverlay.vue'
 import { hexToRgba } from '@airmedy/utils'
 import { usePlayerStore } from './stores/player'
@@ -187,6 +188,7 @@ watch(() => playerStore.playerMode, (newMode) => {
   </template>
   <DevToolsOverlay v-if="isDevelopment && !isMiniPlayer" />
   <FindLyricsDialog />
+  <CreatePlaylistWithTracksDialog v-if="!isMiniPlayer" />
 </template>
 
 <style>

--- a/frontend/src/components/CreatePlaylistDialog.vue
+++ b/frontend/src/components/CreatePlaylistDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { nextTick, ref, watch } from 'vue'
 import { Input } from '@airmedy/ui'
 import { Modal } from '@airmedy/ui'
 import { useI18n } from 'vue-i18n'
@@ -18,10 +18,16 @@ const emit = defineEmits<{
 }>()
 
 const name = ref(props.initialName ?? '')
+const nameInput = ref<InstanceType<typeof Input>>()
 
 watch(() => props.open, (val) => {
-  if (val) name.value = props.initialName ?? ''
-})
+  if (!val) return
+
+  name.value = props.initialName ?? ''
+  void nextTick(() => {
+    if (props.open) nameInput.value?.focus()
+  })
+}, { flush: 'post' })
 
 function submit() {
   if (!name.value.trim()) return
@@ -33,11 +39,10 @@ function submit() {
 <template>
   <Modal :open="open" :title="title ?? t('sidebar.new_playlist')" width-class="w-[30rem]" @close="emit('update:open', false)">
     <Input
+      ref="nameInput"
       v-model="name"
       :placeholder="t('sidebar.playlist_name')"
       class="bg-foreground/[0.07] border-foreground/20 text-foreground placeholder:text-foreground/40 focus-visible:ring-primary/20"
-
-      autofocus
       @keydown.enter="submit" />
 
     <template #footer>

--- a/frontend/src/components/CreatePlaylistWithTracksDialog.vue
+++ b/frontend/src/components/CreatePlaylistWithTracksDialog.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import CreatePlaylistDialog from './CreatePlaylistDialog.vue'
+import { useCreatePlaylistWithTracks } from '@/composables/useCreatePlaylistWithTracks'
+
+const createPlaylistWithTracks = useCreatePlaylistWithTracks()
+
+async function handleConfirm(name: string) {
+  await createPlaylistWithTracks.create(name)
+}
+</script>
+
+<template>
+  <CreatePlaylistDialog
+    :open="createPlaylistWithTracks.isVisible.value"
+    @update:open="(open) => !open && createPlaylistWithTracks.close()"
+    @confirm="handleConfirm"
+  />
+</template>

--- a/frontend/src/composables/useAddToPlaylistMenu.spec.ts
+++ b/frontend/src/composables/useAddToPlaylistMenu.spec.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTestingPinia } from '@pinia/testing'
+import { setActivePinia } from 'pinia'
+import { usePlaylistsStore } from '@/stores/playlists'
+import { useAddToPlaylistMenu } from './useAddToPlaylistMenu'
+import { useCreatePlaylistWithTracks } from './useCreatePlaylistWithTracks'
+import * as PlaylistService from '../../bindings/airmedy/internal/infra/wails/playlistservice'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('../../bindings/airmedy/internal/infra/wails/playlistservice', () => ({
+  AddTracksToPlaylist: vi.fn(),
+}))
+
+vi.mock('@wailsio/runtime', () => ({
+  Events: { On: vi.fn(() => vi.fn()) },
+}))
+
+describe('useAddToPlaylistMenu', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ createSpy: vi.fn }))
+    useCreatePlaylistWithTracks().close()
+  })
+
+  it('puts Create Playlist before a divider', async () => {
+    const { buildCreatePlaylistItems } = useAddToPlaylistMenu()
+    const items = buildCreatePlaylistItems(['track-1'])
+
+    expect(items[0].label).toBe('sidebar.new_playlist')
+    expect(items[1].separator).toBe(true)
+
+    await items[0].action?.()
+    expect(useCreatePlaylistWithTracks().isVisible.value).toBe(true)
+  })
+
+  it('creates a playlist and adds every pending track to it', async () => {
+    const playlistsStore = usePlaylistsStore()
+    vi.mocked(playlistsStore.create).mockResolvedValue({ id: 'playlist-1' } as never)
+    const dialog = useCreatePlaylistWithTracks()
+    dialog.open(['track-1', 'track-2', 'track-1'])
+
+    await dialog.create('Road trip')
+
+    expect(PlaylistService.AddTracksToPlaylist).toHaveBeenCalledWith(
+      'playlist-1',
+      ['track-1', 'track-2'],
+      '',
+    )
+  })
+})

--- a/frontend/src/composables/useAddToPlaylistMenu.ts
+++ b/frontend/src/composables/useAddToPlaylistMenu.ts
@@ -1,0 +1,24 @@
+import { ListPlus } from '@lucide/vue'
+import { useI18n } from 'vue-i18n'
+import type { ContextMenuItem } from './useContextMenu'
+import { useCreatePlaylistWithTracks } from './useCreatePlaylistWithTracks'
+
+export function useAddToPlaylistMenu() {
+  const { t } = useI18n()
+  const createPlaylistWithTracks = useCreatePlaylistWithTracks()
+
+  function buildCreatePlaylistItems(trackIDs: string[] | (() => Promise<string[]>)): ContextMenuItem[] {
+    return [
+      {
+        label: t('sidebar.new_playlist'),
+        icon: ListPlus,
+        action: async () => {
+          createPlaylistWithTracks.open(typeof trackIDs === 'function' ? await trackIDs() : trackIDs)
+        },
+      },
+      { separator: true },
+    ]
+  }
+
+  return { buildCreatePlaylistItems }
+}

--- a/frontend/src/composables/useAlbumContextMenu.ts
+++ b/frontend/src/composables/useAlbumContextMenu.ts
@@ -3,6 +3,7 @@ import { useI18n } from 'vue-i18n'
 import { usePlaylistsStore } from '@/stores/playlists'
 import { usePlayerStore } from '@/stores/player'
 import { useFavoritesStore } from '@/stores/favorites'
+import { useAddToPlaylistMenu } from './useAddToPlaylistMenu'
 import type { ContextMenuItem } from './useContextMenu'
 import type { TrackDTO, AlbumDTO } from '../../bindings/airmedy/internal/domain/models'
 import * as PlayerService from '../../bindings/airmedy/internal/infra/wails/playerservice'
@@ -18,6 +19,7 @@ export function useAlbumContextMenu() {
   const playlistsStore = usePlaylistsStore()
   const playerStore = usePlayerStore()
   const favoritesStore = useFavoritesStore()
+  const { buildCreatePlaylistItems } = useAddToPlaylistMenu()
 
   async function getTracks(albumId: string, providedTracks?: TrackDTO[]): Promise<TrackDTO[]> {
     if (providedTracks && providedTracks.length > 0) return providedTracks
@@ -103,8 +105,10 @@ export function useAlbumContextMenu() {
       {
         label: t('context_menu.add_to_playlist'),
         icon: ListPlus,
-        children: playlistsStore.manualPlaylists.length
-          ? playlistsStore.manualPlaylists.map(p => ({
+        children: [
+          ...buildCreatePlaylistItems(async () => (await fetchTracks()).map(track => track.id)),
+          ...(playlistsStore.manualPlaylists.length
+            ? playlistsStore.manualPlaylists.map(p => ({
               label: p.name,
               action: async () => {
                 const tracks = await fetchTracks()
@@ -113,7 +117,8 @@ export function useAlbumContextMenu() {
                 }
               },
             }))
-          : [{ label: t('context_menu.no_playlists'), disabled: true }],
+            : [{ label: t('context_menu.no_playlists'), disabled: true }]),
+        ],
       }
     )
 

--- a/frontend/src/composables/useCreatePlaylistWithTracks.ts
+++ b/frontend/src/composables/useCreatePlaylistWithTracks.ts
@@ -1,0 +1,29 @@
+import { ref } from 'vue'
+import { usePlaylistsStore } from '@/stores/playlists'
+import * as PlaylistService from '../../bindings/airmedy/internal/infra/wails/playlistservice'
+
+const isVisible = ref(false)
+const pendingTrackIDs = ref<string[]>([])
+
+export function useCreatePlaylistWithTracks() {
+  function open(trackIDs: string[]) {
+    pendingTrackIDs.value = [...new Set(trackIDs)]
+    isVisible.value = true
+  }
+
+  function close() {
+    isVisible.value = false
+    pendingTrackIDs.value = []
+  }
+
+  async function create(name: string) {
+    const trackIDs = pendingTrackIDs.value
+    const playlist = await usePlaylistsStore().create(name)
+    if (!playlist) return
+
+    await PlaylistService.AddTracksToPlaylist(playlist.id, trackIDs, '')
+    pendingTrackIDs.value = []
+  }
+
+  return { isVisible, open, close, create }
+}

--- a/frontend/src/composables/useGroupContextMenu.ts
+++ b/frontend/src/composables/useGroupContextMenu.ts
@@ -1,6 +1,7 @@
 import { ListEnd, ListPlus } from '@lucide/vue'
 import { useI18n } from 'vue-i18n'
 import { usePlaylistsStore } from '@/stores/playlists'
+import { useAddToPlaylistMenu } from './useAddToPlaylistMenu'
 import type { ContextMenuItem } from './useContextMenu'
 import type { TrackDTO } from '../../bindings/airmedy/internal/domain/models'
 import * as PlayerService from '../../bindings/airmedy/internal/infra/wails/playerservice'
@@ -9,6 +10,7 @@ import * as PlaylistService from '../../bindings/airmedy/internal/infra/wails/pl
 export function useGroupContextMenu() {
   const { t } = useI18n()
   const playlistsStore = usePlaylistsStore()
+  const { buildCreatePlaylistItems } = useAddToPlaylistMenu()
 
   function buildMenuItems(tracks: TrackDTO[]): ContextMenuItem[] {
     return [
@@ -20,8 +22,10 @@ export function useGroupContextMenu() {
       {
         label: t('context_menu.add_to_playlist'),
         icon: ListPlus,
-        children: playlistsStore.manualPlaylists.length
-          ? playlistsStore.manualPlaylists.map(p => ({
+        children: [
+          ...buildCreatePlaylistItems(tracks.map(track => track.id)),
+          ...(playlistsStore.manualPlaylists.length
+            ? playlistsStore.manualPlaylists.map(p => ({
               label: p.name,
               action: async () => {
                 // Add all tracks to playlist
@@ -30,7 +34,8 @@ export function useGroupContextMenu() {
                 }
               },
             }))
-          : [{ label: t('context_menu.no_playlists'), disabled: true }],
+            : [{ label: t('context_menu.no_playlists'), disabled: true }]),
+        ],
       },
     ]
   }

--- a/frontend/src/composables/useTrackContextMenu.spec.ts
+++ b/frontend/src/composables/useTrackContextMenu.spec.ts
@@ -78,6 +78,16 @@ describe('useTrackContextMenu', () => {
     expect(playNextItem?.label).toBe('context_menu.play_next')
   })
 
+  it('puts Create Playlist before the existing playlists', () => {
+    const track: TrackDTO = { id: 'track-1', title: 'Track 1' } as any
+    const { buildMenuItems } = useTrackContextMenu(vi.fn())
+
+    const addToPlaylist = buildMenuItems(track).find(item => item.label === 'context_menu.add_to_playlist')
+
+    expect(addToPlaylist?.children?.[0].label).toBe('sidebar.new_playlist')
+    expect(addToPlaylist?.children?.[1].separator).toBe(true)
+  })
+
   it('excludes "Play Next" if excludePlayNext option is true', () => {
     const track: TrackDTO = { id: 'track-1', title: 'Track 1' } as any
     const otherTrack: TrackDTO = { id: 'track-2', title: 'Track 2' } as any

--- a/frontend/src/composables/useTrackContextMenu.ts
+++ b/frontend/src/composables/useTrackContextMenu.ts
@@ -7,6 +7,7 @@ import { usePlayerStore } from '@/stores/player'
 import { useAppStore } from '@/stores/app'
 import { useMoodRadioStore } from '@/stores/moodRadio'
 import { useFindLyricsDialog } from './useFindLyricsDialog'
+import { useAddToPlaylistMenu } from './useAddToPlaylistMenu'
 import type { ContextMenuItem } from './useContextMenu'
 import type { TrackDTO } from '../../bindings/airmedy/internal/domain/models'
 import * as PlayerService from '../../bindings/airmedy/internal/infra/wails/playerservice'
@@ -31,6 +32,7 @@ export function useTrackContextMenu(onEditMetadata: (track: TrackDTO) => void) {
   const moodRadioStore = useMoodRadioStore()
   const router = useRouter()
   const findLyricsDialog = useFindLyricsDialog()
+  const { buildCreatePlaylistItems } = useAddToPlaylistMenu()
 
   function buildMenuItems(track: TrackDTO, options: TrackContextMenuOptions = {}): ContextMenuItem[] {
     const items: ContextMenuItem[] = []
@@ -131,12 +133,16 @@ export function useTrackContextMenu(onEditMetadata: (track: TrackDTO) => void) {
 
     if (!options.playlistId) {
       const addablePlaylists = playlistsStore.manualPlaylists
-      const playlistChildren: ContextMenuItem[] = addablePlaylists.length
+      const existingPlaylistChildren: ContextMenuItem[] = addablePlaylists.length
         ? addablePlaylists.map(p => ({
           label: p.name,
           action: () => { PlaylistService.AddTrackToPlaylist(p.id, track.id, '') },
         }))
         : [{ label: t('context_menu.no_playlists'), disabled: true }]
+      const playlistChildren = [
+        ...buildCreatePlaylistItems([track.id]),
+        ...existingPlaylistChildren,
+      ]
 
       items.push({
         label: t('context_menu.add_to_playlist'),
@@ -148,7 +154,7 @@ export function useTrackContextMenu(onEditMetadata: (track: TrackDTO) => void) {
       PlaylistService.GetPlaylistsForTrack(track.id).then(playlistIds => {
         if (!playlistIds || !playlistIds.length) return
 
-        playlistChildren.forEach((child, index) => {
+        existingPlaylistChildren.forEach((child, index) => {
           const p = addablePlaylists[index]
           if (p && playlistIds.includes(p.id)) {
             child.iconRight = Check
@@ -276,14 +282,17 @@ export function useTrackContextMenu(onEditMetadata: (track: TrackDTO) => void) {
     })
 
     if (!options.playlistId) {
-      const playlistChildren: ContextMenuItem[] = playlistsStore.manualPlaylists.length
-        ? playlistsStore.manualPlaylists.map(p => ({
-          label: p.name,
-          action: () => {
-            PlaylistService.AddTracksToPlaylist(p.id, tracks.map(t => t.id), '')
-          },
-        }))
-        : [{ label: t('context_menu.no_playlists'), disabled: true }]
+      const playlistChildren: ContextMenuItem[] = [
+        ...buildCreatePlaylistItems(tracks.map(track => track.id)),
+        ...(playlistsStore.manualPlaylists.length
+          ? playlistsStore.manualPlaylists.map(p => ({
+              label: p.name,
+              action: () => {
+                PlaylistService.AddTracksToPlaylist(p.id, tracks.map(t => t.id), '')
+              },
+            }))
+          : [{ label: t('context_menu.no_playlists'), disabled: true }]),
+      ]
 
       items.push({
         label: t('context_menu.add_to_playlist'),


### PR DESCRIPTION
## Summary
- add Create Playlist as the first action in Add to Playlist submenus
- create the playlist and immediately add tracks from track, selection, album, or group actions
- cover the shared create-and-add flow with tests and update catalogs

## Verification
- wails3 task verify